### PR TITLE
Add support for configuring an import callback

### DIFF
--- a/sjsonnet/src/sjsonnet/Interpreter.scala
+++ b/sjsonnet/src/sjsonnet/Interpreter.scala
@@ -11,8 +11,9 @@ class Interpreter(parseCache: collection.mutable.Map[String, fastparse.Parsed[Ex
                   extVars: Map[String, ujson.Js],
                   tlaVars: Map[String, ujson.Js],
                   wd: os.Path,
-                  allowedInputs: Option[Set[os.Path]]) {
-  val evaluator = new Evaluator(parseCache, scope, extVars, wd, allowedInputs)
+                  allowedInputs: Option[Set[os.Path]],
+                  importer: Option[(Scope, String) => Option[os.Path]] = None) {
+  val evaluator = new Evaluator(parseCache, scope, extVars, wd, allowedInputs, importer)
   def interpret(p: os.Path): Either[String, ujson.Js] = {
     for{
       txt <- try Right(os.read(p)) catch{ case e: Throwable => Left(e.toString) }

--- a/sjsonnet/src/sjsonnet/SjsonnetMain.scala
+++ b/sjsonnet/src/sjsonnet/SjsonnetMain.scala
@@ -26,7 +26,8 @@ object SjsonnetMain {
             stdout: PrintStream,
             stderr: PrintStream,
             wd: os.Path,
-            allowedInputs: Option[Set[os.Path]] = None): Int = {
+            allowedInputs: Option[Set[os.Path]] = None,
+            importer: Option[(Scope, String) => Option[os.Path]] = None): Int = {
 
     Cli.groupArgs(args.toList, Cli.genericSignature(wd), Cli.Config()) match{
       case Left(err) =>
@@ -60,7 +61,8 @@ object SjsonnetMain {
                     config.varBinding,
                     config.tlaBinding,
                     wd,
-                    allowedInputs
+                    allowedInputs,
+                    importer
                   )
                   interp.interpret(path) match{
                     case Left(errMsg) =>

--- a/sjsonnet/test/src/sjsonnet/Example.java
+++ b/sjsonnet/test/src/sjsonnet/Example.java
@@ -9,6 +9,7 @@ public class Example {
             System.out,
             System.err,
             os.package$.MODULE$.pwd(),
+            scala.None$.empty(),
             scala.None$.empty()
         );
     }


### PR DESCRIPTION
This PR lets clients customize import resolution ([as supported in the C library](https://github.com/google/jsonnet/blob/30f07a2684ebc40d800bb1948e1f5987e5fb02e3/include/libjsonnet.h#L67)). This is accomplished with an optional param to the evaluator that resolves a (scope, import path) to a filesystem path.

We use this to support non-filesystem paths (in particular HTTP), and it seems like the equivalent support in the C and go APIs are fairly widely used.