### PR TITLE
Added GZip Encode Feature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -73,7 +73,7 @@ Or from Javascript:
 $ curl -L https://github.com/databricks/sjsonnet/releases/download/0.1.6/sjsonnet.js > sjsonnet.js
 
 $ node
- 
+
 > require("./sjsonnet.js")
 
 > SjsonnetMain.interpret("local f = function(x) x * x; f(11)", {}, {}, "", (wd, imported) => null)
@@ -98,14 +98,14 @@ by emulating a filesystem in-memory)
 
 ### Running deeply recursive Jsonnet programs
 
-The depth of recursion is limited by JVM stack size. You can run Sjsonnet with increased 
+The depth of recursion is limited by JVM stack size. You can run Sjsonnet with increased
 stack size as follows:
 ```
 java -Xss100m -cp sjsonnet.jar sjsonnet.SjsonnetMain foo.jsonnet
 ```
 
-The -Xss option above is responsible for JVM stack size. Please try this if you 
-ever run into `sjsonnet.Error: Internal Error ... Caused by: java.lang.StackOverflowError ...`. 
+The -Xss option above is responsible for JVM stack size. Please try this if you
+ever run into `sjsonnet.Error: Internal Error ... Caused by: java.lang.StackOverflowError ...`.
 
 There is no analog of `--max-stack`/`-s` option of [google/jsonnet](https://github.com/google/jsonnet).
 The only stack size limit is the one of the JVM.
@@ -148,7 +148,7 @@ Some notes on the values used in parts of the pipeline:
 
 ## Performance
 
-Due to pervasive caching, sjsonnet is much faster than google/jsonnet. See 
+Due to pervasive caching, sjsonnet is much faster than google/jsonnet. See
 this blog post for more details:
 
 - [Writing a Faster Jsonnet Compiler](https://databricks.com/blog/2018/10/12/writing-a-faster-jsonnet-compiler.html)
@@ -230,7 +230,7 @@ programmatically via `new Interpreter(...).interpret(...)`.
 To publish, run the following commands:
 
 ```bash
-./mill -i mill.scalalib.PublishModule/publishAll lihaoyi:$SONATYPE_PASSWORD $GPG_PASSWORD __.publishArtifacts --release true
+./mill -i mill.scalalib.PublishModule/publishAll lihaoyi:$SONATYPE_PASSWORD $GPG_PASSWORD --publishArtifacts __.publishArtifacts --release true
 
 ./mill -i show sjsonnet[2.13.0].js.fullOpt
 ./mill -i show sjsonnet[2.13.0].jvm.assembly

--- a/sjsonnet/src-js/sjsonnet/Platform.scala
+++ b/sjsonnet/src-js/sjsonnet/Platform.scala
@@ -1,5 +1,11 @@
 package sjsonnet
-object Platform{
+object Platform {
+  def gzipBytes(s: Array[Byte]): String = {
+    throw new Exception("GZip not implemented in Scala.js")
+  }
+  def gzipString(s: String): String = {
+    throw new Exception("GZip not implemented in Scala.js")
+  }
   def md5(s: String): String = {
     throw new Exception("MD5 not implemented in Scala.js")
   }

--- a/sjsonnet/src-jvm/sjsonnet/Platform.scala
+++ b/sjsonnet/src-jvm/sjsonnet/Platform.scala
@@ -1,5 +1,23 @@
 package sjsonnet
-object Platform{
+object Platform {
+  def gzipBytes(b: Array[Byte]): String = {
+    val outputStream = new java.io.ByteArrayOutputStream(b.length)
+    val gzip = new java.util.zip.GZIPOutputStream(outputStream)
+    gzip.write(b)
+    gzip.close()
+    val gzippedBase64: String = java.util.Base64.getEncoder.encodeToString(outputStream.toByteArray)
+    outputStream.close()
+    gzippedBase64
+  }
+  def gzipString(s: String): String = {
+    val outputStream = new java.io.ByteArrayOutputStream(s.length)
+    val gzip = new java.util.zip.GZIPOutputStream(outputStream)
+    gzip.write(s.getBytes())
+    gzip.close()
+    val gzippedBase64: String = java.util.Base64.getEncoder.encodeToString(outputStream.toByteArray)
+    outputStream.close()
+    gzippedBase64
+  }
   def md5(s: String): String = {
     java.security.MessageDigest.getInstance("MD5")
       .digest(s.getBytes("UTF-8"))

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -487,24 +487,8 @@ object Std {
 
     builtin("gzip", "v"){ (ev, fs, v: Val) =>
       v match{
-        case Val.Str(value) => {
-          val outputStream: ByteArrayOutputStream = new ByteArrayOutputStream(value.length)
-          val gzip: GZIPOutputStream = new GZIPOutputStream(outputStream)
-          gzip.write(value.getBytes())
-          gzip.close()
-          val gzippedBase64: String = Base64.getEncoder.encodeToString(outputStream.toByteArray)
-          outputStream.close()
-          gzippedBase64
-        }
-        case Val.Arr(bytes) => {
-          val outputStream: ByteArrayOutputStream = new ByteArrayOutputStream(bytes.length)
-          val gzip: GZIPOutputStream = new GZIPOutputStream(outputStream)
-          gzip.write(bytes.map(_.force.cast[Val.Num].value.toByte).toArray)
-          gzip.close()
-          val gzippedBase64: String = Base64.getEncoder.encodeToString(outputStream.toByteArray)
-          outputStream.close()
-          gzippedBase64
-        }
+        case Val.Str(value) => Platform.gzipString(value)
+        case Val.Arr(bytes) => Platform.gzipBytes(bytes.map(_.force.cast[Val.Num].value.toByte).toArray)
         case x => throw new Error.Delegate("Cannot gzip encode " + x.prettyName)
       }
     },


### PR DESCRIPTION
## Description
This is a modification/fix to the previous PR (Ref: https://github.com/databricks/sjsonnet/pull/48) which added a standard function to gzip the given data (String/Bytes Array) and return a Base64 encoded gzipped string back.

## Changes
* We are not supporting the `gzip` feature in JS currently.
* Updated Readme file to reflect changes in the `publishArtifact` mill argument passing.

## Usage
`std.gzip(...)`