### PR TITLE
Only catch non-fatal exception

### DIFF
--- a/sjsonnet/server/src/sjsonnet/SjsonnetServerMain.scala
+++ b/sjsonnet/server/src/sjsonnet/SjsonnetServerMain.scala
@@ -9,6 +9,8 @@ import org.scalasbt.ipcsocket._
 import sjsonnet.client.{Lock, Locks, ProxyOutputStream, Util => ClientUtil}
 import sun.misc.{Signal, SignalHandler}
 
+import scala.util.control.NonFatal
+
 trait SjsonnetServerMain[T]{
   var stateCache = Option.empty[T]
   def main0(args: Array[String],
@@ -118,7 +120,7 @@ class Server[T](lockBase: String,
                 handleRun(sock)
                 serverSocket.close()
               }
-              catch{case e: Throwable => e.printStackTrace(originalStdout) }
+              catch{case NonFatal(e) => e.printStackTrace(originalStdout) }
           }
         }
         // Make sure you give an opportunity for the client to probe the lock
@@ -231,7 +233,7 @@ object Server{
     try {
       val res =
         try Some(t)
-        catch {case e: Throwable => None}
+        catch {case NonFatal(e) => None}
 
       if (interrupted) None
       else res

--- a/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMain.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMain.scala
@@ -7,6 +7,7 @@ import java.nio.file.NoSuchFileException
 
 import scala.collection.mutable
 import scala.util.Try
+import scala.util.control.NonFatal
 
 object SjsonnetMain {
   def createParseCache() = collection.mutable.Map[String, fastparse.Parsed[(Expr, Map[String, Int])]]()
@@ -21,7 +22,7 @@ object SjsonnetMain {
       })
       .filter(p => allowedInputs.fold(true)(_(p)))
       .find(os.exists)
-      .flatMap(p => try Some((OsPath(p), os.read(p))) catch{case e: Throwable => None})
+      .flatMap(p => try Some((OsPath(p), os.read(p))) catch{case NonFatal(_) => None})
   }
   def main(args: Array[String]): Unit = {
     val exitCode = main0(

--- a/sjsonnet/src/sjsonnet/Error.scala
+++ b/sjsonnet/src/sjsonnet/Error.scala
@@ -2,6 +2,8 @@ package sjsonnet
 
 import fastparse.IndexedParserInput
 
+import scala.util.control.NonFatal
+
 /**
   * An exception that can keep track of the Sjsonnet call-stack while it is
   * propagating upwards. This helps provide good error messages with line
@@ -43,7 +45,7 @@ object Error {
     case e: Error.Delegate =>
       throw new Error(e.msg, Nil, None)
         .addFrame(fileScope.currentFile, evaluator.wd, offset)
-    case e: Throwable =>
+    case NonFatal(e) =>
       throw new Error("Internal Error", Nil, Some(e))
         .addFrame(fileScope.currentFile, evaluator.wd, offset)
   }
@@ -53,7 +55,7 @@ object Error {
     case e: Error.Delegate =>
       throw new Error(e.msg, Nil, None)
         .addFrame(fileScope.currentFile, evaluator.wd, offset)
-    case e: Throwable =>
+    case NonFatal(e) =>
       throw new Error("Internal Error", Nil, Some(e))
         .addFrame(fileScope.currentFile, evaluator.wd, offset)
   }

--- a/sjsonnet/src/sjsonnet/Interpreter.scala
+++ b/sjsonnet/src/sjsonnet/Interpreter.scala
@@ -5,6 +5,8 @@ import java.io.{PrintWriter, StringWriter}
 import fastparse.Parsed
 import sjsonnet.Expr.Params
 
+import scala.util.control.NonFatal
+
 /**
   * Wraps all the machinery of evaluating Jsonnet source code, from parsing to
   * evaluation to materialization, into a convenient wrapper class.
@@ -47,7 +49,7 @@ class Interpreter(parseCache: collection.mutable.Map[String, fastparse.Parsed[(E
             new FileScope(path, nameIndices)
           )
         )
-        catch{case e: Throwable =>
+        catch{case NonFatal(e) =>
           val s = new StringWriter()
           val p = new PrintWriter(s)
           e.printStackTrace(p)
@@ -68,7 +70,7 @@ class Interpreter(parseCache: collection.mutable.Map[String, fastparse.Parsed[(E
         try Right(Materializer.apply0(res, visitor, storePos = storePos)(evaluator))
         catch{
           case Error.Delegate(msg) => Left(msg)
-          case e: Throwable =>
+          case NonFatal(e) =>
             val s = new StringWriter()
             val p = new PrintWriter(s)
             e.printStackTrace(p)

--- a/sjsonnet/test/src-jvm/sjsonnet/ErrorTestsJvmOnly.scala
+++ b/sjsonnet/test/src-jvm/sjsonnet/ErrorTestsJvmOnly.scala
@@ -2,7 +2,24 @@ package sjsonnet
 
 import utest._
 
-object ErrorTestsJvmOnly extends TestSuite with ErrorTestsBase{
+object ErrorTestsJvmOnly extends TestSuite {
+  val testSuiteRoot = os.pwd / "sjsonnet" / "test" / "resources" / "test_suite"
+  def eval(p: os.Path) = {
+    val interp = new Interpreter(
+      sjsonnet.SjsonnetMain.createParseCache(),
+      Map(),
+      Map(),
+      OsPath(os.pwd),
+      importer = sjsonnet.SjsonnetMain.resolveImport(Array.empty[Path]),
+    )
+    interp.interpret(os.read(p), OsPath(p))
+  }
+  def check(expected: String)(implicit tp: utest.framework.TestPath) = {
+    val res = eval(testSuiteRoot / s"error.${tp.value.mkString(".")}.jsonnet")
+
+    assert(res == Left(expected))
+  }
+
   val tests = Tests{
     test("array_recursive_manifest") - check(
       """Stackoverflow while materializing, possibly due to recursive value""".stripMargin


### PR DESCRIPTION
Catching fatal exceptions causes problems when Sjsonnet is run as a persistent worker in Bazel. When a fatal error like an OutOfMemoryError occurs, we want the process to die so it can be restarted instead of keeping a broken version around.