### PR TITLE
Use passed streams instead of standard streams

### DIFF
--- a/sjsonnet/src-jvm/sjsonnet/SjsonnetMain.scala
+++ b/sjsonnet/src-jvm/sjsonnet/SjsonnetMain.scala
@@ -75,10 +75,10 @@ object SjsonnetMain {
 
     result match{
       case Left(err) =>
-        if (!err.isEmpty) System.err.println(err)
+        if (!err.isEmpty) stderr.println(err)
         1
       case Right(str) =>
-        if (!str.isEmpty) System.out.println(str)
+        if (!str.isEmpty) stdout.println(str)
         0
     }
   }


### PR DESCRIPTION
On overriding the print stream, errors are still getting printed on console.