### PR TITLE
Lazily relativize file paths

### DIFF
--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -399,14 +399,14 @@ class Evaluator(parseCache: collection.mutable.Map[String, fastparse.Parsed[Expr
       lazy val newSelf: Val.Obj = Val.Obj(
         value.flatMap {
           case Member.Field(offset, fieldName, plus, None, sep, rhs) =>
-            visitFieldName(fieldName, scope, offset).map(_ -> Val.Obj.Member(plus, sep, (self: Val.Obj, sup: Option[Val.Obj], thisFile: String) => {
+            visitFieldName(fieldName, scope, offset).map(_ -> Val.Obj.Member(plus, sep, (self: Val.Obj, sup: Option[Val.Obj], _) => {
               Lazy {
                 assertions(self)
                 visitExpr(rhs, makeNewScope(self, sup))
               }
             }))
           case Member.Field(offset, fieldName, false, Some(argSpec), sep, rhs) =>
-            visitFieldName(fieldName, scope, offset).map(_ -> Val.Obj.Member(false, sep, (self: Val.Obj, sup: Option[Val.Obj], thisFile: String) => {
+            visitFieldName(fieldName, scope, offset).map(_ -> Val.Obj.Member(false, sep, (self: Val.Obj, sup: Option[Val.Obj], _) => {
               Lazy {
                 assertions(self)
                 visitMethod(makeNewScope(self, sup), rhs, argSpec, offset)
@@ -455,7 +455,7 @@ class Evaluator(parseCache: collection.mutable.Map[String, fastparse.Parsed[Expr
 
             visitExpr(key, s) match {
               case Val.Str(k) =>
-                Some(k -> Val.Obj.Member(false, Visibility.Normal, (self: Val.Obj, sup: Option[Val.Obj], thisFile: String) =>
+                Some(k -> Val.Obj.Member(false, Visibility.Normal, (self: Val.Obj, sup: Option[Val.Obj], _) =>
                   Lazy(visitExpr(
                     value,
                     s.copy(self0 = Some(self), dollar0 = Some(s.dollar0.getOrElse(self))) ++

--- a/sjsonnet/src/sjsonnet/Interpreter.scala
+++ b/sjsonnet/src/sjsonnet/Interpreter.scala
@@ -21,7 +21,7 @@ class Interpreter(parseCache: collection.mutable.Map[String, fastparse.Parsed[Ex
   }
   def interpret(txt: String): Either[String, ujson.Js] = {
     for{
-      parsed <- fastparse.parse(txt, Parser.document(_)) match{
+      parsed <- parseCache.getOrElseUpdate(txt, fastparse.parse(txt, Parser.document(_))) match{
         case f @ Parsed.Failure(l, i, e) => Left("Parse error: " + f.trace().msg)
         case Parsed.Success(r, index) => Right(r)
       }

--- a/sjsonnet/src/sjsonnet/Materializer.scala
+++ b/sjsonnet/src/sjsonnet/Materializer.scala
@@ -1,5 +1,4 @@
 package sjsonnet
-import java.lang.ThreadLocal
 import java.util.IdentityHashMap
 
 import sjsonnet.Expr.{FieldName, Member, ObjBody}
@@ -8,58 +7,22 @@ import ujson.Js
 object Materializer {
   def apply(v: Val,
             extVars: Map[String, ujson.Js],
-            wd: os.Path): Js = {
-    val originalFastPath = useFastPath.get
-    useFastPath.set(false)
-    try {
-      val seen = if (originalFastPath) {
-        None
-      } else {
-        Some(new IdentityHashMap[Val, Unit]())
-      }
-      apply0(v, extVars, wd, seen)
-    } finally {
-      useFastPath.set(originalFastPath)
-    }
-  }
-
-  def apply0(v: Val,
-             extVars: Map[String, ujson.Js],
-             wd: os.Path,
-             seen: Option[IdentityHashMap[Val, Unit]]): Js = v match{
+            wd: os.Path,
+            seen: IdentityHashMap[Val, Unit] = new IdentityHashMap[Val, Unit]): Js = v match{
     case Val.True => Js.True
     case Val.False => Js.False
     case Val.Null => Js.Null
     case Val.Num(n) => Js.Num(n)
     case Val.Str(s) => Js.Str(s)
-    case arr @ Val.Arr(xs) =>
-      seen match {
-        case Some(seen) =>
-          if (seen.containsKey(arr)) throw new DelegateError("Failed to materialize recursive value")
-          seen.put(arr, ())
-        case None =>
-          if (arr.observed) throw new DelegateError("Failed to materialize recursive value")
-          arr.observed = true
-      }
-      try {
-        Js.Arr.from(xs.map(x => apply0(x.force, extVars, wd, seen)))
-      } finally {
-        seen match {
-          case Some(seen) => seen.remove(arr)
-          case None => arr.observed = false
-        }
-      }
+    case Val.Arr(xs) =>
+      if (seen.containsKey(v)) throw new DelegateError("Failed to materialize recursive value")
+      seen.put(v, ())
+      val res = Js.Arr.from(xs.map(x => apply(x.force, extVars, wd, seen)))
+      seen.remove(v, ())
+      res
     case obj: Val.Obj =>
-      seen match {
-        case Some(seen) =>
-          if (seen.containsKey(obj)) throw new DelegateError("Failed to materialize recursive value")
-          seen.put(obj, ())
-        case None =>
-          if (obj.observed) throw new DelegateError("Failed to materialize recursive value")
-          obj.observed = true
-      }
-
-      obj.observed = true
+      if (seen.containsKey(v)) throw new DelegateError("Failed to materialize recursive value")
+      seen.put(v, ())
       def rec(x: Val.Obj): Unit = {
         x.triggerAsserts(obj)
         x.`super` match{
@@ -67,22 +30,17 @@ object Materializer {
           case None => Unit
         }
       }
-      try {
-        rec(obj)
+      rec(obj)
 
-        Js.Obj.from(
-          for {
-            (k, hidden) <- obj.getVisibleKeys().toSeq.sortBy(_._1)
-            if !hidden
-          }yield k -> apply0(obj.value(k, wd / "(Unknown)", wd, -1, wd, extVars).force, extVars, wd, seen)
-        )
-      } finally {
-        seen match {
-          case Some(seen) => seen.remove(obj)
-          case None => obj.observed = false
-        }
-      }
-    case f: Val.Func => apply(f.apply(Nil, "(memory)", extVars, -1, wd), extVars, wd)
+      val res = Js.Obj.from(
+        for {
+          (k, hidden) <- obj.getVisibleKeys().toSeq.sortBy(_._1)
+          if !hidden
+        }yield k -> apply(obj.value(k, wd / "(Unknown)", wd, -1, wd, extVars).force, extVars, wd, seen)
+      )
+      seen.remove(v, ())
+      res
+    case f: Val.Func => apply(f.apply(Nil, "(memory)", extVars, -1, wd), extVars, wd, seen)
   }
 
   def reverse(v: Js.Value): Val = v match{
@@ -115,6 +73,4 @@ object Materializer {
       )
   }
 
-  val useFastPath = new ThreadLocal[Boolean]()
-  useFastPath.set(true)
 }

--- a/sjsonnet/src/sjsonnet/Materializer.scala
+++ b/sjsonnet/src/sjsonnet/Materializer.scala
@@ -1,4 +1,5 @@
 package sjsonnet
+import java.lang.ThreadLocal
 import java.util.IdentityHashMap
 
 import sjsonnet.Expr.{FieldName, Member, ObjBody}
@@ -7,22 +8,58 @@ import ujson.Js
 object Materializer {
   def apply(v: Val,
             extVars: Map[String, ujson.Js],
-            wd: os.Path,
-            seen: IdentityHashMap[Val, Unit] = new IdentityHashMap[Val, Unit]): Js = v match{
+            wd: os.Path): Js = {
+    val originalFastPath = useFastPath.get
+    useFastPath.set(false)
+    try {
+      val seen = if (originalFastPath) {
+        None
+      } else {
+        Some(new IdentityHashMap[Val, Unit]())
+      }
+      apply0(v, extVars, wd, seen)
+    } finally {
+      useFastPath.set(originalFastPath)
+    }
+  }
+
+  def apply0(v: Val,
+             extVars: Map[String, ujson.Js],
+             wd: os.Path,
+             seen: Option[IdentityHashMap[Val, Unit]]): Js = v match{
     case Val.True => Js.True
     case Val.False => Js.False
     case Val.Null => Js.Null
     case Val.Num(n) => Js.Num(n)
     case Val.Str(s) => Js.Str(s)
-    case Val.Arr(xs) =>
-      if (seen.containsKey(v)) throw new DelegateError("Failed to materialize recursive value")
-      seen.put(v, ())
-      val res = Js.Arr.from(xs.map(x => apply(x.force, extVars, wd, seen)))
-      seen.remove(v, ())
-      res
+    case arr @ Val.Arr(xs) =>
+      seen match {
+        case Some(seen) =>
+          if (seen.containsKey(arr)) throw new DelegateError("Failed to materialize recursive value")
+          seen.put(arr, ())
+        case None =>
+          if (arr.observed) throw new DelegateError("Failed to materialize recursive value")
+          arr.observed = true
+      }
+      try {
+        Js.Arr.from(xs.map(x => apply0(x.force, extVars, wd, seen)))
+      } finally {
+        seen match {
+          case Some(seen) => seen.remove(arr)
+          case None => arr.observed = false
+        }
+      }
     case obj: Val.Obj =>
-      if (seen.containsKey(v)) throw new DelegateError("Failed to materialize recursive value")
-      seen.put(v, ())
+      seen match {
+        case Some(seen) =>
+          if (seen.containsKey(obj)) throw new DelegateError("Failed to materialize recursive value")
+          seen.put(obj, ())
+        case None =>
+          if (obj.observed) throw new DelegateError("Failed to materialize recursive value")
+          obj.observed = true
+      }
+
+      obj.observed = true
       def rec(x: Val.Obj): Unit = {
         x.triggerAsserts(obj)
         x.`super` match{
@@ -30,17 +67,22 @@ object Materializer {
           case None => Unit
         }
       }
-      rec(obj)
+      try {
+        rec(obj)
 
-      val res = Js.Obj.from(
-        for {
-          (k, hidden) <- obj.getVisibleKeys().toSeq.sortBy(_._1)
-          if !hidden
-        }yield k -> apply(obj.value(k, wd / "(Unknown)", wd, -1, wd, extVars).force, extVars, wd, seen)
-      )
-      seen.remove(v, ())
-      res
-    case f: Val.Func => apply(f.apply(Nil, "(memory)", extVars, -1, wd), extVars, wd, seen)
+        Js.Obj.from(
+          for {
+            (k, hidden) <- obj.getVisibleKeys().toSeq.sortBy(_._1)
+            if !hidden
+          }yield k -> apply0(obj.value(k, wd / "(Unknown)", wd, -1, wd, extVars).force, extVars, wd, seen)
+        )
+      } finally {
+        seen match {
+          case Some(seen) => seen.remove(obj)
+          case None => obj.observed = false
+        }
+      }
+    case f: Val.Func => apply(f.apply(Nil, "(memory)", extVars, -1, wd), extVars, wd)
   }
 
   def reverse(v: Js.Value): Val = v match{
@@ -51,7 +93,7 @@ object Materializer {
     case Js.Str(s) => Val.Str(s)
     case Js.Arr(xs) => Val.Arr(xs.map(x => Lazy(reverse(x))))
     case Js.Obj(xs) => Val.Obj(
-      xs.map(x => (x._1, Val.Obj.Member(false, Visibility.Normal, (_: Val.Obj, _: Option[Val.Obj], thisFile: String) => Lazy(reverse(x._2))))).toMap,
+      xs.map(x => (x._1, Val.Obj.Member(false, Visibility.Normal, (_: Val.Obj, _: Option[Val.Obj], _) => Lazy(reverse(x._2))))).toMap,
       _ => (),
       None
     )
@@ -73,4 +115,6 @@ object Materializer {
       )
   }
 
+  val useFastPath = new ThreadLocal[Boolean]()
+  useFastPath.set(true)
 }

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -344,7 +344,7 @@ object Std {
       val allKeys = obj.getVisibleKeys()
       Val.Obj(
         allKeys.map{ k =>
-          k._1 -> (Val.Obj.Member(false, Visibility.Normal, (self: Val.Obj, sup: Option[Val.Obj], thisFile: String) => Lazy(
+          k._1 -> (Val.Obj.Member(false, Visibility.Normal, (self: Val.Obj, sup: Option[Val.Obj], _) => Lazy(
             func.apply(
               Lazy(Val.Str(k._1)),
               obj.value(k._1, wd / "(memory)", wd, -1, wd, extVars)
@@ -736,7 +736,7 @@ object Std {
             Val.Obj.Member(
               false,
               Visibility.Hidden,
-              (self: Val.Obj, sup: Option[Val.Obj],  thisFile: String) => Lazy(v)
+              (self: Val.Obj, sup: Option[Val.Obj], _) => Lazy(v)
             )
           )
       }
@@ -746,7 +746,7 @@ object Std {
         Val.Obj.Member(
           false,
           Visibility.Hidden,
-          { (self: Val.Obj, sup: Option[Val.Obj], thisFile: String) => Lazy(Val.Str(thisFile))},
+          { (self: Val.Obj, sup: Option[Val.Obj], thisFile: () => String) => Lazy(Val.Str(thisFile()))},
           cached = false
         )
       )

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -53,7 +53,6 @@ object Val{
   }
   case class Arr(value: Seq[Lazy]) extends Val{
     def prettyName = "array"
-    var observed: Boolean = false
   }
   object Obj{
 
@@ -66,7 +65,6 @@ object Val{
                  triggerAsserts: Val.Obj => Unit,
                  `super`: Option[Obj]) extends Val{
     def prettyName = "object"
-    var observed: Boolean = false
 
     def getVisibleKeys() = {
       def rec(current: Val.Obj): Seq[(String, Visibility)] = {

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -53,18 +53,20 @@ object Val{
   }
   case class Arr(value: Seq[Lazy]) extends Val{
     def prettyName = "array"
+    var observed: Boolean = false
   }
   object Obj{
 
     case class Member(add: Boolean,
                       visibility: Visibility,
-                      invoke: (Obj, Option[Obj], String) => Lazy,
+                      invoke: (Obj, Option[Obj], () => String) => Lazy,
                       cached: Boolean = true)
   }
   case class Obj(value0: Map[String, Obj.Member],
                  triggerAsserts: Val.Obj => Unit,
                  `super`: Option[Obj]) extends Val{
     def prettyName = "object"
+    var observed: Boolean = false
 
     def getVisibleKeys() = {
       def rec(current: Val.Obj): Seq[(String, Visibility)] = {
@@ -95,7 +97,7 @@ object Val{
               self: Obj = this) = {
 
       val (cached, lazyValue) =
-        valueRaw(k, self, fileName.relativeTo(currentRoot).toString(), extVars, wd, fileName, offset).getOrElse(Evaluator.fail("Field does not exist: " + k, fileName, offset, wd))
+        valueRaw(k, self, () => fileName.relativeTo(currentRoot).toString(), extVars, wd, fileName, offset).getOrElse(Evaluator.fail("Field does not exist: " + k, fileName, offset, wd))
       if (!cached) lazyValue
       else valueCache.getOrElseUpdate(
         // It is very rare that self != this, so fast-path the common case
@@ -126,7 +128,7 @@ object Val{
 
     def valueRaw(k: String,
                  self: Obj,
-                 thisFile: String,
+                 thisFile: () => String,
                  extVars: Map[String, ujson.Js],
                  wd: os.Path,
                  currentFile: os.Path, offset: Int): Option[(Boolean, Lazy)] = this.value0.get(k) match{

--- a/sjsonnet/test/src/sjsonnet/SjsonnetTestMain.scala
+++ b/sjsonnet/test/src/sjsonnet/SjsonnetTestMain.scala
@@ -43,7 +43,7 @@ object SjsonnetTestMain {
     val start = System.currentTimeMillis()
     var count = 0
     val parseCache = sjsonnet.SjsonnetMain.createParseCache()
-    while(System.currentTimeMillis() - start < 2000000){
+    while(System.currentTimeMillis() - start < 20000000){
       count += 1
       for(name <- names){
 

--- a/sjsonnet/test/src/sjsonnet/SjsonnetTestMain.scala
+++ b/sjsonnet/test/src/sjsonnet/SjsonnetTestMain.scala
@@ -42,23 +42,24 @@ object SjsonnetTestMain {
 
     val start = System.currentTimeMillis()
     var count = 0
-    while(System.currentTimeMillis() - start < 20000){
+    val parseCache = sjsonnet.SjsonnetMain.createParseCache()
+    while(System.currentTimeMillis() - start < 2000000){
       count += 1
       for(name <- names){
 
 //        println(name)
 //
-        os.proc("jsonnet", FileTests.testSuiteRoot / s"$name.jsonnet").call()
-//        val parseCache = sjsonnet.SjsonnetMain.createParseCache()
-//        val path = FileTests.testSuiteRoot / s"$name.jsonnet"
-//        val interp = new Interpreter(
-//          parseCache,
-//          Scope.standard(path, FileTests.testSuiteRoot, Nil),
-//          Map(),
-//          Map(),
-//          os.pwd
-//        )
-//        interp.interpret(path)
+//        os.proc("jsonnet", FileTests.testSuiteRoot / s"$name.jsonnet").call()
+        val path = FileTests.testSuiteRoot / s"$name.jsonnet"
+        val interp = new Interpreter(
+          parseCache,
+          Scope.standard(path, FileTests.testSuiteRoot, Nil),
+          Map(),
+          Map(),
+          os.pwd,
+          None
+        )
+        interp.interpret(path)
       }
     }
     println(count)


### PR DESCRIPTION
This PR lazily resolves the file path because it is only used in the `thisFile` standard library function or in error messages. Making it a lambda means that it never needs to be computed unless that function is used or an error happens.
