### PR TITLE
Implement `std.manifestDocYaml` and `create-output-dirs`, `string`, `multi` command line options

### DIFF
--- a/sjsonnet/src/sjsonnet/Cli.scala
+++ b/sjsonnet/src/sjsonnet/Cli.scala
@@ -48,7 +48,7 @@ object Cli{
     ),
     Arg[Config, String](
       "ext-str", Some('V'),
-      "???",
+      "<var>[=<val>] Provide 'external' variable as string. 'If <val> is omitted, get from environment var <var>",
       (c, v) => v split('=') match{
         case Array(x) => c.copy(varBinding = c.varBinding ++ Seq(x -> ujson.Js.Str(System.getenv(x))))
         case Array(x, v) => c.copy(varBinding = c.varBinding ++ Seq(x -> ujson.Js.Str(v)))
@@ -56,7 +56,7 @@ object Cli{
     ),
     Arg[Config, String](
       "ext-str-file", None,
-      "???",
+      "<var>=<file> Provide 'external' variable as string from the file",
       (c, v) => v split('=') match{
         case Array(x, v) =>
           c.copy(varBinding = c.varBinding ++ Seq(x -> ujson.Js.Str(os.read(os.Path(v, wd)))))
@@ -64,7 +64,7 @@ object Cli{
     ),
     Arg[Config, String](
       "ext-code", None,
-      "???",
+      "<var>[=<code>] Provide 'external' variable as Jsonnet code. If <code> is omitted, get from environment var <var>",
       (c, v) => v split('=') match{
         case Array(x) => c.copy(varBinding = c.varBinding ++ Seq(x -> ujson.read(System.getenv(x))))
         case Array(x, v) => c.copy(varBinding = c.varBinding ++ Seq(x -> ujson.read(v)))
@@ -72,7 +72,7 @@ object Cli{
     ),
     Arg[Config, String](
       "ext-code-file", None,
-      "???",
+      "<var>=<file> Provide 'external' variable as Jsonnet code from the file",
       (c, v) => v split('=') match{
         case Array(x, v) =>
           c.copy(varBinding = c.varBinding ++ Seq(x -> ujson.read(os.read(os.Path(v, wd)))))
@@ -80,7 +80,7 @@ object Cli{
     ),
     Arg[Config, String](
       "tla-str", Some('A'),
-      "???",
+      "<var>[=<val>] Provide top-level arguments as string. 'If <val> is omitted, get from environment var <var>",
       (c, v) => v split('=') match{
         case Array(x) => c.copy(tlaBinding = c.tlaBinding ++ Seq(x -> ujson.Js.Str(System.getenv(x))))
         case Array(x, v) => c.copy(tlaBinding = c.tlaBinding ++ Seq(x -> ujson.Js.Str(v)))
@@ -88,7 +88,7 @@ object Cli{
     ),
     Arg[Config, String](
       "tla-str-file", None,
-      "???",
+      "<var>=<file> Provide top-level arguments variable as string from the file",
       (c, v) => v split('=') match{
         case Array(x, v) =>
           c.copy(tlaBinding = c.tlaBinding ++ Seq(x -> ujson.Js.Str(os.read(os.Path(v, wd)))))
@@ -96,7 +96,7 @@ object Cli{
     ),
     Arg[Config, String](
       "tla-code", None,
-      "???",
+      "<var>[=<val>] Provide top-level arguments as Jsonnet code. 'If <val> is omitted, get from environment var <var>",
       (c, v) => v split('=') match{
         case Array(x) => c.copy(tlaBinding = c.tlaBinding ++ Seq(x -> ujson.read(System.getenv(x))))
         case Array(x, v) => c.copy(tlaBinding = c.tlaBinding ++ Seq(x -> ujson.read(v)))
@@ -104,7 +104,7 @@ object Cli{
     ),
     Arg[Config, String](
       "tla-code-file", None,
-      "???",
+      "<var>=<file> Provide top-level arguments variable as Jsonnet code from the file",
       (c, v) => v split('=') match{
         case Array(x, v) =>
           c.copy(tlaBinding = c.tlaBinding ++ Seq(x -> ujson.read(os.read(os.Path(v, wd)))))

--- a/sjsonnet/src/sjsonnet/Cli.scala
+++ b/sjsonnet/src/sjsonnet/Cli.scala
@@ -14,6 +14,7 @@ object Cli{
   case class Config(interactive: Boolean = false,
                     jpaths: List[String] = Nil,
                     outputFile: Option[String] = None,
+                    createDirs: Boolean = false,
                     varBinding: Map[String, ujson.Js] = Map(),
                     tlaBinding: Map[String, ujson.Js] = Map(),
                     indent: Int = 3)
@@ -39,6 +40,11 @@ object Cli{
       "output-file", Some('o'),
       "Write to the output file rather than stdout",
       (c, v) => c.copy(outputFile = Some(v))
+    ),
+    Arg[Config, Unit](
+      "create-output-dirs", Some('c'),
+      "Automatically creates all parent directories for files",
+      (c, v) => c.copy(createDirs = true)
     ),
     Arg[Config, String](
       "ext-str", Some('V'),

--- a/sjsonnet/src/sjsonnet/Cli.scala
+++ b/sjsonnet/src/sjsonnet/Cli.scala
@@ -16,6 +16,7 @@ object Cli{
                     outputFile: Option[String] = None,
                     multi: Option[String] = None,
                     createDirs: Boolean = false,
+                    expectString: Boolean = false,
                     varBinding: Map[String, ujson.Js] = Map(),
                     tlaBinding: Map[String, ujson.Js] = Map(),
                     indent: Int = 3)
@@ -51,6 +52,11 @@ object Cli{
       "create-output-dirs", Some('c'),
       "Automatically creates all parent directories for files",
       (c, v) => c.copy(createDirs = true)
+    ),
+    Arg[Config, Unit](
+      "String", Some('S'),
+      "Expect a string, manifest as plain text",
+      (c, v) => c.copy(expectString = true)
     ),
     Arg[Config, String](
       "ext-str", Some('V'),

--- a/sjsonnet/src/sjsonnet/Cli.scala
+++ b/sjsonnet/src/sjsonnet/Cli.scala
@@ -14,6 +14,7 @@ object Cli{
   case class Config(interactive: Boolean = false,
                     jpaths: List[String] = Nil,
                     outputFile: Option[String] = None,
+                    multi: Option[String] = None,
                     createDirs: Boolean = false,
                     varBinding: Map[String, ujson.Js] = Map(),
                     tlaBinding: Map[String, ujson.Js] = Map(),
@@ -40,6 +41,11 @@ object Cli{
       "output-file", Some('o'),
       "Write to the output file rather than stdout",
       (c, v) => c.copy(outputFile = Some(v))
+    ),
+    Arg[Config, String](
+      "multi", Some('m'),
+      "Write multiple files to the directory, list files on stdout",
+      (c, v) => c.copy(multi = Some(v))
     ),
     Arg[Config, Unit](
       "create-output-dirs", Some('c'),

--- a/sjsonnet/src/sjsonnet/Renderer.scala
+++ b/sjsonnet/src/sjsonnet/Renderer.scala
@@ -1,7 +1,8 @@
 package sjsonnet
 import java.io.StringWriter
+import java.util.regex.Pattern
 
-import ujson.{ArrVisitor, BaseRenderer, ObjVisitor, Renderer}
+import ujson.{ArrVisitor, BaseRenderer, ObjVisitor}
 
 class PythonRenderer(out: StringWriter = new java.io.StringWriter(),
                      indent: Int = -1) extends BaseRenderer(out, indent){
@@ -47,14 +48,7 @@ class Renderer(out: StringWriter = new java.io.StringWriter(),
   var newlineBuffered = false
   override def visitNumRaw(d: Double, index: Int) = {
     flushBuffer()
-    out.append(
-      if (d.toLong == d) d.toLong.toString
-      else if (d % 1 == 0) {
-        BigDecimal(d).setScale(0, BigDecimal.RoundingMode.HALF_EVEN).toBigInt.toString()
-      }
-      else d.toString
-    )
-    flushBuffer()
+    RenderUtils.renderDouble(out, d)
     out
   }
   override val colonSnippet = ": "
@@ -129,5 +123,138 @@ class Renderer(out: StringWriter = new java.io.StringWriter(),
       out.append('}')
       out
     }
+  }
+}
+
+class YamlRenderer(out: StringWriter = new java.io.StringWriter(), indentArrayInObject: Boolean = false,
+                   indent: Int = 2) extends BaseRenderer(out, indent){
+  var newlineBuffered = false
+  var dashBuffered = false
+  var afterKey = false
+  var topLevel = true
+
+  val newlinePattern = Pattern.compile("\n")
+  val outBuffer = out.getBuffer()
+
+  override def visitString(s: CharSequence, index: Int): StringWriter = {
+    flushBuffer()
+    val len = s.length()
+    if (len == 0) out.append("\"\"")
+    else if (s.charAt(len - 1) == '\n') {
+      val splits = newlinePattern.split(s)
+      out.append('|')
+      depth += 1
+      splits.foreach { split =>
+        newlineBuffered = true
+        flushBuffer()
+        out.append(split) // TODO escaping?
+      }
+      depth -= 1
+      out
+    } else {
+      ujson.Renderer.escape(out, s, unicode = true)
+      out
+    }
+  }
+  override def visitNumRaw(d: Double, index: Int) = {
+    flushBuffer()
+    RenderUtils.renderDouble(out, d)
+    out
+  }
+  override val colonSnippet = ": "
+  override def flushBuffer() = {
+    if (newlineBuffered) {
+      // drop space between colon and newline
+      if (outBuffer.length() > 1 && outBuffer.charAt(outBuffer.length() - 1) == ' ') {
+        outBuffer.setLength(outBuffer.length() - 1)
+      }
+      out.append('\n')
+
+      var i = indent * depth
+      while(i > 0) {
+        out.append(' ')
+        i -= 1
+      }
+    }
+    if (dashBuffered) {
+      out.append("- ")
+    }
+    dashBuffered = false
+    newlineBuffered = false
+    dashBuffered = false
+  }
+  override def visitArray(index: Int) = new ArrVisitor[StringWriter, StringWriter] {
+    var empty = true
+    flushBuffer()
+
+    if (!topLevel) {
+      depth += 1
+      newlineBuffered = true
+    }
+    topLevel = false
+
+    var dedentInObject = afterKey && !indentArrayInObject
+    afterKey = false
+    if (dedentInObject) depth -= 1
+    dashBuffered = true
+
+    def subVisitor = YamlRenderer.this
+    def visitValue(v: StringWriter, index: Int): Unit = {
+      empty = false
+      flushBuffer()
+      newlineBuffered = true
+      dashBuffered = true
+    }
+    def visitEnd(index: Int) = {
+      if (!dedentInObject) depth -= 1
+      if (empty) out.append("[]")
+      newlineBuffered = false
+      dashBuffered = false
+      out
+    }
+  }
+  override def visitObject(index: Int) = new ObjVisitor[StringWriter, StringWriter] {
+    var empty = true
+    flushBuffer()
+    if (!topLevel) depth += 1
+    topLevel = false
+
+    if (afterKey) newlineBuffered = true
+
+    def subVisitor = YamlRenderer.this
+    def visitKey(s: CharSequence, index: Int): Unit = {
+      empty = false
+      flushBuffer()
+      ujson.Renderer.escape(out, s, true)
+      out.append(colonSnippet)
+      afterKey = true
+      newlineBuffered = false
+    }
+    def visitValue(v: StringWriter, index: Int): Unit = {
+      newlineBuffered = true
+      afterKey = false
+    }
+    def visitEnd(index: Int) = {
+      if (empty) out.append("{}")
+      newlineBuffered = false
+      depth -= 1
+      flushBuffer()
+      out
+    }
+  }
+}
+
+object RenderUtils {
+  /**
+    * Custom rendering of Doubles used in rendering
+    */
+  def renderDouble(out: java.io.Writer, d: Double): Unit = {
+    out.append(
+      if (d.toLong == d) d.toLong.toString
+      else if (d % 1 == 0) {
+        BigDecimal(d).setScale(0, BigDecimal.RoundingMode.HALF_EVEN).toBigInt.toString()
+      }
+      else d.toString
+    )
   }
 }

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -464,10 +464,12 @@ object Std {
       Materializer(v, extVars, wd).transform(new PythonRenderer()).toString
     },
     builtin("manifestJson", "v"){ (wd, extVars, v: Val) =>
-      Materializer(v, extVars, wd).render(indent = 4)
+      // account for rendering differences of whitespaces in ujson and jsonnet manifestJson
+      Materializer(v, extVars, wd).render(indent = 4).replaceAll("\n[ ]+\n", "\n\n")
     },
     builtin("manifestJsonEx", "value", "indent"){ (wd, extVars, v: Val, i: String) =>
-      Materializer(v, extVars, wd).render(indent = i.length)
+      // account for rendering differences of whitespaces in ujson and jsonnet manifestJsonEx
+      Materializer(v, extVars, wd).render(indent = i.length).replaceAll("\n[ ]+\n", "\n\n")
     },
     builtin("manifestPythonVars", "v"){ (wd, extVars, v: Val.Obj) =>
       Materializer(v, extVars, wd).obj

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -371,8 +371,11 @@ object Std {
         }
       )
     },
-    builtin("substr", "s", "from", "len"){ (wd, extVars, s: String, from: Int, len: Int) =>
-      s.substring(from, from + len)
+    builtin("substr", "s", "from", "len"){ (wd, extVars, s: String, from: Int, len: Int) => {
+      val safeOffset = math.min(from, s.length - 1)
+      val safeLength = math.min(len, s.length - 1 - safeOffset)
+      s.substring(safeOffset, safeOffset + safeLength)
+      }
     },
     builtin("startsWith", "a", "b"){ (wd, extVars, a: String, b: String) =>
       a.startsWith(b)

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -451,31 +451,7 @@ object Std {
     },
     builtin("escapeStringJson", "str"){ (wd, extVars, str: String) =>
       val out = new StringWriter()
-      // Fork of `ujson.Renderer.escape(out, str, unicode = true)`
-      // to improperly escape `~`, for bug-for-bug compatibility with google/jsonnet
-      def escape(sb: java.io.Writer, s: CharSequence, unicode: Boolean): Unit = {
-        sb.append('"')
-        var i = 0
-        val len = s.length
-        while (i < len) {
-          (s.charAt(i): @switch) match {
-            case '"' => sb.append("\\\"")
-            case '\\' => sb.append("\\\\")
-            case '\b' => sb.append("\\b")
-            case '\f' => sb.append("\\f")
-            case '\n' => sb.append("\\n")
-            case '\r' => sb.append("\\r")
-            case '\t' => sb.append("\\t")
-            case c =>
-              if (c < ' ' || (c >= '~' && unicode)) sb.append("\\u%04x" format c.toInt)
-              // if (c < ' ' || (c > '~' && unicode)) sb.append("\\u%04x" format c.toInt)
-              else sb.append(c)
-          }
-          i += 1
-        }
-        sb.append('"')
-      }
-      escape(out, str, unicode = true)
+      ujson.Renderer.escape(out, str, unicode = true)
       out.toString
     },
     builtin("escapeStringBash", "str"){ (wd, extVars, str: String) =>

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -729,7 +729,7 @@ object Std {
       Params(Seq("str" -> None, "rest" -> None)),
       { (scope, thisFile, extVars, outerOffset, wd) =>
         val Val.Str(msg) = scope.bindings("str").get.force
-        println(s"TRACE: $thisFile " + msg)
+        System.err.println(s"TRACE: $thisFile " + msg)
         scope.bindings("rest").get.force
       }
     ),

--- a/sjsonnet/test/resources/test_suite/stdlib.jsonnet
+++ b/sjsonnet/test/resources/test_suite/stdlib.jsonnet
@@ -414,49 +414,49 @@ local some_json = {
   '"': null,
 };
 
-//std.assertEqual(
-//  std.manifestJsonEx(some_json, '    ') + '\n',
-//  |||
-//    {
-//        "\"": null,
-//        "arr": [
-//            [
-//                [
-//
-//                ]
-//            ]
-//        ],
-//        "emptyArray": [
-//
-//        ],
-//        "emptyObject": {
-//
-//        },
-//        "objectInArray": [
-//            {
-//                "f": 3
-//            }
-//        ],
-//        "x": [
-//            1,
-//            2,
-//            3,
-//            true,
-//            false,
-//            null,
-//            "string\nstring\n"
-//        ],
-//        "y": {
-//            "a": 1,
-//            "b": 2,
-//            "c": [
-//                1,
-//                2
-//            ]
-//        }
-//    }
-//  |||
-//) &&
+std.assertEqual(
+ std.manifestJsonEx(some_json, '    ') + '\n',
+ |||
+   {
+       "\"": null,
+       "arr": [
+           [
+               [
+
+               ]
+           ]
+       ],
+       "emptyArray": [
+
+       ],
+       "emptyObject": {
+
+       },
+       "objectInArray": [
+           {
+               "f": 3
+           }
+       ],
+       "x": [
+           1,
+           2,
+           3,
+           true,
+           false,
+           null,
+           "string\nstring\n"
+       ],
+       "y": {
+           "a": 1,
+           "b": 2,
+           "c": [
+               1,
+               2
+           ]
+       }
+   }
+ |||
+) &&
 //
 //std.assertEqual(
 //  std.manifestYamlDoc(some_json) + '\n',

--- a/sjsonnet/test/resources/test_suite/stdlib.jsonnet
+++ b/sjsonnet/test/resources/test_suite/stdlib.jsonnet
@@ -457,98 +457,362 @@ std.assertEqual(
    }
  |||
 ) &&
-//
-//std.assertEqual(
-//  std.manifestYamlDoc(some_json) + '\n',
-//  |||
-//    "\"": null
-//    "arr":
-//    - - []
-//    "emptyArray": []
-//    "emptyObject": {}
-//    "objectInArray":
-//    - "f": 3
-//    "x":
-//    - 1
-//    - 2
-//    - 3
-//    - true
-//    - false
-//    - null
-//    - |
-//      string
-//      string
-//    "y":
-//      "a": 1
-//      "b": 2
-//      "c":
-//      - 1
-//      - 2
-//  |||
-//) &&
-//
-//std.assertEqual(
-//  std.manifestYamlStream([some_json, some_json, {}, [], 3, '"']),
-//  |||
-//    ---
-//    "\"": null
-//    "arr":
-//    - - []
-//    "emptyArray": []
-//    "emptyObject": {}
-//    "objectInArray":
-//    - "f": 3
-//    "x":
-//    - 1
-//    - 2
-//    - 3
-//    - true
-//    - false
-//    - null
-//    - |
-//      string
-//      string
-//    "y":
-//      "a": 1
-//      "b": 2
-//      "c":
-//      - 1
-//      - 2
-//    ---
-//    "\"": null
-//    "arr":
-//    - - []
-//    "emptyArray": []
-//    "emptyObject": {}
-//    "objectInArray":
-//    - "f": 3
-//    "x":
-//    - 1
-//    - 2
-//    - 3
-//    - true
-//    - false
-//    - null
-//    - |
-//      string
-//      string
-//    "y":
-//      "a": 1
-//      "b": 2
-//      "c":
-//      - 1
-//      - 2
-//    ---
-//    {}
-//    ---
-//    []
-//    ---
-//    3
-//    ---
-//    "\""
-//    ...
-//  |||
-//) &&
+
+std.assertEqual(
+  std.manifestYamlDoc({ x: [1, 2, 3] }) + '\n',
+  |||
+    "x":
+    - 1
+    - 2
+    - 3
+  |||
+) &&
+
+std.assertEqual(
+  std.manifestYamlDoc([[[1, 2], [3, 4]]]) + '\n',
+  |||
+    -
+      -
+        - 1
+        - 2
+      -
+        - 3
+        - 4
+  |||
+) &&
+
+std.assertEqual(
+  std.manifestYamlDoc({ x: [[[1, [1], 1]]] }) + '\n',
+  |||
+    "x":
+    -
+      -
+        - 1
+        -
+          - 1
+        - 1
+  |||
+) &&
+
+std.assertEqual(
+  std.manifestYamlDoc({ x: [[[1, { f: 3, g: [1, 2] }, 1]]] }) + '\n',
+  |||
+    "x":
+    -
+      -
+        - 1
+        - "f": 3
+          "g":
+          - 1
+          - 2
+        - 1
+  |||
+) &&
+
+std.assertEqual(
+  std.manifestYamlDoc('hello\nworld\n') + '\n',
+  |||
+    |
+      hello
+      world
+  |||
+) &&
+
+std.assertEqual(
+  std.manifestYamlDoc(['hello\nworld\n']) + '\n',
+  |||
+    - |
+      hello
+      world
+  |||
+) &&
+
+std.assertEqual(
+  std.manifestYamlDoc({ f: 'hello\nworld\n' }) + '\n',
+  |||
+    "f": |
+      hello
+      world
+  |||
+) &&
+
+std.assertEqual(
+  std.manifestYamlDoc(some_json) + '\n',
+  |||
+    "\"": null
+    "arr":
+    -
+      - []
+    "emptyArray": []
+    "emptyObject": {}
+    "objectInArray":
+    - "f": 3
+    "x":
+    - 1
+    - 2
+    - 3
+    - true
+    - false
+    - null
+    - |
+      string
+      string
+    "y":
+      "a": 1
+      "b": 2
+      "c":
+      - 1
+      - 2
+  |||
+) &&
+
+std.assertEqual(
+  std.manifestYamlDoc([{ x: [1, 2, 3] }], indent_array_in_object=true) + '\n',
+  |||
+    - "x":
+        - 1
+        - 2
+        - 3
+  |||
+) &&
+
+std.assertEqual(
+  std.manifestYamlDoc({ x: [1, 2, 3] }, indent_array_in_object=true) + '\n',
+  |||
+    "x":
+      - 1
+      - 2
+      - 3
+  |||
+) &&
+
+std.assertEqual(
+  std.manifestYamlDoc([[[1, 2], [3, 4]]], indent_array_in_object=true) + '\n',
+  |||
+    -
+      -
+        - 1
+        - 2
+      -
+        - 3
+        - 4
+  |||
+) &&
+
+std.assertEqual(
+  std.manifestYamlDoc({ x: [[[1, [1], 1]]] }, indent_array_in_object=true) + '\n',
+  |||
+    "x":
+      -
+        -
+          - 1
+          -
+            - 1
+          - 1
+  |||
+) &&
+
+std.assertEqual(
+  std.manifestYamlDoc({ x: [[[1, { f: 3, g: [1, 2] }, 1]]] }, indent_array_in_object=true) + '\n',
+  |||
+    "x":
+      -
+        -
+          - 1
+          - "f": 3
+            "g":
+              - 1
+              - 2
+          - 1
+  |||
+) &&
+
+std.assertEqual(
+  std.manifestYamlDoc('hello\nworld\n', indent_array_in_object=true) + '\n',
+  |||
+    |
+      hello
+      world
+  |||
+) &&
+
+std.assertEqual(
+  std.manifestYamlDoc(['hello\nworld\n'], indent_array_in_object=true) + '\n',
+  |||
+    - |
+      hello
+      world
+  |||
+) &&
+
+std.assertEqual(
+  std.manifestYamlDoc({ f: 'hello\nworld\n' }, indent_array_in_object=true) + '\n',
+  |||
+    "f": |
+      hello
+      world
+  |||
+) &&
+
+std.assertEqual(
+  std.manifestYamlDoc(some_json, indent_array_in_object=true) + '\n',
+  |||
+    "\"": null
+    "arr":
+      -
+        - []
+    "emptyArray": []
+    "emptyObject": {}
+    "objectInArray":
+      - "f": 3
+    "x":
+      - 1
+      - 2
+      - 3
+      - true
+      - false
+      - null
+      - |
+        string
+        string
+    "y":
+      "a": 1
+      "b": 2
+      "c":
+        - 1
+        - 2
+  |||
+) &&
+
+std.assertEqual(
+  std.manifestYamlStream([some_json, some_json, {}, [], 3, '"']),
+  |||
+    ---
+    "\"": null
+    "arr":
+    -
+      - []
+    "emptyArray": []
+    "emptyObject": {}
+    "objectInArray":
+    - "f": 3
+    "x":
+    - 1
+    - 2
+    - 3
+    - true
+    - false
+    - null
+    - |
+      string
+      string
+    "y":
+      "a": 1
+      "b": 2
+      "c":
+      - 1
+      - 2
+    ---
+    "\"": null
+    "arr":
+    -
+      - []
+    "emptyArray": []
+    "emptyObject": {}
+    "objectInArray":
+    - "f": 3
+    "x":
+    - 1
+    - 2
+    - 3
+    - true
+    - false
+    - null
+    - |
+      string
+      string
+    "y":
+      "a": 1
+      "b": 2
+      "c":
+      - 1
+      - 2
+    ---
+    {}
+    ---
+    []
+    ---
+    3
+    ---
+    "\""
+    ...
+  |||
+) &&
+
+std.assertEqual(
+  std.manifestYamlStream([some_json, some_json, {}, [], 3, '"'], indent_array_in_object=true),
+  |||
+    ---
+    "\"": null
+    "arr":
+      -
+        - []
+    "emptyArray": []
+    "emptyObject": {}
+    "objectInArray":
+      - "f": 3
+    "x":
+      - 1
+      - 2
+      - 3
+      - true
+      - false
+      - null
+      - |
+        string
+        string
+    "y":
+      "a": 1
+      "b": 2
+      "c":
+        - 1
+        - 2
+    ---
+    "\"": null
+    "arr":
+      -
+        - []
+    "emptyArray": []
+    "emptyObject": {}
+    "objectInArray":
+      - "f": 3
+    "x":
+      - 1
+      - 2
+      - 3
+      - true
+      - false
+      - null
+      - |
+        string
+        string
+    "y":
+      "a": 1
+      "b": 2
+      "c":
+        - 1
+        - 2
+    ---
+    {}
+    ---
+    []
+    ---
+    3
+    ---
+    "\""
+    ...
+  |||
+) &&
 
 std.assertEqual(std.parseInt('01234567890'), 1234567890) &&
 std.assertEqual(std.parseInt('-01234567890'), -1234567890) &&

--- a/sjsonnet/test/resources/test_suite/stdlib.jsonnet
+++ b/sjsonnet/test/resources/test_suite/stdlib.jsonnet
@@ -160,6 +160,8 @@ std.assertEqual(std.toString([1, 2, 'foo']), '[1, 2, "foo"]') &&
 
 std.assertEqual(std.substr('cookie', 1, 3), 'ook') &&
 std.assertEqual(std.substr('cookie', 1, 0), '') &&
+std.assertEqual(std.substr('cookie', 6, 2), '') &&
+std.assertEqual(std.substr('cookie', 6, 0), '') &&
 
 std.assertEqual(std.startsWith('food', 'foo'), true) &&
 std.assertEqual(std.startsWith('food', 'food'), true) &&

--- a/sjsonnet/test/resources/test_suite/stdlib.jsonnet
+++ b/sjsonnet/test/resources/test_suite/stdlib.jsonnet
@@ -265,6 +265,7 @@ std.assertEqual(std.escapeStringJson('he"llo'), '"he\\"llo"') &&
 std.assertEqual(std.escapeStringJson('he"llo'), '"he\\"llo"') &&
 std.assertEqual(std.escapeStringBash("he\"l'lo"), "'he\"l'\"'\"'lo'") &&
 std.assertEqual(std.escapeStringDollars('The path is ${PATH}.'), 'The path is $${PATH}.') &&
+std.assertEqual(std.escapeStringJson('!~'), '"!~"') &&
 
 std.assertEqual(std.manifestPython({
   x: 'test',

--- a/sjsonnet/test/src/sjsonnet/YamlRendererTests.scala
+++ b/sjsonnet/test/src/sjsonnet/YamlRendererTests.scala
@@ -1,0 +1,36 @@
+package sjsonnet
+
+import utest._
+
+object YamlRendererTests extends TestSuite{
+  def tests = Tests {
+    'empty - {
+      ujson.transform(ujson.Js.Arr(), new YamlRenderer()).toString ==> "[]"
+      ujson.transform(ujson.Js.Obj(), new YamlRenderer()).toString ==> "{}"
+      ujson.transform(ujson.Js.Obj("a" -> ujson.Js.Arr(), "b" -> ujson.Js.Obj()), new YamlRenderer()).toString ==>
+        """"a": []
+          |"b": {}""".stripMargin
+    }
+    'nonEmpty - {
+      ujson.transform(ujson.Js.Arr(1), new YamlRenderer()).toString ==>
+        """- 1""".stripMargin
+      ujson.transform(ujson.Js.Arr(1, 2), new YamlRenderer()).toString ==>
+        """- 1
+          |- 2""".stripMargin
+      ujson.transform(ujson.Js.Obj("a" -> 1), new YamlRenderer()).toString ==>
+        """"a": 1""".stripMargin
+      ujson.transform(ujson.Js.Obj("a" -> 1, "b" -> 2), new YamlRenderer()).toString ==>
+        """"a": 1
+          |"b": 2""".stripMargin
+    }
+    'nested - {
+      ujson.transform(
+        ujson.Js.Arr(ujson.Js.Obj("a" -> ujson.Js.Arr(1))),
+        new YamlRenderer()).toString ==>
+        """- "a":
+          |  - 1""".stripMargin
+    }
+
+  }
+
+}


### PR DESCRIPTION
Closes https://github.com/databricks/sjsonnet/issues/14 https://github.com/databricks/sjsonnet/issues/9

This pull request implements new features:

* implements `std.manifestYamlDoc` and `std.manifestYamlStream`
* `create-output-dirs`, `string`, `multi` command line options
* documents previously undocumented flags (replaces `???`)

and fixes some differences between the reference implementation and `sjsonnet`:

* `std.substr` does not care about being out of bounds - it just produces an empty output for characters out of bounds
* `std.manifestJson` does not contain spaces between `\n` characters in empty objects and arrays
* incorrect escaping of `~` has been fixed in https://github.com/google/jsonnet/pull/564
* `std.trace` outputs to stderr

NOTICE: a potentially breaking change is the addition of the `create-output-dirs` flag. `sjsonnet` previously behaved as if it were enabled, which differed from default behaviour of `jsonnet`

The number of lines changes seems huge, but most of it is caused by addition of tests for `std.manifestYamlDoc` in ` sjsonnet/test/resources/test_suite/stdlib.jsonnet`