### PR TITLE
Fix compiler crash when '+' signal is true in a field declaration inside a list comprehension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@ output/
 .DS_STORE
 .idea_modules
 .idea
+.metals
+.vscode
 out/

--- a/sjsonnet/src/sjsonnet/Parser.scala
+++ b/sjsonnet/src/sjsonnet/Parser.scala
@@ -287,7 +287,7 @@ object Parser{
       val preLocals = exprs
         .takeWhile(_.isInstanceOf[Expr.Member.BindStmt])
         .map(_.asInstanceOf[Expr.Member.BindStmt])
-      val Expr.Member.Field(offset, Expr.FieldName.Dyn(lhs), false, None, Visibility.Normal, rhs) =
+      val Expr.Member.Field(offset, Expr.FieldName.Dyn(lhs), _, None, Visibility.Normal, rhs) =
         exprs(preLocals.length)
       val postLocals = exprs.drop(preLocals.length+1).takeWhile(_.isInstanceOf[Expr.Member.BindStmt])
         .map(_.asInstanceOf[Expr.Member.BindStmt])

--- a/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
+++ b/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
@@ -321,5 +321,12 @@ object EvaluatorTests extends TestSuite{
         """sjsonnet.Error: Adjacent object literals not allowed in strict mode - Use '+' to concatenate objects
           |at .(:1:31)""".stripMargin
     }
+    test("objectDeclaration") {
+      eval("{ ['foo']: x for x in  []}", false) ==> ujson.Obj()
+      eval("{ ['foo']: x for x in  [1]}", false) ==> ujson.Obj("foo" -> 1)
+
+      eval("{ ['foo']+: x for x in  []}", false) ==> ujson.Obj()
+      eval("{ ['foo']+: x for x in  [1]}", false) ==> ujson.Obj("foo" -> 1)
+    }
   }
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR fixes [issue 92](https://github.com/databricks/sjsonnet/issues/92) by changing the pattern match to match the '+' value to either true or false.

## How is this tested?
- A new unit test with a reproducible scenario of the issue
- `./mill "sjsonnet[2.13.3].jvm.test.testLocal"`

