### PR TITLE
Add strict mode

### DIFF
--- a/sjsonnet/src-jvm/sjsonnet/Cli.scala
+++ b/sjsonnet/src-jvm/sjsonnet/Cli.scala
@@ -21,7 +21,8 @@ object Cli{
                     varBinding: Map[String, ujson.Value] = Map(),
                     tlaBinding: Map[String, ujson.Value] = Map(),
                     indent: Int = 3,
-                    preserveOrder: Boolean = false)
+                    preserveOrder: Boolean = false,
+                    strict: Boolean = false)
 
 
   def genericSignature(wd: os.Path) = Seq(
@@ -133,6 +134,11 @@ object Cli{
       "preserve-order", Some('p'),
       "Preserves order of keys in the resulting JSON",
       (c, v) => c.copy(preserveOrder = true)
+    ),
+    Arg[Config, Unit](
+      "strict", None,
+      "Enforce some additional syntax limitations",
+      (c, v) => c.copy(strict = true)
     ),
 
   )

--- a/sjsonnet/src-jvm/sjsonnet/SjsonnetMain.scala
+++ b/sjsonnet/src-jvm/sjsonnet/SjsonnetMain.scala
@@ -103,7 +103,8 @@ object SjsonnetMain {
         config.jpaths.map(os.Path(_, wd)).map(OsPath(_)),
         allowedInputs
       ),
-      config.preserveOrder
+      preserveOrder = config.preserveOrder,
+      strict = config.strict
     )
 
     def handleWriteFile[T](f: => T): Either[String, T] =

--- a/sjsonnet/src/sjsonnet/Expr.scala
+++ b/sjsonnet/src/sjsonnet/Expr.scala
@@ -38,9 +38,9 @@ object Expr{
     sealed trait Visibility
     object Visibility{
 
-      object Normal extends Visibility
-      object Hidden extends Visibility
-      object Unhide extends Visibility
+      case object Normal extends Visibility
+      case object Hidden extends Visibility
+      case object Unhide extends Visibility
     }
     case class Field(offset: Int,
                      fieldName: FieldName,

--- a/sjsonnet/src/sjsonnet/Interpreter.scala
+++ b/sjsonnet/src/sjsonnet/Interpreter.scala
@@ -14,14 +14,16 @@ class Interpreter(parseCache: collection.mutable.Map[String, fastparse.Parsed[(E
                   tlaVars: Map[String, ujson.Value],
                   wd: Path,
                   importer: (Path, String) => Option[(Path, String)],
-                  preserveOrder: Boolean = false) {
+                  preserveOrder: Boolean = false,
+                  strict: Boolean = true) {
 
   val evaluator = new Evaluator(
     parseCache,
     extVars,
     wd,
     importer,
-    preserveOrder
+    preserveOrder,
+    strict
   )
 
   def interpret(txt: String, path: Path): Either[String, ujson.Value] = {


### PR DESCRIPTION
This makes adjacent object literals an error. Fixes https://github.com/databricks/sjsonnet/issues/87