### PR TITLE
Only print to stdout/stderr if there's something to say

### DIFF
--- a/sjsonnet/src-jvm/sjsonnet/SjsonnetMain.scala
+++ b/sjsonnet/src-jvm/sjsonnet/SjsonnetMain.scala
@@ -75,10 +75,10 @@ object SjsonnetMain {
 
     result match{
       case Left(err) =>
-        System.err.println(err)
+        if (!err.isEmpty) System.err.println(err)
         1
       case Right(str) =>
-        System.out.println(str)
+        if (!str.isEmpty) System.out.println(str)
         0
     }
   }


### PR DESCRIPTION
I suspect unconditionally printing empty strings with `printLn()` creates unnecessary noise in the build output:

```
INFO: From Compiling Jsonnet to JSON for apiproxy/deploy/accounts:aws_to_yamls_template_input_sources:

INFO: From Compiling Jsonnet to JSON for apiproxy/deploy/multitenant:aws_to_yamls_template_input_sources:





INFO: From Compiling Jsonnet to JSON for apiproxy/router_check:create_unit_test_prod_to_yamls_template_input_sources:




```