### PR TITLE
Write output directly to disk with -o

### DIFF
--- a/sjsonnet/src/sjsonnet/Renderer.scala
+++ b/sjsonnet/src/sjsonnet/Renderer.scala
@@ -1,5 +1,5 @@
 package sjsonnet
-import java.io.StringWriter
+import java.io.{StringWriter, Writer}
 import java.util.regex.Pattern
 
 import upickle.core.{ArrVisitor, ObjVisitor}
@@ -13,7 +13,7 @@ import ujson.BaseRenderer
   * - Custom printing of empty dictionaries and arrays
   *
   */
-class Renderer(out: StringWriter = new java.io.StringWriter(),
+class Renderer(out: Writer = new java.io.StringWriter(),
                indent: Int = -1) extends BaseRenderer(out, indent){
   var newlineBuffered = false
   override def visitFloat64(d: Double, index: Int) = {
@@ -40,7 +40,7 @@ class Renderer(out: StringWriter = new java.io.StringWriter(),
     newlineBuffered = false
     commaBuffered = false
   }
-  override def visitArray(length: Int, index: Int) = new ArrVisitor[StringWriter, StringWriter] {
+  override def visitArray(length: Int, index: Int) = new ArrVisitor[Writer, Writer] {
     var empty = true
     flushBuffer()
     out.append('[')
@@ -48,7 +48,7 @@ class Renderer(out: StringWriter = new java.io.StringWriter(),
 
     depth += 1
     def subVisitor = Renderer.this
-    def visitValue(v: StringWriter, index: Int): Unit = {
+    def visitValue(v: Writer, index: Int): Unit = {
       empty = false
       flushBuffer()
       commaBuffered = true
@@ -65,7 +65,7 @@ class Renderer(out: StringWriter = new java.io.StringWriter(),
     }
   }
 
-  override def visitObject(length: Int, index: Int) = new ObjVisitor[StringWriter, StringWriter] {
+  override def visitObject(length: Int, index: Int) = new ObjVisitor[Writer, Writer] {
     var empty = true
     flushBuffer()
     out.append('{')
@@ -78,7 +78,7 @@ class Renderer(out: StringWriter = new java.io.StringWriter(),
       flushBuffer()
       out.append(colonSnippet)
     }
-    def visitValue(v: StringWriter, index: Int): Unit = {
+    def visitValue(v: Writer, index: Int): Unit = {
       commaBuffered = true
     }
     def visitEnd(index: Int) = {
@@ -212,7 +212,7 @@ class YamlRenderer(out: StringWriter = new java.io.StringWriter(), indentArrayIn
   }
 }
 
-class PythonRenderer(out: StringWriter = new java.io.StringWriter(),
+class PythonRenderer(out: Writer = new java.io.StringWriter(),
                      indent: Int = -1) extends BaseRenderer(out, indent){
 
   override def visitNull(index: Int) = {

--- a/sjsonnet/test/src-jvm/sjsonnet/MainTests.scala
+++ b/sjsonnet/test/src-jvm/sjsonnet/MainTests.scala
@@ -1,0 +1,32 @@
+package sjsonnet
+
+import java.io.{ByteArrayOutputStream, File, PrintStream}
+import java.util.Arrays
+
+import utest._
+
+object MainTests extends TestSuite {
+
+  val testSuiteRoot = os.pwd / "sjsonnet" / "test" / "resources" / "test_suite"
+
+  val tests = Tests {
+    // Compare writing to stdout with writing to a file
+    test("writeToFile") {
+      val source = (testSuiteRoot / "local.jsonnet").toString()
+      val outF = File.createTempFile("sjsonnet", ".json")
+      val out = new ByteArrayOutputStream()
+      val pout = new PrintStream(out)
+      SjsonnetMain.main0(Array(source), collection.mutable.Map.empty, System.in, pout, System.err, os.pwd, None)
+      pout.flush()
+      SjsonnetMain.main0(Array("-o", outF.getAbsolutePath, source), collection.mutable.Map.empty, System.in, System.out, System.err, os.pwd, None)
+      val stdoutBytes = out.toByteArray
+      val fileBytes = os.read(os.Path(outF)).getBytes
+      // stdout mode uses println so it has an extra platform-specific line separator at the end
+      val eol = System.getProperty("line.separator").getBytes
+
+      //println(stdoutBytes.map(_.toInt).mkString(","))
+      //println(fileBytes.map(_.toInt).mkString(","))
+      assert(Arrays.equals(fileBytes ++ eol, stdoutBytes))
+    }
+  }
+}


### PR DESCRIPTION
This prevents caching the entire output string in memory, reducing the heap usage for our largest output file of 7.2 MB from 101 MB to 93 MB in my test.

Only JSON is supported for now. YAML requires more work because the YamlRenderer is more closely tied to the underlying StringWriter, so it still has to buffer.