### PR TITLE
fix std.mapWithIndex argument ordering

### DIFF
--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -374,8 +374,8 @@ object Std {
     },
     builtin("mapWithIndex", "func", "arr"){ (wd, extVars, func: Applyer, arr: Val.Arr) =>
       Val.Arr(
-        arr.value.zipWithIndex.map{ case (i, i2) =>
-          Lazy(func.apply(i, Lazy(Val.Num(i2))))
+        arr.value.zipWithIndex.map{ case (x, i) =>
+          Lazy(func.apply(Lazy(Val.Num(i)), x))
         }
       )
     },

--- a/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
+++ b/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
@@ -168,6 +168,7 @@ object EvaluatorTests extends TestSuite{
       eval("std.pow(n=3, x=2)") ==> Js.Num(8)
       eval("({a:: 1} + {a+:::2}).a") ==> Js.Num(3)
       eval("(std.prune({a:: 1}) + {a+:::2}).a") ==> Js.Num(2)
+      eval("std.toString(std.mapWithIndex(function(idx, elem) elem, [2,1,0]))") ==> Js.Str("[2, 1, 0]")
     }
     'unboundParam - {
       val ex = intercept[Exception]{


### PR DESCRIPTION
Addresses https://github.com/databricks/sjsonnet/issues/26. Note the Jsonnet Stdlib documentation for mapWithIndex:

```
std.mapWithIndex(func, arr)
Similar to map above, but it also passes to the function the element's index in the array. The function func is expected to take the index as the first parameter and the element as the second.
```

This PR fixes function evaluation to move the index first and adds a unit test case.