### PR TITLE
remove synchronized from format string

### DIFF
--- a/sjsonnet/src/sjsonnet/Format.scala
+++ b/sjsonnet/src/sjsonnet/Format.scala
@@ -78,7 +78,7 @@ object Format{
   def format(s: String,
              values0: Val,
              offset: Int)
-            (implicit fileScope: FileScope, evaluator: EvalScope): String = synchronized{
+            (implicit fileScope: FileScope, evaluator: EvalScope): String = {
     val values = values0 match{
       case x: Val.Arr => x
       case x: Val.Obj => x


### PR DESCRIPTION
To improve the performance of sjsonnet's `format`, we can remove the synchronized keyword. 

History:
The synchronized keyword was added in 2018 https://github.com/databricks/sjsonnet/blob/2272e2de8b844085ff20d37807e21e5be09e7dca/sjsonnet/src/sjsonnet/Format.scala#L31. It was seemingly added to avoid potential thread issues because the `intp` variable (Python Interpreter) was not thread safe.

In the current iteration of the function, format doesn't seem to be using any global mutable objects. 

Testing: 
`./mill "sjsonnet[2.13.4].jvm.test.testLocal"` ran successfully.

