### PR TITLE
Added XZ Compression Support

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -65,6 +65,7 @@ class SjsonnetModule(val crossScalaVersion: String) extends Module {
     def ivyDeps = super.ivyDeps() ++ Agg(
       ivy"com.lihaoyi::os-lib:0.7.1",
       ivy"com.github.scopt::scopt::3.7.1",
+      ivy"org.tukaani:xz::1.8"
     )
     def compileIvyDeps = Agg( ivy"com.lihaoyi::acyclic:0.2.0")
     def scalacOptions = Seq("-P:acyclic:force")
@@ -101,7 +102,6 @@ class SjsonnetModule(val crossScalaVersion: String) extends Module {
       ivy"net.java.dev.jna:jna:4.5.0",
       ivy"net.java.dev.jna:jna-platform:4.5.0"
     )
-
 
     override def prependShellScript = mill.modules.Jvm.universalScript(
       shellCommands = {

--- a/sjsonnet/src-js/sjsonnet/Platform.scala
+++ b/sjsonnet/src-js/sjsonnet/Platform.scala
@@ -6,6 +6,12 @@ object Platform {
   def gzipString(s: String): String = {
     throw new Exception("GZip not implemented in Scala.js")
   }
+  def xzBytes(s: Array[Byte]): String = {
+    throw new Exception("XZ not implemented in Scala.js")
+  }
+  def xzString(s: String): String = {
+    throw new Exception("XZ not implemented in Scala.js")
+  }
   def md5(s: String): String = {
     throw new Exception("MD5 not implemented in Scala.js")
   }

--- a/sjsonnet/src-jvm/sjsonnet/Platform.scala
+++ b/sjsonnet/src-jvm/sjsonnet/Platform.scala
@@ -18,6 +18,24 @@ object Platform {
     outputStream.close()
     gzippedBase64
   }
+  def xzBytes(b: Array[Byte]): String = {
+    val outputStream = new java.io.ByteArrayOutputStream(b.length)
+    val gzip = new org.tukaani.xz.XZOutputStream(outputStream, new org.tukaani.xz.LZMA2Options())
+    gzip.write(b)
+    gzip.close()
+    val xzedBase64: String = java.util.Base64.getEncoder.encodeToString(outputStream.toByteArray)
+    outputStream.close()
+    xzedBase64
+  }
+  def xzString(s: String): String = {
+    val outputStream = new java.io.ByteArrayOutputStream(s.length)
+    val gzip = new org.tukaani.xz.XZOutputStream(outputStream, new org.tukaani.xz.LZMA2Options())
+    gzip.write(s.getBytes())
+    gzip.close()
+    val xzedBase64: String = java.util.Base64.getEncoder.encodeToString(outputStream.toByteArray)
+    outputStream.close()
+    xzedBase64
+  }
   def md5(s: String): String = {
     java.security.MessageDigest.getInstance("MD5")
       .digest(s.getBytes("UTF-8"))

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -585,6 +585,14 @@ object Std {
       }
     },
 
+    builtin("xz", "v"){ (ev, fs, v: Val) =>
+      v match{
+        case Val.Str(value) => Platform.xzString(value)
+        case Val.Arr(bytes) => Platform.xzBytes(bytes.map(_.force.cast[Val.Num].value.toByte).toArray)
+        case x => throw new Error.Delegate("Cannot xz encode " + x.prettyName)
+      }
+    },
+
     builtin("encodeUTF8", "s"){ (ev, fs, s: String) =>
       Val.Arr(s.getBytes(UTF_8).map(i => Val.Lazy(Val.Num(i & 0xff))))
     },


### PR DESCRIPTION
## Description
Added a standard function to xz the given data (String/Bytes Array) and return a Base64 encoded xz-ed string back. I ran the following commands:

```bash
./mill -i show sjsonnet[2.13.3].jvm.assembly
./mill -i show sjsonnet[2.13.3].js.fullOpt
```

## Changes
* We are not supporting the `xz` feature in JS currently.

## Usage
`std.xz(...)`