### PR TITLE
Sjsonnet performance improvements

### DIFF
--- a/bench/src/main/scala/sjsonnet/MainBenchmark.scala
+++ b/bench/src/main/scala/sjsonnet/MainBenchmark.scala
@@ -9,10 +9,10 @@ import org.openjdk.jmh.infra._
 import scala.collection.mutable.ArrayBuffer
 
 @BenchmarkMode(Array(Mode.AverageTime))
-@Fork(2)
+@Fork(4)
 @Threads(1)
-@Warmup(iterations = 10)
-@Measurement(iterations = 10)
+@Warmup(iterations = 30)
+@Measurement(iterations = 40)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 class MainBenchmark {

--- a/bench/src/main/scala/sjsonnet/MainBenchmark.scala
+++ b/bench/src/main/scala/sjsonnet/MainBenchmark.scala
@@ -1,0 +1,44 @@
+package sjsonnet
+
+import java.io.{OutputStream, PrintStream}
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra._
+
+import scala.collection.mutable.ArrayBuffer
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(2)
+@Threads(1)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+class MainBenchmark {
+
+  val mainArgs = Array[String](
+    "../../universe2/rulemanager/deploy/rulemanager.jsonnet",
+    "-J", "../../universe2",
+    "-J", "../../universe2/mt-shards/dev/az-westus-c2",
+  )
+
+  val dummyOut = new PrintStream(new OutputStream {
+    def write(b: Int): Unit = ()
+    override def write(b: Array[Byte]): Unit = ()
+    override def write(b: Array[Byte], off: Int, len: Int): Unit = ()
+  })
+
+  @Benchmark
+  def main(bh: Blackhole): Unit = {
+    bh.consume(SjsonnetMain.main0(
+      mainArgs,
+      collection.mutable.Map.empty,
+      System.in,
+      dummyOut,
+      System.err,
+      os.pwd,
+      None
+    ))
+  }
+}

--- a/bench/src/main/scala/sjsonnet/MainBenchmark.scala
+++ b/bench/src/main/scala/sjsonnet/MainBenchmark.scala
@@ -33,7 +33,7 @@ class MainBenchmark {
   def main(bh: Blackhole): Unit = {
     bh.consume(SjsonnetMain.main0(
       mainArgs,
-      collection.mutable.Map.empty,
+      collection.mutable.HashMap.empty,
       System.in,
       dummyOut,
       System.err,

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ cancelable in Global := true
 
 lazy val main = (project in file("sjsonnet"))
   .settings(
-    scalacOptions ++= Seq("-opt:l:inline", "-opt-inline-from:sjsonnet.**"),
+    scalacOptions in Compile ++= Seq("-opt:l:inline", "-opt-inline-from:sjsonnet.**"),
     fork in Test := true,
     baseDirectory in Test := (baseDirectory in ThisBuild).value,
     libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,54 @@
+val sjsonnetVersion = "0.3.3"
+
+scalaVersion in Global := "2.13.4"
+
+cancelable in Global := true
+
+lazy val main = (project in file("sjsonnet"))
+  .settings(
+    scalacOptions ++= Seq("-opt:l:inline", "-opt-inline-from:sjsonnet.**"),
+    fork in Test := true,
+    baseDirectory in Test := (baseDirectory in ThisBuild).value,
+    libraryDependencies ++= Seq(
+      "com.lihaoyi" %% "fastparse" % "2.3.1",
+      "com.lihaoyi" %% "pprint" % "0.6.1",
+      "com.lihaoyi" %% "ujson" % "1.3.7",
+      "com.lihaoyi" %% "scalatags" % "0.9.3",
+      "com.lihaoyi" %% "os-lib" % "0.7.2",
+      "com.lihaoyi" %% "mainargs" % "0.2.0",
+      "org.scala-lang.modules" %% "scala-collection-compat" % "2.4.0",
+      "org.tukaani" % "xz" % "1.8",
+    ),
+    libraryDependencies ++= Seq(
+      "com.lihaoyi" %% "utest" % "0.7.7",
+    ).map(_ % "test"),
+    testFrameworks += new TestFramework("utest.runner.Framework"),
+    (unmanagedSourceDirectories in Compile) := Seq(
+      baseDirectory.value / "src",
+      baseDirectory.value / "src-jvm",
+      baseDirectory.value / "src-jvm-native",
+    ),
+    (unmanagedSourceDirectories in Test) := Seq(
+      baseDirectory.value / "test/src",
+      baseDirectory.value / "test/src-jvm",
+    ),
+    (unmanagedResourceDirectories in Test) := Seq(
+      baseDirectory.value / "test/resources",
+    ),
+    (sourceGenerators in Compile) += Def.task {
+      val file = (Compile / sourceManaged).value / "jsonnet" / "Version.scala"
+      IO.write(file,
+        s"""package sjsonnet
+           |object Version{
+           |  val version = "${sjsonnetVersion}"
+           |}
+           |""".stripMargin)
+      Seq(file)
+    }.taskValue
+  )
+
+lazy val bench = (project in file("bench"))
+  .dependsOn(main)
+  .enablePlugins(JmhPlugin)
+  .settings(
+  )

--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,7 @@ lazy val main = (project in file("sjsonnet"))
     (unmanagedSourceDirectories in Test) := Seq(
       baseDirectory.value / "test/src",
       baseDirectory.value / "test/src-jvm",
+      baseDirectory.value / "test/src-jvm-native",
     ),
     (unmanagedResourceDirectories in Test) := Seq(
       baseDirectory.value / "test/resources",

--- a/build.sc
+++ b/build.sc
@@ -107,6 +107,7 @@ class SjsonnetModule(val crossScalaVersion: String) extends Module {
     def ivyDeps = super.ivyDeps() ++ Agg(
       ivy"org.tukaani:xz::1.8"
     )
+    def scalacOptions = Seq("-opt:l:inline", "-opt-inline-from:sjsonnet.**")
     //def compileIvyDeps = Agg( ivy"com.lihaoyi::acyclic:0.2.0")
     //def scalacOptions = Seq("-P:acyclic:force")
     //def scalacPluginIvyDeps = Agg( ivy"com.lihaoyi::acyclic:0.2.0")

--- a/build.sc
+++ b/build.sc
@@ -107,13 +107,13 @@ class SjsonnetModule(val crossScalaVersion: String) extends Module {
     def ivyDeps = super.ivyDeps() ++ Agg(
       ivy"org.tukaani:xz::1.8"
     )
-    def compileIvyDeps = Agg( ivy"com.lihaoyi::acyclic:0.2.0")
-    def scalacOptions = Seq("-P:acyclic:force")
-    def scalacPluginIvyDeps = Agg( ivy"com.lihaoyi::acyclic:0.2.0")
+    //def compileIvyDeps = Agg( ivy"com.lihaoyi::acyclic:0.2.0")
+    //def scalacOptions = Seq("-P:acyclic:force")
+    //def scalacPluginIvyDeps = Agg( ivy"com.lihaoyi::acyclic:0.2.0")
     object test extends Tests with CrossTests{
-      def compileIvyDeps = Agg( ivy"com.lihaoyi::acyclic:0.2.0")
-      def scalacOptions = Seq("-P:acyclic:force")
-      def scalacPluginIvyDeps = Agg( ivy"com.lihaoyi::acyclic:0.2.0")
+      //def compileIvyDeps = Agg( ivy"com.lihaoyi::acyclic:0.2.0")
+      //def scalacOptions = Seq("-P:acyclic:force")
+      //def scalacPluginIvyDeps = Agg( ivy"com.lihaoyi::acyclic:0.2.0")
       def forkOptions = Seq("-Xss100m")
       def sources = T.sources(
         millSourcePath / "src",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.3.10

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,2 @@
+//addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.7")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.3")

--- a/sjsonnet/server/src/sjsonnet/SjsonnetServerMain.scala
+++ b/sjsonnet/server/src/sjsonnet/SjsonnetServerMain.scala
@@ -24,7 +24,7 @@ trait SjsonnetServerMain[T]{
             wd: os.Path): (Boolean, Option[T])
 }
 
-object SjsonnetServerMain extends SjsonnetServerMain[collection.mutable.HashMap[String, fastparse.Parsed[(Expr, Map[String, Int])]]]{
+object SjsonnetServerMain extends SjsonnetServerMain[collection.mutable.HashMap[String, fastparse.Parsed[(Expr, FileScope)]]]{
   def main(args0: Array[String]): Unit = {
     // Disable SIGINT interrupt signal in the Mill server.
     //
@@ -45,7 +45,7 @@ object SjsonnetServerMain extends SjsonnetServerMain[collection.mutable.HashMap[
     ).run()
   }
   def main0(args: Array[String],
-            stateCache: Option[collection.mutable.HashMap[String, fastparse.Parsed[(Expr, Map[String, Int])]]],
+            stateCache: Option[collection.mutable.HashMap[String, fastparse.Parsed[(Expr, FileScope)]]],
             mainInteractive: Boolean,
             stdin: InputStream,
             stdout: PrintStream,
@@ -55,7 +55,7 @@ object SjsonnetServerMain extends SjsonnetServerMain[collection.mutable.HashMap[
             wd: os.Path) = {
 
     val stateCache2 = stateCache.getOrElse{
-      val p = collection.mutable.HashMap[String, fastparse.Parsed[(Expr, Map[String, Int])]]()
+      val p = collection.mutable.HashMap[String, fastparse.Parsed[(Expr, FileScope)]]()
       this.stateCache = Some(p)
       p
     }

--- a/sjsonnet/server/src/sjsonnet/SjsonnetServerMain.scala
+++ b/sjsonnet/server/src/sjsonnet/SjsonnetServerMain.scala
@@ -24,7 +24,7 @@ trait SjsonnetServerMain[T]{
             wd: os.Path): (Boolean, Option[T])
 }
 
-object SjsonnetServerMain extends SjsonnetServerMain[collection.mutable.Map[String, fastparse.Parsed[(Expr, Map[String, Int])]]]{
+object SjsonnetServerMain extends SjsonnetServerMain[collection.mutable.HashMap[String, fastparse.Parsed[(Expr, Map[String, Int])]]]{
   def main(args0: Array[String]): Unit = {
     // Disable SIGINT interrupt signal in the Mill server.
     //
@@ -45,7 +45,7 @@ object SjsonnetServerMain extends SjsonnetServerMain[collection.mutable.Map[Stri
     ).run()
   }
   def main0(args: Array[String],
-            stateCache: Option[collection.mutable.Map[String, fastparse.Parsed[(Expr, Map[String, Int])]]],
+            stateCache: Option[collection.mutable.HashMap[String, fastparse.Parsed[(Expr, Map[String, Int])]]],
             mainInteractive: Boolean,
             stdin: InputStream,
             stdout: PrintStream,
@@ -55,7 +55,7 @@ object SjsonnetServerMain extends SjsonnetServerMain[collection.mutable.Map[Stri
             wd: os.Path) = {
 
     val stateCache2 = stateCache.getOrElse{
-      val p = collection.mutable.Map[String, fastparse.Parsed[(Expr, Map[String, Int])]]()
+      val p = collection.mutable.HashMap[String, fastparse.Parsed[(Expr, Map[String, Int])]]()
       this.stateCache = Some(p)
       p
     }

--- a/sjsonnet/server/src/sjsonnet/SjsonnetServerMain.scala
+++ b/sjsonnet/server/src/sjsonnet/SjsonnetServerMain.scala
@@ -24,7 +24,7 @@ trait SjsonnetServerMain[T]{
             wd: os.Path): (Boolean, Option[T])
 }
 
-object SjsonnetServerMain extends SjsonnetServerMain[collection.mutable.HashMap[String, fastparse.Parsed[(Expr, FileScope)]]]{
+object SjsonnetServerMain extends SjsonnetServerMain[collection.mutable.HashMap[(Path, String), fastparse.Parsed[(Expr, FileScope)]]]{
   def main(args0: Array[String]): Unit = {
     // Disable SIGINT interrupt signal in the Mill server.
     //
@@ -45,7 +45,7 @@ object SjsonnetServerMain extends SjsonnetServerMain[collection.mutable.HashMap[
     ).run()
   }
   def main0(args: Array[String],
-            stateCache: Option[collection.mutable.HashMap[String, fastparse.Parsed[(Expr, FileScope)]]],
+            stateCache: Option[collection.mutable.HashMap[(Path, String), fastparse.Parsed[(Expr, FileScope)]]],
             mainInteractive: Boolean,
             stdin: InputStream,
             stdout: PrintStream,
@@ -55,7 +55,7 @@ object SjsonnetServerMain extends SjsonnetServerMain[collection.mutable.HashMap[
             wd: os.Path) = {
 
     val stateCache2 = stateCache.getOrElse{
-      val p = collection.mutable.HashMap[String, fastparse.Parsed[(Expr, FileScope)]]()
+      val p = collection.mutable.HashMap[(Path, String), fastparse.Parsed[(Expr, FileScope)]]()
       this.stateCache = Some(p)
       p
     }

--- a/sjsonnet/src-js/java/util/BitSet.scala
+++ b/sjsonnet/src-js/java/util/BitSet.scala
@@ -1,0 +1,18 @@
+package java.util
+
+import java.util.stream.IntStream
+
+import scala.collection.mutable.{BitSet => SBitSet}
+import scala.collection.JavaConverters._
+
+class BitSet(_initialSizeDummy: Int) extends java.lang.Cloneable {
+  val bs: SBitSet = SBitSet.empty
+  def isEmpty: Boolean = bs.isEmpty
+  override def clone(): AnyRef = super.clone()
+  def cardinality(): Int = bs.size
+  def stream(): IntStream = IntStream.of(bs.toArray: _*)
+  def get(i: Int): Boolean = bs.apply(i)
+  def set(i: Int): Unit = bs += i
+  def clear(): Unit = bs.clear()
+  def andNot(other: BitSet): Unit = bs.&~=(other.bs)
+}

--- a/sjsonnet/src-js/sjsonnet/BitSetUtils.scala
+++ b/sjsonnet/src-js/sjsonnet/BitSetUtils.scala
@@ -1,0 +1,7 @@
+package sjsonnet
+
+import java.util.BitSet
+
+object BitSetUtils {
+  def iterator(bs: BitSet): Iterator[Int] = bs.bs.iterator
+}

--- a/sjsonnet/src-js/sjsonnet/SjsonnetMain.scala
+++ b/sjsonnet/src-js/sjsonnet/SjsonnetMain.scala
@@ -6,7 +6,7 @@ import scala.scalajs.js.annotation.{JSExport, JSExportTopLevel}
 
 @JSExportTopLevel("SjsonnetMain")
 object SjsonnetMain {
-  def createParseCache() = collection.mutable.HashMap[String, fastparse.Parsed[(Expr, FileScope)]]()
+  def createParseCache() = collection.mutable.HashMap[(Path, String), fastparse.Parsed[(Expr, FileScope)]]()
   @JSExport
   def interpret(text: String,
                 extVars: js.Any,

--- a/sjsonnet/src-js/sjsonnet/SjsonnetMain.scala
+++ b/sjsonnet/src-js/sjsonnet/SjsonnetMain.scala
@@ -6,7 +6,7 @@ import scala.scalajs.js.annotation.{JSExport, JSExportTopLevel}
 
 @JSExportTopLevel("SjsonnetMain")
 object SjsonnetMain {
-  def createParseCache() = collection.mutable.Map[String, fastparse.Parsed[(Expr, FileScope)]]()
+  def createParseCache() = collection.mutable.HashMap[String, fastparse.Parsed[(Expr, FileScope)]]()
   @JSExport
   def interpret(text: String,
                 extVars: js.Any,
@@ -15,7 +15,7 @@ object SjsonnetMain {
                 importer: js.Function2[String, String, js.Array[String]],
                 preserveOrder: Boolean = false): js.Any = {
     val interp = new Interpreter(
-      mutable.Map.empty,
+      mutable.HashMap.empty,
       ujson.WebJson.transform(extVars, ujson.Value).obj.toMap,
       ujson.WebJson.transform(tlaVars, ujson.Value).obj.toMap,
       JsVirtualPath(wd0),
@@ -51,7 +51,7 @@ case class JsVirtualPath(path: String) extends Path{
 
   def /(s: String): Path = JsVirtualPath(path + "/" + s)
 
-  def renderOffsetStr(offset: Int, loadedFileContents: mutable.Map[Path, Array[Int]]): String = {
+  def renderOffsetStr(offset: Int, loadedFileContents: mutable.HashMap[Path, Array[Int]]): String = {
     path + ":" + offset
   }
 }

--- a/sjsonnet/src-js/sjsonnet/SjsonnetMain.scala
+++ b/sjsonnet/src-js/sjsonnet/SjsonnetMain.scala
@@ -6,7 +6,7 @@ import scala.scalajs.js.annotation.{JSExport, JSExportTopLevel}
 
 @JSExportTopLevel("SjsonnetMain")
 object SjsonnetMain {
-  def createParseCache() = collection.mutable.Map[String, fastparse.Parsed[(Expr, Map[String, Int])]]()
+  def createParseCache() = collection.mutable.Map[String, fastparse.Parsed[(Expr, FileScope)]]()
   @JSExport
   def interpret(text: String,
                 extVars: js.Any,

--- a/sjsonnet/src-jvm-native/sjsonnet/OsPath.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/OsPath.scala
@@ -10,6 +10,12 @@ case class OsPath(p: os.Path) extends Path{
   def last: String = p.last
   def /(s: String): Path = OsPath(p / s)
 
+  override def equals(other: Any): Boolean = other match {
+    case OsPath(p2) => p == p2
+    case _ => false
+  }
+
+  override def hashCode: Int = p.hashCode()
 
   def renderOffsetStr(offset: Int, loadedFileContents: mutable.HashMap[Path, Array[Int]]): String = {
     val offsetStr =

--- a/sjsonnet/src-jvm-native/sjsonnet/OsPath.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/OsPath.scala
@@ -11,7 +11,7 @@ case class OsPath(p: os.Path) extends Path{
   def /(s: String): Path = OsPath(p / s)
 
 
-  def renderOffsetStr(offset: Int, loadedFileContents: mutable.Map[Path, Array[Int]]): String = {
+  def renderOffsetStr(offset: Int, loadedFileContents: mutable.HashMap[Path, Array[Int]]): String = {
     val offsetStr =
       if (p.toString.contains("(materialize)")) ""
       else {

--- a/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMain.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMain.scala
@@ -10,7 +10,7 @@ import scala.util.Try
 import scala.util.control.NonFatal
 
 object SjsonnetMain {
-  def createParseCache() = collection.mutable.Map[String, fastparse.Parsed[(Expr, FileScope)]]()
+  def createParseCache() = collection.mutable.HashMap[String, fastparse.Parsed[(Expr, FileScope)]]()
   def resolveImport(searchRoots0: Seq[Path], allowedInputs: Option[Set[os.Path]] = None)(wd: Path, str: String) = {
     (wd +: searchRoots0)
       .flatMap(base => os.FilePath(str) match {
@@ -32,7 +32,7 @@ object SjsonnetMain {
           case Array(s, _*) if s == "-i" || s == "--interactive" => args.tail
           case _ => args
         },
-        collection.mutable.Map.empty,
+        collection.mutable.HashMap.empty,
         System.in,
         System.out,
         System.err,
@@ -44,7 +44,7 @@ object SjsonnetMain {
   }
 
   def main0(args: Array[String],
-            parseCache: collection.mutable.Map[String, fastparse.Parsed[(Expr, FileScope)]],
+            parseCache: collection.mutable.HashMap[String, fastparse.Parsed[(Expr, FileScope)]],
             stdin: InputStream,
             stdout: PrintStream,
             stderr: PrintStream,
@@ -127,7 +127,7 @@ object SjsonnetMain {
 
   def mainConfigured(file: String,
                      config: Config,
-                     parseCache: collection.mutable.Map[String, fastparse.Parsed[(Expr, FileScope)]],
+                     parseCache: collection.mutable.HashMap[String, fastparse.Parsed[(Expr, FileScope)]],
                      wd: os.Path,
                      allowedInputs: Option[Set[os.Path]] = None,
                      importer: Option[(Path, String) => Option[os.Path]] = None): Either[String, String] = {

--- a/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMain.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMain.scala
@@ -25,18 +25,21 @@ object SjsonnetMain {
       .flatMap(p => try Some((OsPath(p), os.read(p))) catch{case NonFatal(_) => None})
   }
   def main(args: Array[String]): Unit = {
-    val exitCode = main0(
-      args match {
-        case Array(s, _*) if s == "-i" || s == "--interactive" => args.tail
-        case _ => args
-      },
-      collection.mutable.Map.empty,
-      System.in,
-      System.out,
-      System.err,
-      os.pwd,
-      None
-    )
+    var exitCode = 1
+    (0 to 10).foreach { _ =>
+      exitCode = main0(
+        args match {
+          case Array(s, _*) if s == "-i" || s == "--interactive" => args.tail
+          case _ => args
+        },
+        collection.mutable.Map.empty,
+        System.in,
+        System.out,
+        System.err,
+        os.pwd,
+        None
+      )
+    }
     System.exit(exitCode)
   }
 

--- a/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMain.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMain.scala
@@ -10,7 +10,7 @@ import scala.util.Try
 import scala.util.control.NonFatal
 
 object SjsonnetMain {
-  def createParseCache() = collection.mutable.HashMap[String, fastparse.Parsed[(Expr, FileScope)]]()
+  def createParseCache() = collection.mutable.HashMap[(Path, String), fastparse.Parsed[(Expr, FileScope)]]()
   def resolveImport(searchRoots0: Seq[Path], allowedInputs: Option[Set[os.Path]] = None)(wd: Path, str: String) = {
     (wd +: searchRoots0)
       .flatMap(base => os.FilePath(str) match {
@@ -41,7 +41,7 @@ object SjsonnetMain {
   }
 
   def main0(args: Array[String],
-            parseCache: collection.mutable.HashMap[String, fastparse.Parsed[(Expr, FileScope)]],
+            parseCache: collection.mutable.HashMap[(Path, String), fastparse.Parsed[(Expr, FileScope)]],
             stdin: InputStream,
             stdout: PrintStream,
             stderr: PrintStream,
@@ -124,7 +124,7 @@ object SjsonnetMain {
 
   def mainConfigured(file: String,
                      config: Config,
-                     parseCache: collection.mutable.HashMap[String, fastparse.Parsed[(Expr, FileScope)]],
+                     parseCache: collection.mutable.HashMap[(Path, String), fastparse.Parsed[(Expr, FileScope)]],
                      wd: os.Path,
                      allowedInputs: Option[Set[os.Path]] = None,
                      importer: Option[(Path, String) => Option[os.Path]] = None): Either[String, String] = {

--- a/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMain.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMain.scala
@@ -25,21 +25,18 @@ object SjsonnetMain {
       .flatMap(p => try Some((OsPath(p), os.read(p))) catch{case NonFatal(_) => None})
   }
   def main(args: Array[String]): Unit = {
-    var exitCode = 1
-    (0 to 10).foreach { _ =>
-      exitCode = main0(
-        args match {
-          case Array(s, _*) if s == "-i" || s == "--interactive" => args.tail
-          case _ => args
-        },
-        collection.mutable.HashMap.empty,
-        System.in,
-        System.out,
-        System.err,
-        os.pwd,
-        None
-      )
-    }
+    var exitCode = main0(
+      args match {
+        case Array(s, _*) if s == "-i" || s == "--interactive" => args.tail
+        case _ => args
+      },
+      collection.mutable.HashMap.empty,
+      System.in,
+      System.out,
+      System.err,
+      os.pwd,
+      None
+    )
     System.exit(exitCode)
   }
 

--- a/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMain.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMain.scala
@@ -10,7 +10,7 @@ import scala.util.Try
 import scala.util.control.NonFatal
 
 object SjsonnetMain {
-  def createParseCache() = collection.mutable.Map[String, fastparse.Parsed[(Expr, Map[String, Int])]]()
+  def createParseCache() = collection.mutable.Map[String, fastparse.Parsed[(Expr, FileScope)]]()
   def resolveImport(searchRoots0: Seq[Path], allowedInputs: Option[Set[os.Path]] = None)(wd: Path, str: String) = {
     (wd +: searchRoots0)
       .flatMap(base => os.FilePath(str) match {
@@ -44,7 +44,7 @@ object SjsonnetMain {
   }
 
   def main0(args: Array[String],
-            parseCache: collection.mutable.Map[String, fastparse.Parsed[(Expr, Map[String, Int])]],
+            parseCache: collection.mutable.Map[String, fastparse.Parsed[(Expr, FileScope)]],
             stdin: InputStream,
             stdout: PrintStream,
             stderr: PrintStream,
@@ -127,7 +127,7 @@ object SjsonnetMain {
 
   def mainConfigured(file: String,
                      config: Config,
-                     parseCache: collection.mutable.Map[String, fastparse.Parsed[(Expr, Map[String, Int])]],
+                     parseCache: collection.mutable.Map[String, fastparse.Parsed[(Expr, FileScope)]],
                      wd: os.Path,
                      allowedInputs: Option[Set[os.Path]] = None,
                      importer: Option[(Path, String) => Option[os.Path]] = None): Either[String, String] = {

--- a/sjsonnet/src-jvm/sjsonnet/BitSetUtils.scala
+++ b/sjsonnet/src-jvm/sjsonnet/BitSetUtils.scala
@@ -1,0 +1,17 @@
+package sjsonnet
+
+import java.util.BitSet
+
+import scala.collection.mutable.ArrayBuffer
+
+object BitSetUtils {
+  def iterator(bs: BitSet): Iterator[Int] = {
+    val b = ArrayBuffer.empty[Int]
+    var i = bs.nextSetBit(0)
+    while(i  > 0) {
+      b += i
+      i = bs.nextSetBit(i+1)
+    }
+    b.iterator
+  }
+}

--- a/sjsonnet/src-native/java/util/BitSet.scala
+++ b/sjsonnet/src-native/java/util/BitSet.scala
@@ -1,0 +1,18 @@
+package java.util
+
+import java.util.stream.IntStream
+
+import scala.collection.mutable.{BitSet => SBitSet}
+import scala.collection.JavaConverters._
+
+class BitSet(_initialSizeDummy: Int) extends java.lang.Cloneable {
+  val bs: SBitSet = SBitSet.empty
+  def isEmpty: Boolean = bs.isEmpty
+  override def clone(): AnyRef = super.clone()
+  def cardinality(): Int = bs.size
+  def stream(): IntStream = IntStream.of(bs.toArray: _*)
+  def get(i: Int): Boolean = bs.apply(i)
+  def set(i: Int): Unit = bs += i
+  def clear(): Unit = bs.clear()
+  def andNot(other: BitSet): Unit = bs.&~=(other.bs)
+}

--- a/sjsonnet/src-native/sjsonnet/BitSetUtils.scala
+++ b/sjsonnet/src-native/sjsonnet/BitSetUtils.scala
@@ -1,0 +1,7 @@
+package sjsonnet
+
+import java.util.BitSet
+
+object BitSetUtils {
+  def iterator(bs: BitSet): Iterator[Int] = bs.bs.iterator
+}

--- a/sjsonnet/src/sjsonnet/Error.scala
+++ b/sjsonnet/src/sjsonnet/Error.scala
@@ -100,6 +100,8 @@ class FileScope(val currentFile: Path,
   // Only used for error messages, so in the common case
   // where nothing blows up this does not need to be allocated
   lazy val indexNames = nameIndices.map(_.swap)
+
+  lazy val currentFileLastPathElement = currentFile.last
 }
 
 trait EvalErrorScope {

--- a/sjsonnet/src/sjsonnet/Error.scala
+++ b/sjsonnet/src/sjsonnet/Error.scala
@@ -1,5 +1,9 @@
 package sjsonnet
 
+import java.util.BitSet
+
+import scala.collection.JavaConverters._
+
 import fastparse.IndexedParserInput
 
 import scala.util.control.NonFatal
@@ -64,15 +68,15 @@ object Error {
     throw Error(msg, Nil, None).addFrame(fileScope.currentFile, evaluator.wd, offset)
   }
 
-  def failIfNonEmpty(names: collection.BitSet,
+  def failIfNonEmpty(names: BitSet,
                      outerOffset: Int,
                      formatMsg: (String, String) => String,
                      // Allows the use of a custom file scope for computing the error message
                      // for details see: https://github.com/databricks/sjsonnet/issues/83
                      customFileScope: Option[FileScope] = None)
-                    (implicit fileScope: FileScope, eval: EvalErrorScope) = if (names.nonEmpty){
+                    (implicit fileScope: FileScope, eval: EvalErrorScope) = if (!names.isEmpty) {
     val plural = if (names.size > 1) "s" else ""
-    val nameSnippet = names.map(customFileScope.getOrElse(fileScope).indexNames).mkString(", ")
+    val nameSnippet = names.stream().iterator().asScala.map(i => customFileScope.getOrElse(fileScope).indexNames(i)).mkString(", ")
     fail(formatMsg(plural, nameSnippet), outerOffset)
   }
 

--- a/sjsonnet/src/sjsonnet/Error.scala
+++ b/sjsonnet/src/sjsonnet/Error.scala
@@ -2,8 +2,6 @@ package sjsonnet
 
 import java.util.BitSet
 
-import scala.collection.JavaConverters._
-
 import fastparse.IndexedParserInput
 
 import scala.util.control.NonFatal
@@ -76,7 +74,7 @@ object Error {
                      fileScope: FileScope)
                     (implicit eval: EvalErrorScope) = if (!names.isEmpty) {
     val plural = if (names.cardinality() > 1) "s" else ""
-    val nameSnippet = names.stream().iterator().asScala.map(i => fileScope.indexNames(i)).mkString(", ")
+    val nameSnippet = BitSetUtils.iterator(names).map(i => fileScope.indexNames(i)).mkString(", ")
     fail(formatMsg(plural, nameSnippet), outerPos)
   }
 

--- a/sjsonnet/src/sjsonnet/Error.scala
+++ b/sjsonnet/src/sjsonnet/Error.scala
@@ -89,21 +89,6 @@ object Error {
 
 }
 
-/**
-  * FileScope models the per-file context that is propagated throughout the
-  * evaluation of a single Jsonnet file. Contains the current file path, as
-  * well as the mapping of local variable names to local variable array indices
-  * which is shared throughout each file.
-  */
-class FileScope(val currentFile: Path,
-                val nameIndices: scala.collection.Map[String, Int]){
-                // Only used for error messages, so in the common case
-  // where nothing blows up this does not need to be allocated
-  lazy val indexNames = nameIndices.map(_.swap)
-
-  lazy val currentFileLastPathElement = currentFile.last
-}
-
 trait EvalErrorScope {
   def extVars: Map[String, ujson.Value]
   def loadCachedSource(p: Path): Option[String]

--- a/sjsonnet/src/sjsonnet/Error.scala
+++ b/sjsonnet/src/sjsonnet/Error.scala
@@ -75,7 +75,7 @@ object Error {
                      // for details see: https://github.com/databricks/sjsonnet/issues/83
                      customFileScope: Option[FileScope] = None)
                     (implicit fileScope: FileScope, eval: EvalErrorScope) = if (!names.isEmpty) {
-    val plural = if (names.size > 1) "s" else ""
+    val plural = if (names.cardinality() > 1) "s" else ""
     val nameSnippet = names.stream().iterator().asScala.map(i => customFileScope.getOrElse(fileScope).indexNames(i)).mkString(", ")
     fail(formatMsg(plural, nameSnippet), outerOffset)
   }

--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -84,7 +84,7 @@ class Evaluator(parseCache: collection.mutable.Map[String, fastparse.Parsed[(Exp
     case Function(pos, params, body) => visitMethod(body, params, pos)
     case IfElse(pos, cond, then0, else0) => visitIfElse(pos, cond, then0, else0)
     case Comp(pos, value, first, rest) =>
-      Val.Arr(pos, visitComp(first :: rest.toList, Seq(scope)).map(s => (() => visitExpr(value)(s, implicitly)): Val.Lazy))
+      Val.Arr(pos, visitComp(first :: rest.toList, Array(scope)).map(s => (() => visitExpr(value)(s, implicitly)): Val.Lazy))
     case ObjExtend(pos, value, ext) => {
       if(strict && isObjLiteral(value))
         Error.fail("Adjacent object literals not allowed in strict mode - Use '+' to concatenate objects", pos)
@@ -200,7 +200,7 @@ class Evaluator(parseCache: collection.mutable.Map[String, fastparse.Parsed[(Exp
           start.fold(0)(visitExpr(_).cast[Val.Num].value.toInt) until
             end.fold(a.length)(visitExpr(_).cast[Val.Num].value.toInt) by
             stride.fold(1)(visitExpr(_).cast[Val.Num].value.toInt)
-        Val.Arr(pos, range.dropWhile(_ < 0).takeWhile(_ < a.length).map(a))
+        Val.Arr(pos, range.dropWhile(_ < 0).takeWhile(_ < a.length).map(a).toArray)
       case Val.Str(_, s) =>
         val range =
           start.fold(0)(visitExpr(_).cast[Val.Num].value.toInt) until
@@ -487,7 +487,7 @@ class Evaluator(parseCache: collection.mutable.Map[String, fastparse.Parsed[(Exp
 
       lazy val newSelf: Val.Obj = {
         val builder = mutable.LinkedHashMap.newBuilder[String, Val.Obj.Member]
-        for(s <- visitComp(first :: rest.toList, Seq(compScope))){
+        for(s <- visitComp(first :: rest.toList, Array(compScope))){
           lazy val newScope: ValScope = s.extend(
             newBindings,
             newDollar = if(scope.dollar0 != null) scope.dollar0 else newSelf,
@@ -521,8 +521,8 @@ class Evaluator(parseCache: collection.mutable.Map[String, fastparse.Parsed[(Exp
       newSelf
   }
 
-  def visitComp(f: List[CompSpec], scopes: Seq[ValScope])
-               (implicit fileScope: FileScope): Seq[ValScope] = f match{
+  def visitComp(f: List[CompSpec], scopes: Array[ValScope])
+               (implicit fileScope: FileScope): Array[ValScope] = f match{
     case ForSpec(_, name, expr) :: rest =>
       visitComp(
         rest,

--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -550,15 +550,15 @@ class Evaluator(parseCache: collection.mutable.HashMap[String, fastparse.Parsed[
     case Nil => scopes
   }
 
-  def equal(x: Val, y: Val): Boolean = {
+  def equal(x: Val, y: Val): Boolean = (x eq y) || {
     def normalize(x: Val): Val = x match {
       case f: Val.Func => f.apply(Evaluator.emptyStringArray, Evaluator.emptyLazyArray, emptyMaterializeFileScopePos)
       case x => x
     }
     (normalize(x), normalize(y)) match {
-      case (Val.True(_), Val.True(_)) => true
-      case (Val.False(_), Val.False(_)) => true
-      case (Val.Null(_), Val.Null(_)) => true
+      case (Val.True(_), y) => y.isInstanceOf[Val.True]
+      case (Val.False(_), y) => y.isInstanceOf[Val.False]
+      case (Val.Null(_), y) => y.isInstanceOf[Val.Null]
       case (Val.Num(_, n1), Val.Num(_, n2)) => n1 == n2
       case (Val.Str(_, s1), Val.Str(_, s2)) => s1 == s2
       case (Val.Arr(_, xs), Val.Arr(_, ys)) =>
@@ -575,11 +575,10 @@ class Evaluator(parseCache: collection.mutable.HashMap[String, fastparse.Parsed[
         if(k1.length != k2.length) return false
         o1.triggerAllAsserts(o1)
         o2.triggerAllAsserts(o2)
-        val k2s = k2.toSet
         var i = 0
         while(i < k1.length) {
           val k = k1(i)
-          if(!k2s.contains(k)) return false
+          if(!o2.containsKey(k)) return false
           val v1 = o1.value(k, emptyMaterializeFileScopePos)
           val v2 = o2.value(k, emptyMaterializeFileScopePos)
           if(!equal(v1, v2)) return false

--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -406,13 +406,13 @@ class Evaluator(parseCache: collection.mutable.Map[String, fastparse.Parsed[(Exp
                    (implicit fileScope: FileScope): Array[(Int, (Val.Obj, Val.Obj) => Val.Lazy)] = {
     bindings.map{ b: Bind =>
       b.args match{
-        case None =>
+        case null =>
           (
             b.name,
             (self: Val.Obj, sup: Val.Obj) =>
               Val.Lazy(visitExpr(b.rhs)(scope(self, sup), implicitly))
           )
-        case Some(argSpec) =>
+        case argSpec =>
           (
             b.name,
             (self: Val.Obj, sup: Val.Obj) =>
@@ -463,12 +463,12 @@ class Evaluator(parseCache: collection.mutable.Map[String, fastparse.Parsed[(Exp
       lazy val newSelf: Val.Obj = {
         val builder = mutable.LinkedHashMap.newBuilder[String, Val.Obj.Member]
         value.foreach {
-          case Member.Field(offset, fieldName, plus, None, sep, rhs) =>
+          case Member.Field(offset, fieldName, plus, null, sep, rhs) =>
             visitFieldName(fieldName, offset).map(_ -> Val.Obj.Member(plus, sep, (self: Val.Obj, sup: Val.Obj, _, _) => {
               assertions(self)
               visitExpr(rhs)(makeNewScope(self, sup), implicitly)
             })).foreach(builder.+=)
-          case Member.Field(offset, fieldName, false, Some(argSpec), sep, rhs) =>
+          case Member.Field(offset, fieldName, false, argSpec, sep, rhs) =>
             visitFieldName(fieldName, offset).map(_ -> Val.Obj.Member(false, sep, (self: Val.Obj, sup: Val.Obj, _, _) => {
               assertions(self)
               visitMethod(rhs, argSpec, offset)(makeNewScope(self, sup), implicitly)

--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -464,7 +464,7 @@ class Evaluator(parseCache: collection.mutable.Map[String, fastparse.Parsed[(Exp
           case _: Member.AssertStmt => // do nothing
         }
 
-        new Val.Obj(pos, builder.result(), self => assertions(self), null)
+        new Val.Obj(pos, builder.result(), assertions, null)
       }
       newSelf
 
@@ -502,7 +502,7 @@ class Evaluator(parseCache: collection.mutable.Map[String, fastparse.Parsed[(Exp
             case Val.Null(_) => // do nothing
           }
         }
-        new Val.Obj(pos, builder.result(), _ => (), null)
+        new Val.Obj(pos, builder.result(), null, null)
       }
 
       newSelf

--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -43,7 +43,7 @@ class Evaluator(parseCache: collection.mutable.HashMap[String, fastparse.Parsed[
         if(scope.super0 == null) Val.False(pos)
         else {
           val key = visitExpr(lhs).cast[Val.Str]
-          Val.bool(pos, scope.super0.visibleKeys.containsKey(key.value))
+          Val.bool(pos, scope.super0.containsKey(key.value))
         }
 
       case BinaryOp(pos, lhs, Expr.BinaryOp.`&&`, rhs) =>
@@ -370,7 +370,7 @@ class Evaluator(parseCache: collection.mutable.HashMap[String, fastparse.Parsed[
 
       case (Val.Num(_, l), Expr.BinaryOp.`>>`, Val.Num(_, r)) => Val.Num(pos, l.toLong >> r.toLong)
 
-      case (Val.Str(_, l), Expr.BinaryOp.`in`, o: Val.Obj) => Val.bool(pos, o.visibleKeys.containsKey(l))
+      case (Val.Str(_, l), Expr.BinaryOp.`in`, o: Val.Obj) => Val.bool(pos, o.containsKey(l))
 
       case (Val.Num(_, l), Expr.BinaryOp.`&`, Val.Num(_, r)) => Val.Num(pos, l.toLong & r.toLong)
 
@@ -570,8 +570,8 @@ class Evaluator(parseCache: collection.mutable.HashMap[String, fastparse.Parsed[
         }
         true
       case (o1: Val.Obj, o2: Val.Obj) =>
-        val k1 = o1.getVisibleKeysNonHidden
-        val k2 = o2.getVisibleKeysNonHidden
+        val k1 = o1.visibleKeyNames
+        val k2 = o2.visibleKeyNames
         if(k1.length != k2.length) return false
         o1.triggerAllAsserts(o1)
         o2.triggerAllAsserts(o2)

--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -185,7 +185,6 @@ class Evaluator(parseCache: collection.mutable.HashMap[String, fastparse.Parsed[
 
     try lhs.cast[Val.Func].apply(
       argNames, arr,
-      pos.fileScope.currentFileLastPathElement,
       pos
     )
     catch Error.tryCatchWrap(pos)
@@ -394,7 +393,7 @@ class Evaluator(parseCache: collection.mutable.HashMap[String, fastparse.Parsed[
       outerPos,
       scope,
       params,
-      (s, _, _, fs, _) => visitExpr(rhs)(s),
+      (s, _, fs, _) => visitExpr(rhs)(s),
       (default, s, e) => visitExpr(default)(s)
     )
   }
@@ -550,7 +549,7 @@ class Evaluator(parseCache: collection.mutable.HashMap[String, fastparse.Parsed[
 
   def equal(x: Val, y: Val): Boolean = {
     def normalize(x: Val): Val = x match {
-      case f: Val.Func => f.apply(Evaluator.emptyStringArray, Evaluator.emptyLazyArray, "(memory)", emptyMaterializeFileScopePos)
+      case f: Val.Func => f.apply(Evaluator.emptyStringArray, Evaluator.emptyLazyArray, emptyMaterializeFileScopePos)
       case x => x
     }
     (normalize(x), normalize(y)) match {

--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -121,6 +121,7 @@ class Evaluator(parseCache: collection.mutable.HashMap[String, fastparse.Parsed[
         ext match {
           case ObjBody.MemberList(pos, binds, fields, asserts) => visitMemberList(pos, superPos, binds, fields, asserts, original)
           case ObjBody.ObjComp(pos, preLocals, key, value, postLocals, first, rest) => visitObjComp(superPos, preLocals, key, value, postLocals, first, rest, original)
+          case o: Val.Obj => o.addSuper(superPos, original)
         }
       }
     }
@@ -130,6 +131,7 @@ class Evaluator(parseCache: collection.mutable.HashMap[String, fastparse.Parsed[
     case _: ObjBody.MemberList => true
     case _: ObjBody.ObjComp => true
     case _: ObjExtend => true
+    case _: Val.Obj => true
     case _ => false
   }
 
@@ -479,7 +481,7 @@ class Evaluator(parseCache: collection.mutable.HashMap[String, fastparse.Parsed[
           builder.put(k, v)
         }
     }
-    new Val.Obj(objPos, builder, if(asserts != null) assertions else null, sup)
+    new Val.Obj(objPos, builder, false, if(asserts != null) assertions else null, sup)
   }
 
   def visitObjComp(objPos: Position, preLocals: Array[Bind], key: Expr, value: Expr, postLocals: Array[Bind], first: ForSpec, rest: List[CompSpec], sup: Val.Obj)(implicit scope: ValScope): Val.Obj = {
@@ -516,7 +518,7 @@ class Evaluator(parseCache: collection.mutable.HashMap[String, fastparse.Parsed[
           case Val.Null(_) => // do nothing
         }
       }
-      new Val.Obj(objPos, builder, null, sup)
+      new Val.Obj(objPos, builder, false, null, sup)
     }
 
     newSelf

--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -153,7 +153,7 @@ class Evaluator(parseCache: collection.mutable.Map[String, fastparse.Parsed[(Exp
     val lhs = visitExpr(value)
     try lhs.cast[Val.Func].apply(
       args.map { case (k, v) => (k, Val.Lazy(visitExpr(v))) },
-      fileScope.currentFile.last,
+      fileScope.currentFileLastPathElement,
       offset
     )
     catch Error.tryCatchWrap(offset)

--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -105,13 +105,8 @@ class Evaluator(parseCache: collection.mutable.Map[String, fastparse.Parsed[(Exp
 
   def visitId(pos: Position, value: Int)(implicit scope: ValScope): Val = {
     val ref = scope.bindings(value)
-      .getOrElse(
-        Error.fail(
-          "Unknown variable " + pos.fileScope.indexNames(value),
-          pos
-        )
-      )
-
+    if(ref == null)
+      Error.fail("Unknown variable " + pos.fileScope.indexNames(value), pos)
     try ref.force catch Error.tryCatchWrap(pos)
   }
 

--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -89,11 +89,15 @@ class Evaluator(parseCache: collection.mutable.HashMap[String, fastparse.Parsed[
         visitAssert(pos, value, msg, returned)
 
       case LocalExpr(pos, bindings, returned) =>
-        lazy val newScope: ValScope = {
-          val f = visitBindings(bindings, (self, sup) => newScope)
-          scope.extend(bindings, f)
-        }
-        visitExpr(returned)(newScope)
+        val s =
+          if(bindings == null) scope else {
+            lazy val newScope: ValScope = {
+              val f = visitBindings(bindings, (self, sup) => newScope)
+              scope.extend(bindings, f)
+            }
+            newScope
+          }
+        visitExpr(returned)(s)
 
       case Import(pos, value) => visitImport(pos, value)
       case ImportStr(pos, value) => visitImportStr(pos, value)

--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -34,7 +34,6 @@ class Evaluator(parseCache: collection.mutable.Map[String, fastparse.Parsed[(Exp
                (implicit scope: ValScope): Val = try {
     expr match {
       case lit: Val.Literal => lit
-      case Parened(_, inner) => visitExpr(inner)
       case Self(pos) =>
         val self = scope.self0
         if(self == null) Error.fail("Cannot use `self` outside an object", pos)

--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -45,7 +45,7 @@ class Evaluator(parseCache: collection.mutable.Map[String, fastparse.Parsed[(Exp
       if(scope.super0 == null) Val.False(pos)
       else {
         val key = visitExpr(lhs).cast[Val.Str]
-        Val.bool(pos, scope.super0.containsKey(key.value))
+        Val.bool(pos, scope.super0.visibleKeys.containsKey(key.value))
       }
 
     case $(pos) =>
@@ -113,14 +113,14 @@ class Evaluator(parseCache: collection.mutable.Map[String, fastparse.Parsed[(Exp
   def visitIfElse(pos: Position,
                   cond: Expr,
                   then: Expr,
-                  else0: Option[Expr])
+                  else0: Expr)
                  (implicit scope: ValScope): Val = {
     visitExpr(cond) match {
       case Val.True(_) => visitExpr(then)
       case Val.False(_) =>
-        else0 match{
-          case None => Val.Null(pos)
-          case Some(v) => visitExpr(v)
+        else0 match {
+          case null => Val.Null(pos)
+          case v => visitExpr(v)
         }
       case v => Error.fail("Need boolean, found " + v.prettyName, pos)
     }
@@ -358,7 +358,7 @@ class Evaluator(parseCache: collection.mutable.Map[String, fastparse.Parsed[(Exp
             }
             try Val.bool(pos, Materializer(l) != Materializer(r))
             catch Error.tryCatchWrap(pos)
-          case (Val.Str(_, l), Expr.BinaryOp.`in`, o: Val.Obj) => Val.bool(pos, o.containsKey(l))
+          case (Val.Str(_, l), Expr.BinaryOp.`in`, o: Val.Obj) => Val.bool(pos, o.visibleKeys.containsKey(l))
           case (Val.Num(_, l), Expr.BinaryOp.`&`, Val.Num(_, r)) => Val.Num(pos, l.toLong & r.toLong)
           case (Val.Num(_, l), Expr.BinaryOp.`^`, Val.Num(_, r)) => Val.Num(pos, l.toLong ^ r.toLong)
           case (Val.Num(_, l), Expr.BinaryOp.`|`, Val.Num(_, r)) => Val.Num(pos, l.toLong | r.toLong)

--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -151,8 +151,16 @@ class Evaluator(parseCache: collection.mutable.Map[String, fastparse.Parsed[(Exp
   private def visitApply(offset: Int, value: Expr, args: Seq[(Option[String], Expr)])
                         (implicit scope: ValScope, fileScope: FileScope) = {
     val lhs = visitExpr(value)
+    val arr = new Array[(Option[String], Val.Lazy)](args.size)
+    var idx = 0
+    while (idx < args.size) {
+      val (k, v) = args(idx)
+      arr(idx) = (k, Val.Lazy(visitExpr(v)))
+      idx += 1
+    }
+
     try lhs.cast[Val.Func].apply(
-      args.map { case (k, v) => (k, Val.Lazy(visitExpr(v))) },
+      arr,
       fileScope.currentFileLastPathElement,
       offset
     )

--- a/sjsonnet/src/sjsonnet/Expr.scala
+++ b/sjsonnet/src/sjsonnet/Expr.scala
@@ -11,21 +11,21 @@ import java.util.BitSet
   * integer offset into the file that is later used to provide error messages.
   */
 sealed trait Expr{
-  def offset: Int
+  def pos: Position
 }
 object Expr{
-  case class Null(offset: Int) extends Expr
-  case class True(offset: Int) extends Expr
-  case class False(offset: Int) extends Expr
-  case class Self(offset: Int) extends Expr
-  case class Super(offset: Int) extends Expr
-  case class $(offset: Int) extends Expr
+  case class Null(pos: Position) extends Expr
+  case class True(pos: Position) extends Expr
+  case class False(pos: Position) extends Expr
+  case class Self(pos: Position) extends Expr
+  case class Super(pos: Position) extends Expr
+  case class $(pos: Position) extends Expr
 
-  case class Str(offset: Int, value: String) extends Expr
-  case class Num(offset: Int, value: Double) extends Expr
-  case class Id(offset: Int, value: Int) extends Expr
-  case class Arr(offset: Int, value: Seq[Expr]) extends Expr
-  case class Obj(offset: Int, value: ObjBody) extends Expr
+  case class Str(pos: Position, value: String) extends Expr
+  case class Num(pos: Position, value: Double) extends Expr
+  case class Id(pos: Position, value: Int) extends Expr
+  case class Arr(pos: Position, value: Seq[Expr]) extends Expr
+  case class Obj(pos: Position, value: ObjBody) extends Expr
 
   sealed trait FieldName
 
@@ -43,7 +43,7 @@ object Expr{
       case object Hidden extends Visibility
       case object Unhide extends Visibility
     }
-    case class Field(offset: Int,
+    case class Field(pos: Position,
                      fieldName: FieldName,
                      plus: Boolean,
                      args: Option[Params],
@@ -54,7 +54,7 @@ object Expr{
   }
 
 
-  case class Parened(offset: Int, value: Expr) extends Expr
+  case class Parened(pos: Position, value: Expr) extends Expr
   //case class Params(args: IndexedSeq[(String, Option[Expr], Int)]){
   case class Params(names: Array[String], defaultExprs: Array[Expr], indices: Array[Int]){
     val argIndices: Map[String, Int] = (names, indices).zipped.toMap
@@ -79,7 +79,7 @@ object Expr{
   }
   case class Args(args: Seq[(Option[String], Expr)])
 
-  case class UnaryOp(offset: Int, op: UnaryOp.Op, value: Expr) extends Expr
+  case class UnaryOp(pos: Position, op: UnaryOp.Op, value: Expr) extends Expr
   object UnaryOp{
     sealed trait Op
     case object `+` extends Op
@@ -87,7 +87,7 @@ object Expr{
     case object `~` extends Op
     case object `!` extends Op
   }
-  case class BinaryOp(offset: Int, lhs: Expr, op: BinaryOp.Op, rhs: Expr) extends Expr
+  case class BinaryOp(pos: Position, lhs: Expr, op: BinaryOp.Op, rhs: Expr) extends Expr
   object BinaryOp{
     sealed trait Op
     case object `*` extends Op
@@ -110,30 +110,30 @@ object Expr{
     case object `&&` extends Op
     case object `||` extends Op
   }
-  case class AssertExpr(offset: Int, asserted: Member.AssertStmt, returned: Expr) extends Expr
-  case class LocalExpr(offset: Int, bindings: Seq[Bind], returned: Expr) extends Expr
+  case class AssertExpr(pos: Position, asserted: Member.AssertStmt, returned: Expr) extends Expr
+  case class LocalExpr(pos: Position, bindings: Seq[Bind], returned: Expr) extends Expr
 
-  case class Bind(offset: Int, name: Int, args: Option[Params], rhs: Expr)
-  case class Import(offset: Int, value: String) extends Expr
-  case class ImportStr(offset: Int, value: String) extends Expr
-  case class Error(offset: Int, value: Expr) extends Expr
-  case class Apply(offset: Int, value: Expr, argNames: Array[String], argExprs: Array[Expr]) extends Expr
-  case class Select(offset: Int, value: Expr, name: String) extends Expr
-  case class Lookup(offset: Int, value: Expr, index: Expr) extends Expr
-  case class Slice(offset: Int,
+  case class Bind(pos: Position, name: Int, args: Option[Params], rhs: Expr)
+  case class Import(pos: Position, value: String) extends Expr
+  case class ImportStr(pos: Position, value: String) extends Expr
+  case class Error(pos: Position, value: Expr) extends Expr
+  case class Apply(pos: Position, value: Expr, argNames: Array[String], argExprs: Array[Expr]) extends Expr
+  case class Select(pos: Position, value: Expr, name: String) extends Expr
+  case class Lookup(pos: Position, value: Expr, index: Expr) extends Expr
+  case class Slice(pos: Position,
                    value: Expr,
                    start: Option[Expr],
                    end: Option[Expr],
                    stride: Option[Expr]) extends Expr
-  case class Function(offset: Int, params: Params, body: Expr) extends Expr
-  case class IfElse(offset: Int, cond: Expr, then: Expr, `else`: Option[Expr]) extends Expr
+  case class Function(pos: Position, params: Params, body: Expr) extends Expr
+  case class IfElse(pos: Position, cond: Expr, then: Expr, `else`: Option[Expr]) extends Expr
 
   sealed trait CompSpec extends Expr
-  case class IfSpec(offset: Int, cond: Expr) extends CompSpec
-  case class ForSpec(offset: Int, name: Int, cond: Expr) extends CompSpec
+  case class IfSpec(pos: Position, cond: Expr) extends CompSpec
+  case class ForSpec(pos: Position, name: Int, cond: Expr) extends CompSpec
 
-  case class Comp(offset: Int, value: Expr, first: ForSpec, rest: Seq[CompSpec]) extends Expr
-  case class ObjExtend(offset: Int, base: Expr, ext: ObjBody) extends Expr
+  case class Comp(pos: Position, value: Expr, first: ForSpec, rest: Seq[CompSpec]) extends Expr
+  case class ObjExtend(pos: Position, base: Expr, ext: ObjBody) extends Expr
 
   sealed trait ObjBody
   object ObjBody{

--- a/sjsonnet/src/sjsonnet/Expr.scala
+++ b/sjsonnet/src/sjsonnet/Expr.scala
@@ -43,7 +43,9 @@ object Expr{
                      plus: Boolean,
                      args: Params,
                      sep: Visibility,
-                     rhs: Expr) extends Member
+                     rhs: Expr) extends Member {
+      def isStatic = fieldName.isInstanceOf[FieldName.Fixed] && !plus && args == null && sep == Visibility.Normal && rhs.isInstanceOf[Val.Literal]
+    }
     case class AssertStmt(value: Expr, msg: Expr) extends Member
   }
 
@@ -126,7 +128,7 @@ object Expr{
   case class Comp(pos: Position, value: Expr, first: ForSpec, rest: Array[CompSpec]) extends Expr
   case class ObjExtend(pos: Position, base: Expr, ext: ObjBody) extends Expr
 
-  sealed abstract class ObjBody extends Expr
+  trait ObjBody extends Expr
   object ObjBody{
     case class MemberList(pos: Position, binds: Array[Bind], fields: Array[Member.Field], asserts: Array[Member.AssertStmt]) extends ObjBody
     case class ObjComp(pos: Position,

--- a/sjsonnet/src/sjsonnet/Expr.scala
+++ b/sjsonnet/src/sjsonnet/Expr.scala
@@ -21,7 +21,6 @@ object Expr{
 
   case class Id(pos: Position, value: Int) extends Expr
   case class Arr(pos: Position, value: Array[Expr]) extends Expr
-  case class Obj(pos: Position, value: ObjBody) extends Expr
 
   sealed trait FieldName
 
@@ -127,10 +126,11 @@ object Expr{
   case class Comp(pos: Position, value: Expr, first: ForSpec, rest: Array[CompSpec]) extends Expr
   case class ObjExtend(pos: Position, base: Expr, ext: ObjBody) extends Expr
 
-  sealed trait ObjBody
+  sealed abstract class ObjBody extends Expr
   object ObjBody{
-    case class MemberList(binds: Array[Bind], fields: Array[Member.Field], asserts: Array[Member.AssertStmt]) extends ObjBody
-    case class ObjComp(preLocals: Array[Bind],
+    case class MemberList(pos: Position, binds: Array[Bind], fields: Array[Member.Field], asserts: Array[Member.AssertStmt]) extends ObjBody
+    case class ObjComp(pos: Position,
+                       preLocals: Array[Bind],
                        key: Expr,
                        value: Expr,
                        postLocals: Array[Bind],

--- a/sjsonnet/src/sjsonnet/Expr.scala
+++ b/sjsonnet/src/sjsonnet/Expr.scala
@@ -1,6 +1,7 @@
 package sjsonnet
 
-import scala.collection.{BitSet, mutable}
+import java.util.BitSet
+
 /**
   * [[Expr]]s are the parsed syntax trees of a Jsonnet program. They model the
   * program mostly as-written, except for resolving local variable names and
@@ -56,9 +57,19 @@ object Expr{
   case class Parened(offset: Int, value: Expr) extends Expr
   case class Params(args: IndexedSeq[(String, Option[Expr], Int)]){
     val argIndices: Map[String, Int] = args.map{case (k, d, i) => (k, i)}.toMap
-    val noDefaultIndices: BitSet = mutable.BitSet.empty ++ args.collect{case (_, None, i) => i}
+    val noDefaultIndices: BitSet = {
+      val b = new BitSet(args.size)
+      args.collect {
+        case (_, None, i) => b.set(i)
+      }
+      b
+    }
     val defaults: IndexedSeq[(Int, Expr)] = args.collect{case (_, Some(x), i) => (i, x)}
-    val allIndices: Set[Int] = args.map{case (_, _, i) => i}.toSet
+    val allIndices: BitSet = {
+      val b = new BitSet(args.size)
+      args.foreach { case (_, _, i) => b.set(i) }
+      b
+    }
   }
   case class Args(args: Seq[(Option[String], Expr)])
 

--- a/sjsonnet/src/sjsonnet/Expr.scala
+++ b/sjsonnet/src/sjsonnet/Expr.scala
@@ -50,7 +50,6 @@ object Expr{
   }
 
 
-  case class Parened(pos: Position, value: Expr) extends Expr
   case class Params(names: Array[String], defaultExprs: Array[Expr], indices: Array[Int]){
     val argIndices: Map[String, Int] = (names, indices).zipped.toMap
     val noDefaultIndices: BitSet = {

--- a/sjsonnet/src/sjsonnet/Expr.scala
+++ b/sjsonnet/src/sjsonnet/Expr.scala
@@ -55,7 +55,6 @@ object Expr{
 
 
   case class Parened(pos: Position, value: Expr) extends Expr
-  //case class Params(args: IndexedSeq[(String, Option[Expr], Int)]){
   case class Params(names: Array[String], defaultExprs: Array[Expr], indices: Array[Int]){
     val argIndices: Map[String, Int] = (names, indices).zipped.toMap
     val noDefaultIndices: BitSet = {
@@ -65,7 +64,6 @@ object Expr{
     }
     val defaultsOnlyIndices: Array[Int] = (defaultExprs, indices).zipped.collect { case (x, i) if x != null => i }.toArray
     val defaultsOnly: Array[Expr] = defaultExprs.filter(_ != null).toArray
-    //val defaults: IndexedSeq[(Int, Expr)] = args.collect{case (_, Some(x), i) => (i, x)}
     val allIndices: BitSet = {
       val b = new BitSet(indices.size)
       indices.foreach(b.set)
@@ -111,7 +109,7 @@ object Expr{
     case object `||` extends Op
   }
   case class AssertExpr(pos: Position, asserted: Member.AssertStmt, returned: Expr) extends Expr
-  case class LocalExpr(pos: Position, bindings: Seq[Bind], returned: Expr) extends Expr
+  case class LocalExpr(pos: Position, bindings: Array[Bind], returned: Expr) extends Expr
 
   case class Bind(pos: Position, name: Int, args: Option[Params], rhs: Expr)
   case class Import(pos: Position, value: String) extends Expr
@@ -132,18 +130,18 @@ object Expr{
   case class IfSpec(pos: Position, cond: Expr) extends CompSpec
   case class ForSpec(pos: Position, name: Int, cond: Expr) extends CompSpec
 
-  case class Comp(pos: Position, value: Expr, first: ForSpec, rest: Seq[CompSpec]) extends Expr
+  case class Comp(pos: Position, value: Expr, first: ForSpec, rest: Array[CompSpec]) extends Expr
   case class ObjExtend(pos: Position, base: Expr, ext: ObjBody) extends Expr
 
   sealed trait ObjBody
   object ObjBody{
-    case class MemberList(value: Seq[Member]) extends ObjBody
-    case class ObjComp(preLocals: Seq[Member.BindStmt],
+    case class MemberList(value: Array[Member]) extends ObjBody
+    case class ObjComp(preLocals: Array[Member.BindStmt],
                        key: Expr,
                        value: Expr,
-                       postLocals: Seq[Member.BindStmt],
+                       postLocals: Array[Member.BindStmt],
                        first: ForSpec,
-                       rest: Seq[CompSpec]) extends ObjBody
+                       rest: Array[CompSpec]) extends ObjBody
   }
 
 }

--- a/sjsonnet/src/sjsonnet/Expr.scala
+++ b/sjsonnet/src/sjsonnet/Expr.scala
@@ -46,7 +46,7 @@ object Expr{
                      sep: Visibility,
                      rhs: Expr) extends Member
     case class BindStmt(value: Bind) extends Member
-    case class AssertStmt(value: Expr, msg: Option[Expr]) extends Member
+    case class AssertStmt(value: Expr, msg: Expr) extends Member
   }
 
 

--- a/sjsonnet/src/sjsonnet/Expr.scala
+++ b/sjsonnet/src/sjsonnet/Expr.scala
@@ -24,7 +24,7 @@ object Expr{
   case class Str(pos: Position, value: String) extends Expr
   case class Num(pos: Position, value: Double) extends Expr
   case class Id(pos: Position, value: Int) extends Expr
-  case class Arr(pos: Position, value: Seq[Expr]) extends Expr
+  case class Arr(pos: Position, value: Array[Expr]) extends Expr
   case class Obj(pos: Position, value: ObjBody) extends Expr
 
   sealed trait FieldName
@@ -46,7 +46,7 @@ object Expr{
     case class Field(pos: Position,
                      fieldName: FieldName,
                      plus: Boolean,
-                     args: Option[Params],
+                     args: Params,
                      sep: Visibility,
                      rhs: Expr) extends Member
     case class BindStmt(value: Bind) extends Member
@@ -75,7 +75,7 @@ object Expr{
       Params(params.map(_._1).toArray, params.map(_._2.getOrElse(null)).toArray, params.map(_._3).toArray)
     }
   }
-  case class Args(args: Seq[(Option[String], Expr)])
+  case class Args(names: Array[String], exprs: Array[Expr])
 
   case class UnaryOp(pos: Position, op: UnaryOp.Op, value: Expr) extends Expr
   object UnaryOp{
@@ -111,7 +111,7 @@ object Expr{
   case class AssertExpr(pos: Position, asserted: Member.AssertStmt, returned: Expr) extends Expr
   case class LocalExpr(pos: Position, bindings: Array[Bind], returned: Expr) extends Expr
 
-  case class Bind(pos: Position, name: Int, args: Option[Params], rhs: Expr)
+  case class Bind(pos: Position, name: Int, args: Params, rhs: Expr)
   case class Import(pos: Position, value: String) extends Expr
   case class ImportStr(pos: Position, value: String) extends Expr
   case class Error(pos: Position, value: Expr) extends Expr

--- a/sjsonnet/src/sjsonnet/Expr.scala
+++ b/sjsonnet/src/sjsonnet/Expr.scala
@@ -10,19 +10,15 @@ import java.util.BitSet
   * Each [[Expr]] represents an expression in the Jsonnet program, and contains an
   * integer offset into the file that is later used to provide error messages.
   */
-sealed trait Expr{
+trait Expr{
   def pos: Position
 }
 object Expr{
-  case class Null(pos: Position) extends Expr
-  case class True(pos: Position) extends Expr
-  case class False(pos: Position) extends Expr
+
   case class Self(pos: Position) extends Expr
   case class Super(pos: Position) extends Expr
   case class $(pos: Position) extends Expr
 
-  case class Str(pos: Position, value: String) extends Expr
-  case class Num(pos: Position, value: Double) extends Expr
   case class Id(pos: Position, value: Int) extends Expr
   case class Arr(pos: Position, value: Array[Expr]) extends Expr
   case class Obj(pos: Position, value: ObjBody) extends Expr

--- a/sjsonnet/src/sjsonnet/Expr.scala
+++ b/sjsonnet/src/sjsonnet/Expr.scala
@@ -45,7 +45,6 @@ object Expr{
                      args: Params,
                      sep: Visibility,
                      rhs: Expr) extends Member
-    case class BindStmt(value: Bind) extends Member
     case class AssertStmt(value: Expr, msg: Expr) extends Member
   }
 
@@ -106,7 +105,7 @@ object Expr{
   case class AssertExpr(pos: Position, asserted: Member.AssertStmt, returned: Expr) extends Expr
   case class LocalExpr(pos: Position, bindings: Array[Bind], returned: Expr) extends Expr
 
-  case class Bind(pos: Position, name: Int, args: Params, rhs: Expr)
+  case class Bind(pos: Position, name: Int, args: Params, rhs: Expr) extends Member
   case class Import(pos: Position, value: String) extends Expr
   case class ImportStr(pos: Position, value: String) extends Expr
   case class Error(pos: Position, value: Expr) extends Expr
@@ -130,11 +129,11 @@ object Expr{
 
   sealed trait ObjBody
   object ObjBody{
-    case class MemberList(value: Array[Member]) extends ObjBody
-    case class ObjComp(preLocals: Array[Member.BindStmt],
+    case class MemberList(binds: Array[Bind], fields: Array[Member.Field], asserts: Array[Member.AssertStmt]) extends ObjBody
+    case class ObjComp(preLocals: Array[Bind],
                        key: Expr,
                        value: Expr,
-                       postLocals: Array[Member.BindStmt],
+                       postLocals: Array[Bind],
                        first: ForSpec,
                        rest: List[CompSpec]) extends ObjBody
   }

--- a/sjsonnet/src/sjsonnet/Expr.scala
+++ b/sjsonnet/src/sjsonnet/Expr.scala
@@ -124,7 +124,7 @@ object Expr{
                    end: Option[Expr],
                    stride: Option[Expr]) extends Expr
   case class Function(pos: Position, params: Params, body: Expr) extends Expr
-  case class IfElse(pos: Position, cond: Expr, then: Expr, `else`: Option[Expr]) extends Expr
+  case class IfElse(pos: Position, cond: Expr, then: Expr, `else`: Expr) extends Expr
 
   sealed trait CompSpec extends Expr
   case class IfSpec(pos: Position, cond: Expr) extends CompSpec

--- a/sjsonnet/src/sjsonnet/Expr.scala
+++ b/sjsonnet/src/sjsonnet/Expr.scala
@@ -141,7 +141,7 @@ object Expr{
                        value: Expr,
                        postLocals: Array[Member.BindStmt],
                        first: ForSpec,
-                       rest: Array[CompSpec]) extends ObjBody
+                       rest: List[CompSpec]) extends ObjBody
   }
 
 }

--- a/sjsonnet/src/sjsonnet/Expr.scala
+++ b/sjsonnet/src/sjsonnet/Expr.scala
@@ -66,8 +66,8 @@ object Expr{
     }
   }
   object Params {
-    def mk(params: (String, Option[Expr], Int)*): Params = {
-      Params(params.map(_._1).toArray, params.map(_._2.getOrElse(null)).toArray, params.map(_._3).toArray)
+    def mk(params: (String, Expr, Int)*): Params = {
+      Params(params.map(_._1).toArray, params.map(_._2).toArray, params.map(_._3).toArray)
     }
   }
   case class Args(names: Array[String], exprs: Array[Expr])

--- a/sjsonnet/src/sjsonnet/Format.scala
+++ b/sjsonnet/src/sjsonnet/Format.scala
@@ -82,7 +82,7 @@ object Format{
     val values = values0 match{
       case x: Val.Arr => x
       case x: Val.Obj => x
-      case x => Val.Arr(pos, Seq(Val.Lazy(x)))
+      case x => Val.Arr(pos, Seq[Val.Lazy](() => x))
     }
     val (leading, chunks) = fastparse.parse(s, format(_)).get.value
     val output = new StringBuilder

--- a/sjsonnet/src/sjsonnet/Format.scala
+++ b/sjsonnet/src/sjsonnet/Format.scala
@@ -78,7 +78,7 @@ object Format{
   def format(s: String,
              values0: Val,
              pos: Position)
-            (implicit fileScope: FileScope, evaluator: EvalScope): String = {
+            (implicit evaluator: EvalScope): String = {
     val values = values0 match{
       case x: Val.Arr => x
       case x: Val.Obj => x

--- a/sjsonnet/src/sjsonnet/Format.scala
+++ b/sjsonnet/src/sjsonnet/Format.scala
@@ -77,12 +77,12 @@ object Format{
   }
   def format(s: String,
              values0: Val,
-             offset: Int)
+             pos: Position)
             (implicit fileScope: FileScope, evaluator: EvalScope): String = {
     val values = values0 match{
       case x: Val.Arr => x
       case x: Val.Obj => x
-      case x => Val.Arr(Position(offset), Seq(Val.Lazy(x)))
+      case x => Val.Arr(pos, Seq(Val.Lazy(x)))
     }
     val (leading, chunks) = fastparse.parse(s, format(_)).get.value
     val output = new StringBuilder
@@ -98,7 +98,7 @@ object Format{
             case Some(key) =>
               values match{
                 case v: Val.Arr => Materializer(v.value(i).force)
-                case v: Val.Obj => Materializer(v.value(key, offset))
+                case v: Val.Obj => Materializer(v.value(key, pos))
               }
           }
           i += 1

--- a/sjsonnet/src/sjsonnet/Format.scala
+++ b/sjsonnet/src/sjsonnet/Format.scala
@@ -82,7 +82,7 @@ object Format{
     val values = values0 match{
       case x: Val.Arr => x
       case x: Val.Obj => x
-      case x => Val.Arr(pos, Seq[Val.Lazy](() => x))
+      case x => Val.Arr(pos, Array[Val.Lazy](() => x))
     }
     val (leading, chunks) = fastparse.parse(s, format(_)).get.value
     val output = new StringBuilder

--- a/sjsonnet/src/sjsonnet/Interpreter.scala
+++ b/sjsonnet/src/sjsonnet/Interpreter.scala
@@ -61,7 +61,7 @@ class Interpreter(parseCache: collection.mutable.HashMap[String, fastparse.Parse
           var i = 0
           while(i < defaults2.length) {
             tlaVars.get(f.params.names(i)) match {
-              case Some(v) => defaults2(i) = Materializer.toExpr(v)
+              case Some(v) => defaults2(i) = Materializer.toExpr(v)(evaluator)
               case None =>
             }
             i += 1

--- a/sjsonnet/src/sjsonnet/Interpreter.scala
+++ b/sjsonnet/src/sjsonnet/Interpreter.scala
@@ -58,12 +58,16 @@ class Interpreter(parseCache: collection.mutable.Map[String, fastparse.Parsed[(E
         }
       res = res0 match{
         case f: Val.Func =>
-          f.copy(params = Params(f.params.args.map{ case (k, default, i) =>
-            (k, tlaVars.get(k) match{
-              case None => default
-              case Some(v) => Some(Materializer.toExpr(v))
-            }, i)
-          }))
+          val defaults2 = f.params.defaultExprs.clone()
+          var i = 0
+          while(i < defaults2.length) {
+            tlaVars.get(f.params.names(i)) match {
+              case Some(v) => defaults2(i) = Materializer.toExpr(v)
+              case None =>
+            }
+            i += 1
+          }
+          f.copy(params = Params(f.params.names, defaults2, f.params.indices))
         case x => x
       }
       json <-

--- a/sjsonnet/src/sjsonnet/Interpreter.scala
+++ b/sjsonnet/src/sjsonnet/Interpreter.scala
@@ -11,7 +11,7 @@ import scala.util.control.NonFatal
   * Wraps all the machinery of evaluating Jsonnet source code, from parsing to
   * evaluation to materialization, into a convenient wrapper class.
   */
-class Interpreter(parseCache: collection.mutable.Map[String, fastparse.Parsed[(Expr, FileScope)]],
+class Interpreter(parseCache: collection.mutable.HashMap[String, fastparse.Parsed[(Expr, FileScope)]],
                   extVars: Map[String, ujson.Value],
                   tlaVars: Map[String, ujson.Value],
                   wd: Path,

--- a/sjsonnet/src/sjsonnet/Interpreter.scala
+++ b/sjsonnet/src/sjsonnet/Interpreter.scala
@@ -11,7 +11,7 @@ import scala.util.control.NonFatal
   * Wraps all the machinery of evaluating Jsonnet source code, from parsing to
   * evaluation to materialization, into a convenient wrapper class.
   */
-class Interpreter(parseCache: collection.mutable.HashMap[String, fastparse.Parsed[(Expr, FileScope)]],
+class Interpreter(parseCache: collection.mutable.HashMap[(Path, String), fastparse.Parsed[(Expr, FileScope)]],
                   extVars: Map[String, ujson.Value],
                   tlaVars: Map[String, ujson.Value],
                   wd: Path,
@@ -36,7 +36,7 @@ class Interpreter(parseCache: collection.mutable.HashMap[String, fastparse.Parse
                     path: Path,
                     visitor: upickle.core.Visitor[T, T]): Either[String, T] = {
     for{
-      res <- parseCache.getOrElseUpdate(txt, fastparse.parse(txt, new Parser(path).document(_))) match{
+      res <- parseCache.getOrElseUpdate((path, txt), fastparse.parse(txt, new Parser(path).document(_))) match{
         case f @ Parsed.Failure(l, i, e) => Left("Parse error: " + f.trace().msg)
         case Parsed.Success(r, index) => Right(r)
       }

--- a/sjsonnet/src/sjsonnet/Interpreter.scala
+++ b/sjsonnet/src/sjsonnet/Interpreter.scala
@@ -45,8 +45,7 @@ class Interpreter(parseCache: collection.mutable.Map[String, fastparse.Parsed[(E
       res0 <-
         try Right(
           evaluator.visitExpr(parsed)(
-            Std.scope(newFileScope.nameIndices.size + 1),
-            newFileScope
+            Std.scope(newFileScope.nameIndices.size + 1)
           )
         )
         catch{case NonFatal(e) =>

--- a/sjsonnet/src/sjsonnet/Materializer.scala
+++ b/sjsonnet/src/sjsonnet/Materializer.scala
@@ -93,7 +93,7 @@ object Materializer {
       val builder = mutable.LinkedHashMap.newBuilder[String, Val.Obj.Member]
       for(x <- xs){
         val v = Val.Obj.Member(false, Visibility.Normal,
-          (_: Val.Obj, _: Option[Val.Obj], _, _) => reverse(pos, x._2)
+          (_: Val.Obj, _: Val.Obj, _, _) => reverse(pos, x._2)
         )
         builder += (x._1 -> v)
       }

--- a/sjsonnet/src/sjsonnet/Materializer.scala
+++ b/sjsonnet/src/sjsonnet/Materializer.scala
@@ -47,7 +47,7 @@ object Materializer {
         val objVisitor = visitor.visitObject(keys.length , -1)
 
         for(k <- keys) {
-          val value = obj.value(k, new Position(evaluator.emptyMaterializeFileScope, -1))
+          val value = obj.value(k, evaluator.emptyMaterializeFileScopePos)
 
           storePos(
             value match{
@@ -69,7 +69,7 @@ object Materializer {
 
       case f: Val.Func =>
         apply0(
-          f.apply(emptyStringArray, emptyLazyArray, new Position(evaluator.emptyMaterializeFileScope, -1)),
+          f.apply(emptyStringArray, emptyLazyArray, evaluator.emptyMaterializeFileScopePos),
           visitor,
           storePos
         )

--- a/sjsonnet/src/sjsonnet/Materializer.scala
+++ b/sjsonnet/src/sjsonnet/Materializer.scala
@@ -90,14 +90,14 @@ object Materializer {
     case ujson.Str(s) => Val.Str(pos, s)
     case ujson.Arr(xs) => Val.Arr(pos, xs.map(x => (() => reverse(pos, x)): Val.Lazy).toArray[Val.Lazy])
     case ujson.Obj(xs) =>
-      val builder = mutable.LinkedHashMap.newBuilder[String, Val.Obj.Member]
-      for(x <- xs){
+      val builder = new java.util.LinkedHashMap[String, Val.Obj.Member]
+      for(x <- xs) {
         val v = Val.Obj.Member(false, Visibility.Normal,
           (_: Val.Obj, _: Val.Obj, _, _) => reverse(pos, x._2)
         )
-        builder += (x._1 -> v)
+        builder.put(x._1, v)
       }
-      new Val.Obj(pos, builder.result(), null, null)
+      new Val.Obj(pos, builder, null, null)
   }
 
   def toExpr(v: ujson.Value): Expr = v match{

--- a/sjsonnet/src/sjsonnet/Materializer.scala
+++ b/sjsonnet/src/sjsonnet/Materializer.scala
@@ -101,11 +101,11 @@ object Materializer {
   }
 
   def toExpr(v: ujson.Value): Expr = v match{
-    case ujson.True => Expr.True(dummyPos)
-    case ujson.False => Expr.False(dummyPos)
-    case ujson.Null => Expr.Null(dummyPos)
-    case ujson.Num(n) => Expr.Num(dummyPos, n)
-    case ujson.Str(s) => Expr.Str(dummyPos, s)
+    case ujson.True => Val.True(dummyPos)
+    case ujson.False => Val.False(dummyPos)
+    case ujson.Null => Val.Null(dummyPos)
+    case ujson.Num(n) => Val.Num(dummyPos, n)
+    case ujson.Str(s) => Val.Str(dummyPos, s)
     case ujson.Arr(xs) => Expr.Arr(dummyPos, xs.map(toExpr).toArray[Expr])
     case ujson.Obj(kvs) =>
       Expr.Obj(dummyPos,

--- a/sjsonnet/src/sjsonnet/Materializer.scala
+++ b/sjsonnet/src/sjsonnet/Materializer.scala
@@ -88,7 +88,7 @@ object Materializer {
     case ujson.Null => Val.Null(pos)
     case ujson.Num(n) => Val.Num(pos, n)
     case ujson.Str(s) => Val.Str(pos, s)
-    case ujson.Arr(xs) => Val.Arr(pos, xs.map(x => Val.Lazy(reverse(pos, x))).toArray[Val.Lazy])
+    case ujson.Arr(xs) => Val.Arr(pos, xs.map(x => (() => reverse(pos, x)): Val.Lazy).toArray[Val.Lazy])
     case ujson.Obj(xs) =>
       val builder = mutable.LinkedHashMap.newBuilder[String, Val.Obj.Member]
       for(x <- xs){

--- a/sjsonnet/src/sjsonnet/Materializer.scala
+++ b/sjsonnet/src/sjsonnet/Materializer.scala
@@ -94,7 +94,7 @@ object Materializer {
         )
         builder.put(x._1, v)
       }
-      new Val.Obj(pos, builder, null, null)
+      new Val.Obj(pos, builder, false, null, null)
   }
 
   def toExpr(v: ujson.Value)(implicit ev: EvalScope): Expr = v match{

--- a/sjsonnet/src/sjsonnet/Materializer.scala
+++ b/sjsonnet/src/sjsonnet/Materializer.scala
@@ -42,7 +42,7 @@ object Materializer {
         storePos(obj.pos)
         obj.triggerAllAsserts(obj)
 
-        val keysUnsorted = obj.getVisibleKeys().toArray
+        val keysUnsorted = obj.getVisibleKeys
         val keys = if (!evaluator.preserveOrder) keysUnsorted.sortBy(_._1) else keysUnsorted
         val objVisitor = visitor.visitObject(keys.length , -1)
 
@@ -53,7 +53,7 @@ object Materializer {
 
             storePos(
               value match{
-                case v: Val.Obj if v.getVisibleKeys().nonEmpty => value.pos
+                case v: Val.Obj if !v.visibleKeys.isEmpty => value.pos
                 case v: Val.Arr if v.value.nonEmpty => value.pos
                 case _ => null
               }

--- a/sjsonnet/src/sjsonnet/Materializer.scala
+++ b/sjsonnet/src/sjsonnet/Materializer.scala
@@ -49,7 +49,7 @@ object Materializer {
         for(t <- keys) {
           val (k, hidden) = t
           if (!hidden){
-            val value = obj.value(k, new Position(evaluator.emptyMaterializeFileScope.currentFile, -1))(evaluator.emptyMaterializeFileScope, implicitly)
+            val value = obj.value(k, new Position(evaluator.emptyMaterializeFileScope, -1))
 
             storePos(
               value match{
@@ -72,7 +72,7 @@ object Materializer {
 
       case f: Val.Func =>
         apply0(
-          f.apply(emptyStringArray, emptyLazyArray, "(memory)", new Position(evaluator.emptyMaterializeFileScope.currentFile, -1))(evaluator.emptyMaterializeFileScope, implicitly),
+          f.apply(emptyStringArray, emptyLazyArray, "(memory)", new Position(evaluator.emptyMaterializeFileScope, -1)),
           visitor,
           storePos
         )

--- a/sjsonnet/src/sjsonnet/Materializer.scala
+++ b/sjsonnet/src/sjsonnet/Materializer.scala
@@ -12,7 +12,7 @@ import scala.collection.mutable
   * to `String`s
   */
 object Materializer {
-  private val dummyPos: Position = new Position(null, 0)
+  //private val dummyPos: Position = new Position(null, 0)
 
   def apply(v: Val, storePos: Position => Unit = _ => ())(implicit evaluator: EvalScope): ujson.Value = apply0(v, ujson.Value)
   def stringify(v: Val)(implicit evaluator: EvalScope): String = {
@@ -72,7 +72,7 @@ object Materializer {
 
       case f: Val.Func =>
         apply0(
-          f.apply(emptyStringArray, emptyLazyArray, "(memory)", new Position(evaluator.emptyMaterializeFileScope, -1)),
+          f.apply(emptyStringArray, emptyLazyArray, new Position(evaluator.emptyMaterializeFileScope, -1)),
           visitor,
           storePos
         )
@@ -100,18 +100,18 @@ object Materializer {
       new Val.Obj(pos, builder, null, null)
   }
 
-  def toExpr(v: ujson.Value): Expr = v match{
-    case ujson.True => Val.True(dummyPos)
-    case ujson.False => Val.False(dummyPos)
-    case ujson.Null => Val.Null(dummyPos)
-    case ujson.Num(n) => Val.Num(dummyPos, n)
-    case ujson.Str(s) => Val.Str(dummyPos, s)
-    case ujson.Arr(xs) => Expr.Arr(dummyPos, xs.map(toExpr).toArray[Expr])
+  def toExpr(v: ujson.Value)(implicit ev: EvalScope): Expr = v match{
+    case ujson.True => Val.True(ev.emptyMaterializeFileScopePos)
+    case ujson.False => Val.False(ev.emptyMaterializeFileScopePos)
+    case ujson.Null => Val.Null(ev.emptyMaterializeFileScopePos)
+    case ujson.Num(n) => Val.Num(ev.emptyMaterializeFileScopePos, n)
+    case ujson.Str(s) => Val.Str(ev.emptyMaterializeFileScopePos, s)
+    case ujson.Arr(xs) => Expr.Arr(ev.emptyMaterializeFileScopePos, xs.map(toExpr).toArray[Expr])
     case ujson.Obj(kvs) =>
-      Expr.Obj(dummyPos,
+      Expr.Obj(ev.emptyMaterializeFileScopePos,
         ObjBody.MemberList(
           for((k, v) <- kvs.toArray)
-          yield Member.Field(dummyPos, FieldName.Fixed(k), false, null, Visibility.Normal, toExpr(v))
+          yield Member.Field(ev.emptyMaterializeFileScopePos, FieldName.Fixed(k), false, null, Visibility.Normal, toExpr(v))
         )
       )
   }

--- a/sjsonnet/src/sjsonnet/Materializer.scala
+++ b/sjsonnet/src/sjsonnet/Materializer.scala
@@ -1,6 +1,7 @@
 package sjsonnet
 import sjsonnet.Expr.{FieldName, Member, ObjBody}
 import sjsonnet.Expr.Member.Visibility
+import sjsonnet.Val.Lazy
 import upickle.core.Visitor
 
 import scala.collection.mutable
@@ -71,7 +72,7 @@ object Materializer {
 
       case f: Val.Func =>
         apply0(
-          f.apply(Nil, "(memory)", -1)(evaluator.emptyMaterializeFileScope, implicitly),
+          f.apply(emptyStringArray, emptyLazyArray, "(memory)", -1)(evaluator.emptyMaterializeFileScope, implicitly),
           visitor,
           storePos
         )
@@ -114,5 +115,8 @@ object Materializer {
         )
       )
   }
+
+  val emptyStringArray = new Array[String](0)
+  val emptyLazyArray = new Array[Lazy](0)
 
 }

--- a/sjsonnet/src/sjsonnet/Materializer.scala
+++ b/sjsonnet/src/sjsonnet/Materializer.scala
@@ -97,7 +97,7 @@ object Materializer {
         )
         builder += (x._1 -> v)
       }
-      new Val.Obj(pos, builder.result(), _ => (), None)
+      new Val.Obj(pos, builder.result(), _ => (), null)
   }
 
   def toExpr(v: ujson.Value): Expr = v match{

--- a/sjsonnet/src/sjsonnet/Materializer.scala
+++ b/sjsonnet/src/sjsonnet/Materializer.scala
@@ -97,7 +97,7 @@ object Materializer {
         )
         builder += (x._1 -> v)
       }
-      new Val.Obj(pos, builder.result(), _ => (), null)
+      new Val.Obj(pos, builder.result(), null, null)
   }
 
   def toExpr(v: ujson.Value): Expr = v match{

--- a/sjsonnet/src/sjsonnet/Materializer.scala
+++ b/sjsonnet/src/sjsonnet/Materializer.scala
@@ -108,13 +108,12 @@ object Materializer {
     case ujson.Str(s) => Val.Str(ev.emptyMaterializeFileScopePos, s)
     case ujson.Arr(xs) => Expr.Arr(ev.emptyMaterializeFileScopePos, xs.map(toExpr).toArray[Expr])
     case ujson.Obj(kvs) =>
-      Expr.Obj(ev.emptyMaterializeFileScopePos,
-        ObjBody.MemberList(
-          null,
-          for((k, v) <- kvs.toArray)
-            yield Member.Field(ev.emptyMaterializeFileScopePos, FieldName.Fixed(k), false, null, Visibility.Normal, toExpr(v)),
-          null
-        )
+      ObjBody.MemberList(
+        ev.emptyMaterializeFileScopePos,
+        null,
+        for((k, v) <- kvs.toArray)
+          yield Member.Field(ev.emptyMaterializeFileScopePos, FieldName.Fixed(k), false, null, Visibility.Normal, toExpr(v)),
+        null
       )
   }
 

--- a/sjsonnet/src/sjsonnet/Materializer.scala
+++ b/sjsonnet/src/sjsonnet/Materializer.scala
@@ -110,8 +110,10 @@ object Materializer {
     case ujson.Obj(kvs) =>
       Expr.Obj(ev.emptyMaterializeFileScopePos,
         ObjBody.MemberList(
+          null,
           for((k, v) <- kvs.toArray)
-          yield Member.Field(ev.emptyMaterializeFileScopePos, FieldName.Fixed(k), false, null, Visibility.Normal, toExpr(v))
+            yield Member.Field(ev.emptyMaterializeFileScopePos, FieldName.Fixed(k), false, null, Visibility.Normal, toExpr(v)),
+          null
         )
       )
   }

--- a/sjsonnet/src/sjsonnet/Materializer.scala
+++ b/sjsonnet/src/sjsonnet/Materializer.scala
@@ -111,7 +111,7 @@ object Materializer {
       Expr.Obj(dummyPos,
         ObjBody.MemberList(
           for((k, v) <- kvs.toArray)
-          yield Member.Field(dummyPos, FieldName.Fixed(k), false, None, Visibility.Normal, toExpr(v))
+          yield Member.Field(dummyPos, FieldName.Fixed(k), false, null, Visibility.Normal, toExpr(v))
         )
       )
   }

--- a/sjsonnet/src/sjsonnet/Parser.scala
+++ b/sjsonnet/src/sjsonnet/Parser.scala
@@ -227,7 +227,6 @@ class Parser(val currentFile: Path) {
   )
 
   def local[_: P] = P( localExpr )
-  def parened[_: P] = P( (Pos ~~ expr).map(Expr.Parened.tupled) )
   def importStr[_: P](pos: Position) = P( string.map(Expr.ImportStr(pos, _)) )
   def `import`[_: P](pos: Position) = P( string.map(Expr.Import(pos, _)) )
   def error[_: P](pos: Position) = P(expr.map(Expr.Error(pos, _)) )
@@ -253,7 +252,7 @@ class Parser(val currentFile: Path) {
           case '{' => Pass ~ obj ~ "}"
           case '+' | '-' | '~' | '!' => Pass ~ unaryOpExpr(pos, c)
           case '[' => Pass ~ arr ~ "]"
-          case '(' => Pass ~ parened ~ ")"
+          case '(' => Pass ~ expr ~ ")"
           case '\"' => doubleString.map(constructString(pos, _))
           case '\'' => singleString.map(constructString(pos, _))
           case '@' => SingleChar./.flatMapX{

--- a/sjsonnet/src/sjsonnet/Parser.scala
+++ b/sjsonnet/src/sjsonnet/Parser.scala
@@ -348,7 +348,7 @@ class Parser(val currentFile: Path) {
     "[" ~ expr.map(Expr.FieldName.Dyn) ~ "]"
   )
   def assertStmt[_: P] =
-    P( expr ~ (":" ~ expr).? ).map(Expr.Member.AssertStmt.tupled)
+    P( expr ~ (":" ~ expr).?.map(_.getOrElse(null)) ).map(Expr.Member.AssertStmt.tupled)
 
   def bind[_: P] =
     P( Pos ~~ id.map(indexFor(_)) ~ ("(" ~/ params.? ~ ")").?.map(_.flatten).map(_.getOrElse(null)) ~ "=" ~ expr ).map(Expr.Bind.tupled)

--- a/sjsonnet/src/sjsonnet/Parser.scala
+++ b/sjsonnet/src/sjsonnet/Parser.scala
@@ -149,7 +149,7 @@ class Parser(val currentFile: Path) {
     P( "(" ~/ params ~ ")" ~ expr ).map(t => Expr.Function(pos, t._1, t._2))
 
   def ifElse[_: P](pos: Position): P[Expr] =
-    P( Pos ~~ expr ~ "then" ~~ break ~ expr ~ ("else" ~~ break ~ expr).? ).map(Expr.IfElse.tupled)
+    P( Pos ~~ expr ~ "then" ~~ break ~ expr ~ ("else" ~~ break ~ expr).?.map(_.getOrElse(null)) ).map(Expr.IfElse.tupled)
 
   def localExpr[_: P]: P[Expr] =
     P( Pos ~~ bind.rep(min=1, sep = ","./).map(_.toArray) ~ ";" ~ expr ).map(Expr.LocalExpr.tupled)

--- a/sjsonnet/src/sjsonnet/Parser.scala
+++ b/sjsonnet/src/sjsonnet/Parser.scala
@@ -323,7 +323,7 @@ class Parser(val currentFile: Path) {
           Fail.opaque(s"""no duplicate field: "${lhs.asInstanceOf[Expr.Str].value}" """)
         case _ => // do nothing
       }
-      Expr.ObjBody.ObjComp(preLocals.toArray, lhs, rhs, postLocals.toArray, comps._1, comps._2.toArray)
+      Expr.ObjBody.ObjComp(preLocals.toArray, lhs, rhs, postLocals.toArray, comps._1, comps._2.toList)
   }
 
   def member[_: P]: P[Expr.Member] = P( objlocal | "assert" ~~ assertStmt | field )

--- a/sjsonnet/src/sjsonnet/Parser.scala
+++ b/sjsonnet/src/sjsonnet/Parser.scala
@@ -435,7 +435,3 @@ class FileScope(val currentFile: Path,
 
   val noOffsetPos: Position = new Position(this, -1)
 }
-
-object FileScope {
-  val nullFileScope = new FileScope(null, Map.empty)
-}

--- a/sjsonnet/src/sjsonnet/Parser.scala
+++ b/sjsonnet/src/sjsonnet/Parser.scala
@@ -152,7 +152,7 @@ class Parser(val currentFile: Path) {
     P( Pos ~~ expr ~ "then" ~~ break ~ expr ~ ("else" ~~ break ~ expr).?.map(_.getOrElse(null)) ).map(Expr.IfElse.tupled)
 
   def localExpr[_: P]: P[Expr] =
-    P( Pos ~~ bind.rep(min=1, sep = ","./).map(_.toArray) ~ ";" ~ expr ).map(Expr.LocalExpr.tupled)
+    P( Pos ~~ bind.rep(min=1, sep = ","./).map(s => if(s.isEmpty) null else s.toArray) ~ ";" ~ expr ).map(Expr.LocalExpr.tupled)
 
   def expr[_: P]: P[Expr] =
     P("" ~ expr1 ~ (Pos ~~ binaryop ~/ expr1).rep ~ "").map{ case (pre, fs) =>

--- a/sjsonnet/src/sjsonnet/Path.scala
+++ b/sjsonnet/src/sjsonnet/Path.scala
@@ -16,5 +16,5 @@ trait Path {
   def segmentCount(): Int
   def last: String
   def /(s: String): Path
-  def renderOffsetStr(offset: Int, loadedFileContents: mutable.Map[Path, Array[Int]]): String
+  def renderOffsetStr(offset: Int, loadedFileContents: mutable.HashMap[Path, Array[Int]]): String
 }

--- a/sjsonnet/src/sjsonnet/PrettyYamlRenderer.scala
+++ b/sjsonnet/src/sjsonnet/PrettyYamlRenderer.scala
@@ -95,7 +95,7 @@ class PrettyYamlRenderer(out: Writer = new java.io.StringWriter(),
     out
   }
 
-  val loadedFileContents = mutable.Map.empty[Path, Array[Int]]
+  val loadedFileContents = mutable.HashMap.empty[Path, Array[Int]]
   def saveCurrentPos() = {
     val current = getCurrentPosition()
     if (current != null){

--- a/sjsonnet/src/sjsonnet/ReadWriter.scala
+++ b/sjsonnet/src/sjsonnet/ReadWriter.scala
@@ -75,6 +75,6 @@ object ReadWriter{
 }
 case class Applyer(f: Val.Func, ev: EvalScope, fs: FileScope){
   def apply(args: Val.Lazy*) = {
-    f.apply(null, args.toArray, "(memory)", new Position(fs, -1))(ev)
+    f.apply(null, args.toArray, new Position(fs, -1))(ev)
   }
 }

--- a/sjsonnet/src/sjsonnet/ReadWriter.scala
+++ b/sjsonnet/src/sjsonnet/ReadWriter.scala
@@ -73,6 +73,6 @@ object ReadWriter{
 }
 case class Applyer(f: Val.Func, ev: EvalScope, fs: FileScope){
   def apply(args: Val.Lazy*) = {
-    f.apply(args.map((None, _)), "(memory)", -1)(fs, ev)
+    f.apply(null, args.toArray, "(memory)", -1)(fs, ev)
   }
 }

--- a/sjsonnet/src/sjsonnet/ReadWriter.scala
+++ b/sjsonnet/src/sjsonnet/ReadWriter.scala
@@ -73,6 +73,7 @@ object ReadWriter{
 }
 case class Applyer(f: Val.Func, ev: EvalScope, fs: FileScope){
   def apply(args: Val.Lazy*) = {
-    f.apply(null, args.toArray, "(memory)", -1)(fs, ev)
+    val file = if(fs == null) null else fs.currentFile
+    f.apply(null, args.toArray, "(memory)", new Position(file, -1))(fs, ev)
   }
 }

--- a/sjsonnet/src/sjsonnet/ReadWriter.scala
+++ b/sjsonnet/src/sjsonnet/ReadWriter.scala
@@ -3,70 +3,72 @@ package sjsonnet
 /**
   * Typeclasses for easy conversion between [[Val]]s and Scala data types
   */
-sealed trait ReadWriter[T]{
-  def apply(t: Val, ev: EvalScope, fs: FileScope): Either[String, T]
+sealed abstract class ReadWriter[T] {
+  protected[this] def fail(err: String, v: Val): Nothing =
+    throw new Error.Delegate("Wrong parameter type: expected " + err + ", got " + v.prettyName)
+  def apply(t: Val, ev: EvalScope, fs: FileScope): T
   def write(pos: Position, t: T): Val
 }
 object ReadWriter{
   implicit object StringRead extends ReadWriter[String]{
     def apply(t: Val, ev: EvalScope, fs: FileScope) = t match{
-      case Val.Str(_, s) => Right(s)
-      case _ => Left("String")
+      case Val.Str(_, s) => s
+      case _ => fail("String", t)
     }
     def write(pos: Position, t: String) = Val.Str(pos, t)
   }
   implicit object BooleanRead extends ReadWriter[Boolean]{
     def apply(t: Val, ev: EvalScope, fs: FileScope) = t match{
-      case Val.True(_) => Right(true)
-      case Val.False(_) => Right(false)
-      case _ => Left("Boolean")
+      case Val.True(_) => true
+      case Val.False(_) => false
+      case _ => fail("Boolean", t)
     }
     def write(pos: Position, t: Boolean) = Val.bool(pos, t)
   }
   implicit object IntRead extends ReadWriter[Int]{
     def apply(t: Val, ev: EvalScope, fs: FileScope) = t match{
-      case Val.Num(_, s) => Right(s.toInt)
-      case _ => Left("Int")
+      case Val.Num(_, s) => s.toInt
+      case _ => fail("Int", t)
     }
     def write(pos: Position, t: Int) = Val.Num(pos, t)
   }
   implicit object DoubleRead extends ReadWriter[Double]{
     def apply(t: Val, ev: EvalScope, fs: FileScope) = t match{
-      case Val.Num(_, s) => Right(s)
-      case _ => Left("Number")
+      case Val.Num(_, s) => s
+      case _ => fail("Number", t)
     }
     def write(pos: Position, t: Double) = Val.Num(pos, t)
   }
   implicit object ValRead extends ReadWriter[Val]{
-    def apply(t: Val, ev: EvalScope, fs: FileScope) = Right(t)
+    def apply(t: Val, ev: EvalScope, fs: FileScope) = t
     def write(pos: Position, t: Val) = t
   }
   implicit object ObjRead extends ReadWriter[Val.Obj]{
     def apply(t: Val, ev: EvalScope, fs: FileScope) = t match{
-      case v: Val.Obj => Right(v)
-      case _ => Left("Object")
+      case v: Val.Obj => v
+      case _ => fail("Object", t)
     }
     def write(pos: Position, t: Val.Obj) = t
   }
   implicit object ArrRead extends ReadWriter[Val.Arr]{
     def apply(t: Val, ev: EvalScope, fs: FileScope) = t match{
-      case v: Val.Arr => Right(v)
-      case _ => Left("Array")
+      case v: Val.Arr => v
+      case _ => fail("Array", t)
     }
     def write(pos: Position, t: Val.Arr) = t
   }
   implicit object FuncRead extends ReadWriter[Val.Func]{
     def apply(t: Val, ev: EvalScope, fs: FileScope) = t match{
-      case v: Val.Func => Right(v)
-      case _ => Left("Function")
+      case v: Val.Func => v
+      case _ => fail("Function", t)
     }
     def write(pos: Position, t: Val.Func) = t
   }
 
   implicit object ApplyerRead extends ReadWriter[Applyer]{
     def apply(t: Val, ev: EvalScope, fs: FileScope) = t match{
-      case v: Val.Func => Right(Applyer(v, ev, fs))
-      case _ => Left("Function")
+      case v: Val.Func => Applyer(v, ev, fs)
+      case _ => fail("Function", t)
     }
     def write(pos: Position, t: Applyer) = t.f
   }

--- a/sjsonnet/src/sjsonnet/ReadWriter.scala
+++ b/sjsonnet/src/sjsonnet/ReadWriter.scala
@@ -73,7 +73,6 @@ object ReadWriter{
 }
 case class Applyer(f: Val.Func, ev: EvalScope, fs: FileScope){
   def apply(args: Val.Lazy*) = {
-    val file = if(fs == null) null else fs.currentFile
-    f.apply(null, args.toArray, "(memory)", new Position(file, -1))(fs, ev)
+    f.apply(null, args.toArray, "(memory)", new Position(fs, -1))(ev)
   }
 }

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -830,7 +830,7 @@ object Std {
             valueMap.foreach { case (k, v) =>
               m.put(k, Val.Obj.Member(false, Expr.Member.Visibility.Normal, (_, _, _, _) => recursiveTransform(v)))
             }
-            new Val.Obj(pos, m, null, null)
+            new Val.Obj(pos, m, false, null, null)
         }
       }
       recursiveTransform(ujson.read(str))

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -42,7 +42,7 @@ object Std {
     builtin("codepoint", "str"){ (offset, ev, fs, v1: Val) =>
       v1.cast[Val.Str].value.charAt(0).toInt
     },
-    "length" -> Val.Func(null, null, Params.mk(("x", null, 0)), { (scope, thisFile, ev, fs, pos) =>
+    "length" -> Val.Func(null, null, Params.mk(("x", null, 0)), { (scope, ev, fs, pos) =>
       val x = scope.bindings(0).force
       Val.Num(pos, x match{
         case Val.Str(_, s) => s.length
@@ -52,12 +52,12 @@ object Std {
         case _ => throw new Error.Delegate("Cannot get length of " + x.prettyName)
       })
     }),
-    "objectHas" -> Val.Func(null, null, Params.mk(("o", null, 0), ("f", null, 1)), { (scope, thisFile, ev, fs, pos) =>
+    "objectHas" -> Val.Func(null, null, Params.mk(("o", null, 0), ("f", null, 1)), { (scope, ev, fs, pos) =>
       val o = implicitly[ReadWriter[Val.Obj]].apply(scope.bindings(0).force, ev, fs)
       val f = implicitly[ReadWriter[String]].apply(scope.bindings(1).force, ev, fs)
       Val.bool(pos, o.visibleKeys.get(f) == java.lang.Boolean.FALSE)
     }),
-    "objectHasAll" -> Val.Func(null, null, Params.mk(("o", null, 0), ("f", null, 1)), { (scope, thisFile, ev, fs, pos) =>
+    "objectHasAll" -> Val.Func(null, null, Params.mk(("o", null, 0), ("f", null, 1)), { (scope, ev, fs, pos) =>
       val o = implicitly[ReadWriter[Val.Obj]].apply(scope.bindings(0).force, ev, fs)
       val f = implicitly[ReadWriter[String]].apply(scope.bindings(1).force, ev, fs)
       Val.bool(pos, o.visibleKeys.containsKey(f))
@@ -262,17 +262,17 @@ object Std {
     builtin("isFunction", "v"){ (pos, ev, fs, v: Val) =>
       v.isInstanceOf[Val.Func]
     },
-    "count" -> Val.Func(null, null, Params.mk(("arr", null, 0), ("x", null, 1)), { (scope, thisFile, ev, fs, pos) =>
+    "count" -> Val.Func(null, null, Params.mk(("arr", null, 0), ("x", null, 1)), { (scope, ev, fs, pos) =>
       val arr = implicitly[ReadWriter[Val.Arr]].apply(scope.bindings(0).force, ev, fs)
       val x = scope.bindings(1).force
       Val.Num(pos, arr.value.count{ i => ev.equal(i.force, x) })
     }),
-    "filter" -> Val.Func(null, null, Params.mk(("func", null, 0), ("arr", null, 1)), { (scope, thisFile, ev, fs, pos) =>
+    "filter" -> Val.Func(null, null, Params.mk(("func", null, 0), ("arr", null, 1)), { (scope, ev, fs, pos) =>
       val func = implicitly[ReadWriter[Applyer]].apply(scope.bindings(0).force, ev, fs)
       val arr = implicitly[ReadWriter[Val.Arr]].apply(scope.bindings(1).force, ev, fs)
       Val.Arr(pos, arr.value.filter(v => func.apply(v).isInstanceOf[Val.True]))
     }),
-    "map" -> Val.Func(null, null, Params.mk(("func", null, 0), ("arr", null, 1)), { (scope, thisFile, ev, fs, pos) =>
+    "map" -> Val.Func(null, null, Params.mk(("func", null, 0), ("arr", null, 1)), { (scope, ev, fs, pos) =>
       val func = implicitly[ReadWriter[Applyer]].apply(scope.bindings(0).force, ev, fs)
       val arr = implicitly[ReadWriter[Val.Arr]].apply(scope.bindings(1).force, ev, fs)
       Val.Arr(pos, arr.value.map(v => (() => func.apply(v)): Val.Lazy))
@@ -340,7 +340,7 @@ object Std {
         }
       )
     },
-    "find" -> Val.Func(null, null, Params.mk(("value", null, 0), ("arr", null, 1)), { (scope, thisFile, ev, fs, pos) =>
+    "find" -> Val.Func(null, null, Params.mk(("value", null, 0), ("arr", null, 1)), { (scope, ev, fs, pos) =>
       val value = scope.bindings(0).force
       val arr = implicitly[ReadWriter[Val.Arr]].apply(scope.bindings(1).force, ev, fs)
       val a = arr.value
@@ -372,12 +372,12 @@ object Std {
       val safeLength = math.min(len, s.length - safeOffset)
       s.substring(safeOffset, safeOffset + safeLength)
     },
-    "startsWith" -> Val.Func(null, null, Params.mk(("a", null, 0), ("b", null, 1)), { (scope, thisFile, ev, fs, pos) =>
+    "startsWith" -> Val.Func(null, null, Params.mk(("a", null, 0), ("b", null, 1)), { (scope, ev, fs, pos) =>
       val a = implicitly[ReadWriter[String]].apply(scope.bindings(0).force, ev, fs)
       val b = implicitly[ReadWriter[String]].apply(scope.bindings(1).force, ev, fs)
       Val.bool(pos, a.startsWith(b))
     }),
-    "endsWith" -> Val.Func(null, null, Params.mk(("a", null, 0), ("b", null, 1)), { (scope, thisFile, ev, fs, pos) =>
+    "endsWith" -> Val.Func(null, null, Params.mk(("a", null, 0), ("b", null, 1)), { (scope, ev, fs, pos) =>
       val a = implicitly[ReadWriter[String]].apply(scope.bindings(0).force, ev, fs)
       val b = implicitly[ReadWriter[String]].apply(scope.bindings(1).force, ev, fs)
       Val.bool(pos, a.endsWith(b))
@@ -403,7 +403,7 @@ object Std {
       str.replaceAll("[" + Regex.quote(chars) + "]+$", "").replaceAll("^[" + Regex.quote(chars) + "]+", "")
     },
 
-    "join" -> Val.Func(null, null, Params.mk(("sep", null, 0), ("arr", null, 1)), { (scope, thisFile, ev, fs, pos) =>
+    "join" -> Val.Func(null, null, Params.mk(("sep", null, 0), ("arr", null, 1)), { (scope, ev, fs, pos) =>
       val sep = scope.bindings(0).force
       val arr = implicitly[ReadWriter[Val.Arr]].apply(scope.bindings(1).force, ev, fs)
       sep match {
@@ -437,7 +437,7 @@ object Std {
       }
     }),
 
-    "member" -> Val.Func(null, null, Params.mk(("arr", null, 0), ("x", null, 1)), { (scope, thisFile, ev, fs, pos) =>
+    "member" -> Val.Func(null, null, Params.mk(("arr", null, 0), ("x", null, 1)), { (scope, ev, fs, pos) =>
       val arr = scope.bindings(0).force
       val x = scope.bindings(1).force
       Val.bool(pos, arr match {
@@ -643,17 +643,17 @@ object Std {
       val arr = args("arr")
       val keyF = args("keyF")
 
-      uniqArr(pos, ev, arr, keyF)
+      uniqArr(pos, ev, arr, keyF, fs)
     },
     builtinWithDefaults("sort", "arr" -> null, "keyF" -> Val.False(dummyPos)) { (pos, args, fs, ev) =>
       val arr = args("arr")
       val keyF = args("keyF")
 
-      sortArr(pos, ev, arr, keyF)
+      sortArr(pos, ev, arr, keyF, fs)
     },
 
     builtinWithDefaults("set", "arr" -> null, "keyF" -> Val.False(dummyPos)) { (pos, args, fs, ev) =>
-      uniqArr(pos, ev, sortArr(pos, ev, args("arr"), args("keyF")), args("keyF"))
+      uniqArr(pos, ev, sortArr(pos, ev, args("arr"), args("keyF"), fs), args("keyF"), fs)
     },
     builtinWithDefaults("setUnion", "a" -> null, "b" -> null, "keyF" -> Val.False(dummyPos)) { (pos, args, fs, ev) =>
       val a = args("a") match {
@@ -668,7 +668,7 @@ object Std {
       }
 
       val concat = Val.Arr(pos, a ++ b)
-      uniqArr(pos, ev, sortArr(pos, ev, concat, args("keyF")), args("keyF"))
+      uniqArr(pos, ev, sortArr(pos, ev, concat, args("keyF"), fs), args("keyF"), fs)
     },
     builtinWithDefaults("setInter", "a" -> null, "b" -> null, "keyF" -> Val.False(dummyPos)) { (pos, args, fs, ev) =>
       val a = args("a") match {
@@ -697,7 +697,7 @@ object Std {
           }
         } else {
           val keyFFunc = keyF.asInstanceOf[Val.Func]
-          val keyFApplyer = Applyer(keyFFunc, ev, null)
+          val keyFApplyer = Applyer(keyFFunc, ev, fs)
           val appliedX = keyFApplyer.apply(v)
 
           if (b.exists(value => {
@@ -712,7 +712,7 @@ object Std {
         }
       }
 
-      sortArr(pos, ev, Val.Arr(pos, out.toArray), keyF)
+      sortArr(pos, ev, Val.Arr(pos, out.toArray), keyF, fs)
     },
     builtinWithDefaults("setDiff", "a" -> null, "b" -> null, "keyF" -> Val.False(dummyPos)) { (pos, args, fs, ev) =>
 
@@ -742,7 +742,7 @@ object Std {
           }
         } else {
           val keyFFunc = keyF.asInstanceOf[Val.Func]
-          val keyFApplyer = Applyer(keyFFunc, ev, null)
+          val keyFApplyer = Applyer(keyFFunc, ev, fs)
           val appliedX = keyFApplyer.apply(v)
 
           if (!b.exists(value => {
@@ -757,7 +757,7 @@ object Std {
         }
       }
 
-      sortArr(pos, ev, Val.Arr(pos, out.toArray), keyF)
+      sortArr(pos, ev, Val.Arr(pos, out.toArray), keyF, fs)
     },
     builtinWithDefaults("setMember", "x" -> null, "arr" -> null, "keyF" -> Val.False(dummyPos)) { (pos, args, fs, ev) =>
       val keyF = args("keyF")
@@ -770,7 +770,7 @@ object Std {
         val x: Val.Lazy = () => args("x")
         val arr = args("arr").asInstanceOf[Val.Arr].value
         val keyFFunc = keyF.asInstanceOf[Val.Func]
-        val keyFApplyer = Applyer(keyFFunc, ev, null)
+        val keyFApplyer = Applyer(keyFFunc, ev, fs)
         val appliedX = keyFApplyer.apply(x)
         arr.exists(value => {
           val appliedValue = keyFApplyer.apply(value)
@@ -779,7 +779,7 @@ object Std {
       }
     },
 
-    "split" -> Val.Func(null, null, Params.mk(("str", null, 0), ("c", null, 1)), { (scope, thisFile, ev, fs, pos) =>
+    "split" -> Val.Func(null, null, Params.mk(("str", null, 0), ("c", null, 1)), { (scope, ev, fs, pos) =>
       val str = implicitly[ReadWriter[String]].apply(scope.bindings(0).force, ev, fs)
       val cStr = implicitly[ReadWriter[String]].apply(scope.bindings(1).force, ev, fs)
       if(cStr.length != 1) throw new Error.Delegate("std.split second parameter should have length 1, got "+cStr.length)
@@ -865,9 +865,9 @@ object Std {
     "trace" -> Val.Func(
       null, null,
       Params.mk(("str", null, 0), ("rest", null, 1)),
-      { (scope, thisFile, ev, fs, outerOffset) =>
+      { (scope, ev, fs, outerPos) =>
         val Val.Str(_, msg) = scope.bindings(0).force
-        System.err.println(s"TRACE: $thisFile " + msg)
+        System.err.println(s"TRACE: ${outerPos.fileScope.currentFileLastPathElement} " + msg)
         scope.bindings(1).force
       }
     ),
@@ -875,7 +875,7 @@ object Std {
     "extVar" -> Val.Func(
       null, null,
       Params.mk(("x", null, 0)),
-      { (scope, thisFile, ev, fs, outerPos) =>
+      { (scope, ev, fs, outerPos) =>
         val Val.Str(_, x) = scope.bindings(0).force
         Materializer.reverse(
           outerPos,
@@ -921,7 +921,7 @@ object Std {
     (name, Val.Func(
       null, null,
       Params(params, new Array[Expr](params.length), params.indices.toArray),
-      { (scope, thisFile, ev, fs, outerPos) =>
+      { (scope, ev, fs, outerPos) =>
         val v1: T1 = implicitly[ReadWriter[T1]].apply(scope.bindings(0).force, ev, fs)
         implicitly[ReadWriter[R]].write(outerPos, eval(outerPos, ev, fs, v1))
       }
@@ -934,7 +934,7 @@ object Std {
     (name, Val.Func(
       null, null,
       Params(params, new Array[Expr](params.length), params.indices.toArray),
-      { (scope, thisFile, ev, fs, outerPos) =>
+      { (scope, ev, fs, outerPos) =>
         //println("--- calling builtin: "+name)
         val v1: T1 = implicitly[ReadWriter[T1]].apply(scope.bindings(0).force, ev, fs)
         val v2: T2 = implicitly[ReadWriter[T2]].apply(scope.bindings(1).force, ev, fs)
@@ -949,7 +949,7 @@ object Std {
     (name, Val.Func(
       null, null,
       Params(params, new Array[Expr](params.length), params.indices.toArray),
-      { (scope, thisFile, ev, fs, outerPos) =>
+      { (scope, ev, fs, outerPos) =>
         val v1: T1 = implicitly[ReadWriter[T1]].apply(scope.bindings(0).force, ev, fs)
         val v2: T2 = implicitly[ReadWriter[T2]].apply(scope.bindings(1).force, ev, fs)
         val v3: T3 = implicitly[ReadWriter[T3]].apply(scope.bindings(2).force, ev, fs)
@@ -970,7 +970,7 @@ object Std {
     name -> Val.Func(
       null, null,
       Params.mk(indexedParams: _*),
-      { (scope, thisFile, ev, fs, outerPos) =>
+      { (scope, ev, fs, outerPos) =>
         val args = indexedParamKeys.map {case (k, i) => k -> scope.bindings(i).force }.toMap
         implicitly[ReadWriter[R]].write(outerPos, eval(outerPos, args, fs, ev))
       },
@@ -984,7 +984,7 @@ object Std {
     )
   }
 
-  def uniqArr(pos: Position, ev: EvalScope, arr: Val, keyF: Val) = {
+  def uniqArr(pos: Position, ev: EvalScope, arr: Val, keyF: Val, fs: FileScope) = {
     val arrValue = arr match {
       case arr: Val.Arr => arr.value
       case str: Val.Str => stringChars(pos, str.value).value
@@ -1001,12 +1001,12 @@ object Std {
         }
       } else if (!keyF.isInstanceOf[Val.False]) {
         val keyFFunc = keyF.asInstanceOf[Val.Func]
-        val keyFApplyer = Applyer(keyFFunc, ev, null)
+        val keyFApplyer = Applyer(keyFFunc, ev, fs)
 
         val o1Key = keyFApplyer.apply(v)
         val o2Key = keyFApplyer.apply(out.last)
-        val o1KeyExpr = Materializer.toExpr(Materializer.apply(o1Key)(ev))
-        val o2KeyExpr = Materializer.toExpr(Materializer.apply(o2Key)(ev))
+        val o1KeyExpr = Materializer.toExpr(Materializer.apply(o1Key)(ev))(ev)
+        val o2KeyExpr = Materializer.toExpr(Materializer.apply(o2Key)(ev))(ev)
 
         val comparisonExpr = Expr.BinaryOp(dummyPos, o1KeyExpr, BinaryOp.`!=`, o2KeyExpr)
         val exprResult = ev.visitExpr(comparisonExpr)(scope(0))
@@ -1022,7 +1022,7 @@ object Std {
     Val.Arr(pos, out.toArray)
   }
 
-  def sortArr(pos: Position, ev: EvalScope, arr: Val, keyF: Val) = {
+  def sortArr(pos: Position, ev: EvalScope, arr: Val, keyF: Val, fs: FileScope) = {
     arr match{
       case Val.Arr(_, vs) =>
         Val.Arr(
@@ -1039,7 +1039,7 @@ object Std {
               val objs = vs.map(_.force.cast[Val.Obj])
 
               val keyFFunc = keyF.asInstanceOf[Val.Func]
-              val keyFApplyer = Applyer(keyFFunc, ev, null)
+              val keyFApplyer = Applyer(keyFFunc, ev, fs)
               val keys = objs.map((v) => keyFApplyer((() => v): Val.Lazy))
 
               if (keys.forall(_.isInstanceOf[Val.Str])){

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -138,7 +138,7 @@ object Std {
             case (_, Some(rChild)) => k -> createMember{recSingle(rChild)}
           }
 
-          new Val.Obj(mergePosition, mutable.LinkedHashMap(kvs:_*), _ => (), None)
+          new Val.Obj(mergePosition, mutable.LinkedHashMap(kvs:_*), _ => (), null)
 
         case (_, _) => recSingle(r)
       }
@@ -150,7 +150,7 @@ object Std {
             if !value.isInstanceOf[Val.Null]
           } yield (k, createMember{recSingle(value)})
 
-          new Val.Obj(obj.pos, mutable.LinkedHashMap(kvs:_*), _ => (), None)
+          new Val.Obj(obj.pos, mutable.LinkedHashMap(kvs:_*), _ => (), null)
 
         case _ => v
       }
@@ -285,7 +285,7 @@ object Std {
           ))
         },
         _ => (),
-        None
+        null
       )
     },
     builtin("mapWithIndex", "func", "arr"){ (pos, ev, fs, func: Applyer, arr: Val.Arr) =>
@@ -799,7 +799,7 @@ object Std {
               .mapValues { v =>
                 Val.Obj.Member(false, Expr.Member.Visibility.Normal, (_, _, _, _) => recursiveTransform(v))
               }
-            new Val.Obj(pos, transformedValue , (x: Val.Obj) => (), None)
+            new Val.Obj(pos, transformedValue , (x: Val.Obj) => (), null)
         }
       }
       recursiveTransform(ujson.read(str))
@@ -822,7 +822,7 @@ object Std {
             v = rec(o.value(k, Position(pos.currentFile, -1))(fs, ev))
             if filter(v)
           }yield (k, Val.Obj.Member(false, Visibility.Normal, (_, _, _, _) => v))
-          new Val.Obj(pos, mutable.LinkedHashMap() ++ bindings, _ => (), None)
+          new Val.Obj(pos, mutable.LinkedHashMap() ++ bindings, _ => (), null)
         case a: Val.Arr =>
           Val.Arr(pos, a.value.map(x => rec(x.force)).filter(filter).map(Val.Lazy(_)))
         case _ => x
@@ -887,7 +887,7 @@ object Std {
       )
     ),
     _ => (),
-    None
+    null
   )
 
   def validate(vs: Array[Val],
@@ -966,7 +966,7 @@ object Std {
 
   def scope(size: Int) = {
     new ValScope(
-      None, None, None, Array(Val.Lazy(Std)).padTo(size, null)
+      null, null, null, Array(Val.Lazy(Std)).padTo(size, null)
     )
   }
 

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -894,15 +894,20 @@ object Std {
   def validate(vs: Array[Val],
                ev: EvalScope,
                fs: FileScope,
-               rs: Array[ReadWriter[_]]) = {
-    for(i <- vs.indices) yield {
+               rs: Array[ReadWriter[_]]): Seq[Any] = {
+    var i = 0
+    val size = vs.size
+    val ret = new Array[Any](size)
+    while (i < size) {
       val v = vs(i)
       val r = rs(i)
       r.apply(v, ev, fs) match {
         case Left(err) => throw new Error.Delegate("Wrong parameter type: expected " + err + ", got " + v.prettyName)
-        case Right(x) => x
+        case Right(x) => ret(i) = x
       }
+      i += 1
     }
+    ret
   }
 
   def builtin[R: ReadWriter, T1: ReadWriter](name: String, p1: String)

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -410,11 +410,13 @@ object Std {
         case Val.Str(_, s) =>
           val b = new java.lang.StringBuilder()
           var i = 0
+          var added = false
           while(i < arr.value.length) {
             arr.value(i).force match {
               case _: Val.Null =>
               case Val.Str(_, x) =>
-                if(b.length() > 0) b.append(s)
+                if(added) b.append(s)
+                added = true
                 b.append(x)
               case x => throw new Error.Delegate("Cannot join " + x.prettyName)
             }
@@ -423,11 +425,13 @@ object Std {
           Val.Str(pos, b.toString)
         case Val.Arr(_, sep) =>
           val out = new mutable.ArrayBuffer[Val.Lazy]
+          var added = false
           for(x <- arr.value){
             x.force match{
               case Val.Null(_) => // do nothing
               case Val.Arr(_, v) =>
-                if (out.nonEmpty) out.appendAll(sep)
+                if (added) out.appendAll(sep)
+                added = true
                 out.appendAll(v)
               case x => throw new Error.Delegate("Cannot join " + x.prettyName)
             }

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -44,7 +44,7 @@ object Std {
         case Val.Str(_, s) => s.length
         case Val.Arr(_, s) => s.length
         case o: Val.Obj => o.getVisibleKeys().count(!_._2)
-        case o: Val.Func => o.params.args.length
+        case o: Val.Func => o.params.names.length
         case _ => throw new Error.Delegate("Cannot get length of " + v1.prettyName)
       }
     },
@@ -836,7 +836,7 @@ object Std {
     "trace" -> Val.Func(
       null,
       None,
-      Params(Array(("str", None, 0), ("rest", None, 1))),
+      Params.mk(("str", None, 0), ("rest", None, 1)),
       { (scope, thisFile, ev, fs, outerOffset) =>
         val Val.Str(_, msg) = scope.bindings(0).get.force
         System.err.println(s"TRACE: $thisFile " + msg)
@@ -847,7 +847,7 @@ object Std {
     "extVar" -> Val.Func(
       null,
       None,
-      Params(Array(("x", None, 0))),
+      Params.mk(("x", None, 0)),
       { (scope, thisFile, ev, fs, outerOffset) =>
         val Val.Str(_, x) = scope.bindings(0).get.force
         Materializer.reverse(
@@ -933,7 +933,7 @@ object Std {
     name -> Val.Func(
       null,
       None,
-      Params(paramData),
+      Params.mk(paramData: _*),
       {(scope, thisFile, ev, fs, outerOffset) =>
         implicitly[ReadWriter[R]].write(
           Position(fs.currentFile, outerOffset),
@@ -954,7 +954,7 @@ object Std {
     name -> Val.Func(
       null,
       None,
-      Params(indexedParams),
+      Params.mk(indexedParams: _*),
       { (scope, thisFile, ev, fs, outerOffset) =>
         val args = indexedParamKeys.map {case (k, i) => k -> scope.bindings(i).get.force }.toMap
         implicitly[ReadWriter[R]].write(Position(fs.currentFile, outerOffset), eval(outerOffset, args, fs, ev))

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -130,8 +130,8 @@ object Std {
         case (l: Val.Obj, r: Val.Obj) =>
           val kvs = for {
             k <- (getNonHiddenKeys(l) ++ getNonHiddenKeys(r)).distinct
-            val lValue = l.valueRaw(k, l, pos)(ev).map(_._1)
-            val rValue = r.valueRaw(k, r, pos)(ev).map(_._1)
+            val lValue = Option(l.valueRaw(k, l, pos)(ev))
+            val rValue = Option(r.valueRaw(k, r, pos)(ev))
             if !rValue.exists(_.isInstanceOf[Val.Null])
           } yield (lValue, rValue) match{
             case (Some(lChild), None) => k -> createMember{lChild}

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -277,7 +277,7 @@ object Std {
         pos,
         mutable.LinkedHashMap() ++
         allKeys.map{ k =>
-          k._1 -> (Val.Obj.Member(false, Visibility.Normal, (self: Val.Obj, sup: Option[Val.Obj], _, _) =>
+          k._1 -> (Val.Obj.Member(false, Visibility.Normal, (self: Val.Obj, sup: Val.Obj, _, _) =>
             func.apply(
               Val.Lazy(Val.Str(pos, k._1)),
               Val.Lazy(obj.value(k._1, new Position(fs.currentFile, -1))(fs,ev))
@@ -870,7 +870,7 @@ object Std {
             Val.Obj.Member(
               false,
               Visibility.Hidden,
-              (self: Val.Obj, sup: Option[Val.Obj], _, _) => v
+              (self: Val.Obj, sup: Val.Obj, _, _) => v
             )
           )
       } ++ Seq(
@@ -879,7 +879,7 @@ object Std {
         Val.Obj.Member(
           false,
           Visibility.Hidden,
-          { (self: Val.Obj, sup: Option[Val.Obj], fs: FileScope, eval: EvalScope) =>
+          { (self: Val.Obj, sup: Val.Obj, fs: FileScope, eval: EvalScope) =>
             Val.Str(self.pos, fs.currentFile.relativeToString(eval.wd))
           },
           cached = false

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -842,9 +842,9 @@ object Std {
       null, null,
       Params.mk(("str", None, 0), ("rest", None, 1)),
       { (scope, thisFile, ev, fs, outerOffset) =>
-        val Val.Str(_, msg) = scope.bindings(0).get.force
+        val Val.Str(_, msg) = scope.bindings(0).force
         System.err.println(s"TRACE: $thisFile " + msg)
-        scope.bindings(1).get.force
+        scope.bindings(1).force
       }
     ),
 
@@ -852,7 +852,7 @@ object Std {
       null, null,
       Params.mk(("x", None, 0)),
       { (scope, thisFile, ev, fs, outerPos) =>
-        val Val.Str(_, x) = scope.bindings(0).get.force
+        val Val.Str(_, x) = scope.bindings(0).force
         Materializer.reverse(
           outerPos,
           ev.extVars.getOrElse(
@@ -939,7 +939,7 @@ object Std {
       {(scope, thisFile, ev, fs, outerPos) =>
         implicitly[ReadWriter[R]].write(
           outerPos,
-          eval(outerPos, paramIndices.map(i => scope.bindings(i).get.force), ev, fs)
+          eval(outerPos, paramIndices.map(i => scope.bindings(i).force), ev, fs)
         )
       }
     )
@@ -957,7 +957,7 @@ object Std {
       null, null,
       Params.mk(indexedParams: _*),
       { (scope, thisFile, ev, fs, outerPos) =>
-        val args = indexedParamKeys.map {case (k, i) => k -> scope.bindings(i).get.force }.toMap
+        val args = indexedParamKeys.map {case (k, i) => k -> scope.bindings(i).force }.toMap
         implicitly[ReadWriter[R]].write(outerPos, eval(outerPos, args, fs, ev))
       },
       { (expr, scope, eval) =>

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -842,7 +842,7 @@ object Std {
     builtin("asciiLower", "str"){ (pos, ev, fs, str: String) => str.toLowerCase()},
     "trace" -> Val.Func(
       null,
-      None,
+      null, null,
       Params.mk(("str", None, 0), ("rest", None, 1)),
       { (scope, thisFile, ev, fs, outerOffset) =>
         val Val.Str(_, msg) = scope.bindings(0).get.force
@@ -853,7 +853,7 @@ object Std {
 
     "extVar" -> Val.Func(
       null,
-      None,
+      null, null,
       Params.mk(("x", None, 0)),
       { (scope, thisFile, ev, fs, outerPos) =>
         val Val.Str(_, x) = scope.bindings(0).get.force
@@ -939,7 +939,7 @@ object Std {
     val paramIndices = params.indices.toArray
     name -> Val.Func(
       null,
-      None,
+      null, null,
       Params.mk(paramData: _*),
       {(scope, thisFile, ev, fs, outerPos) =>
         implicitly[ReadWriter[R]].write(
@@ -960,7 +960,7 @@ object Std {
     val indexedParamKeys = params.zipWithIndex.map{case ((k, v), i) => (k, i)}
     name -> Val.Func(
       null,
-      None,
+      null, null,
       Params.mk(indexedParams: _*),
       { (scope, thisFile, ev, fs, outerPos) =>
         val args = indexedParamKeys.map {case (k, i) => k -> scope.bindings(i).get.force }.toMap

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -6,7 +6,8 @@ import java.util.Base64
 import java.util.zip.GZIPOutputStream
 
 import sjsonnet.Expr.Member.Visibility
-import sjsonnet.Expr.{BinaryOp, False, Params}
+import sjsonnet.Expr.{BinaryOp, Params}
+import sjsonnet.Val.False
 
 import scala.collection.mutable
 import scala.collection.compat._
@@ -526,7 +527,7 @@ object Std {
     },
     builtinWithDefaults("manifestYamlDoc",
                         "v" -> None,
-                        "indent_array_in_object" -> Some(Expr.False(dummyPos))){ (pos, args, fs, ev) =>
+                        "indent_array_in_object" -> Some(Val.False(dummyPos))){ (pos, args, fs, ev) =>
       val v = args("v")
       val indentArrayInObject = args("indent_array_in_object")  match {
           case Val.False(_) => false
@@ -540,7 +541,7 @@ object Std {
     },
     builtinWithDefaults("manifestYamlStream",
                         "v" -> None,
-                        "indent_array_in_object" -> Some(Expr.False(dummyPos))){ (pos, args, fs, ev) =>
+                        "indent_array_in_object" -> Some(Val.False(dummyPos))){ (pos, args, fs, ev) =>
       val v = args("v")
       val indentArrayInObject = args("indent_array_in_object")  match {
         case Val.False(_) => false
@@ -627,23 +628,23 @@ object Std {
       new String(arr.value.map(_.force.cast[Val.Num].value.toByte).toArray, UTF_8)
     },
 
-    builtinWithDefaults("uniq", "arr" -> None, "keyF" -> Some(Expr.False(dummyPos))) { (pos, args, fs, ev) =>
+    builtinWithDefaults("uniq", "arr" -> None, "keyF" -> Some(Val.False(dummyPos))) { (pos, args, fs, ev) =>
       val arr = args("arr")
       val keyF = args("keyF")
 
       uniqArr(pos, ev, arr, keyF)
     },
-    builtinWithDefaults("sort", "arr" -> None, "keyF" -> Some(Expr.False(dummyPos))) { (pos, args, fs, ev) =>
+    builtinWithDefaults("sort", "arr" -> None, "keyF" -> Some(Val.False(dummyPos))) { (pos, args, fs, ev) =>
       val arr = args("arr")
       val keyF = args("keyF")
 
       sortArr(pos, ev, arr, keyF)
     },
 
-    builtinWithDefaults("set", "arr" -> None, "keyF" -> Some(Expr.False(dummyPos))) { (pos, args, fs, ev) =>
+    builtinWithDefaults("set", "arr" -> None, "keyF" -> Some(Val.False(dummyPos))) { (pos, args, fs, ev) =>
       uniqArr(pos, ev, sortArr(pos, ev, args("arr"), args("keyF")), args("keyF"))
     },
-    builtinWithDefaults("setUnion", "a" -> None, "b" -> None, "keyF" -> Some(Expr.False(dummyPos))) { (pos, args, fs, ev) =>
+    builtinWithDefaults("setUnion", "a" -> None, "b" -> None, "keyF" -> Some(Val.False(dummyPos))) { (pos, args, fs, ev) =>
       val a = args("a") match {
         case arr: Val.Arr => arr.value
         case str: Val.Str => stringChars(pos, str.value).value
@@ -658,7 +659,7 @@ object Std {
       val concat = Val.Arr(pos, a ++ b)
       uniqArr(pos, ev, sortArr(pos, ev, concat, args("keyF")), args("keyF"))
     },
-    builtinWithDefaults("setInter", "a" -> None, "b" -> None, "keyF" -> Some(Expr.False(dummyPos))) { (pos, args, fs, ev) =>
+    builtinWithDefaults("setInter", "a" -> None, "b" -> None, "keyF" -> Some(Val.False(dummyPos))) { (pos, args, fs, ev) =>
       val a = args("a") match {
         case arr: Val.Arr => arr.value
         case str: Val.Str => stringChars(pos, str.value).value
@@ -704,7 +705,7 @@ object Std {
 
       sortArr(pos, ev, Val.Arr(pos, out.toArray), keyF)
     },
-    builtinWithDefaults("setDiff", "a" -> None, "b" -> None, "keyF" -> Some(Expr.False(dummyPos))) { (pos, args, fs, ev) =>
+    builtinWithDefaults("setDiff", "a" -> None, "b" -> None, "keyF" -> Some(Val.False(dummyPos))) { (pos, args, fs, ev) =>
 
       val a = args("a") match {
         case arr: Val.Arr => arr.value
@@ -751,7 +752,7 @@ object Std {
 
       sortArr(pos, ev, Val.Arr(pos, out.toArray), keyF)
     },
-    builtinWithDefaults("setMember", "x" -> None, "arr" -> None, "keyF" -> Some(Expr.False(dummyPos))) { (pos, args, fs, ev) =>
+    builtinWithDefaults("setMember", "x" -> None, "arr" -> None, "keyF" -> Some(Val.False(dummyPos))) { (pos, args, fs, ev) =>
       val keyF = args("keyF")
 
       if (keyF.isInstanceOf[Val.False]) {

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -138,7 +138,7 @@ object Std {
             case (_, Some(rChild)) => k -> createMember{recSingle(rChild)}
           }
 
-          new Val.Obj(mergePosition, mutable.LinkedHashMap(kvs:_*), _ => (), null)
+          new Val.Obj(mergePosition, mutable.LinkedHashMap(kvs:_*), null, null)
 
         case (_, _) => recSingle(r)
       }
@@ -150,7 +150,7 @@ object Std {
             if !value.isInstanceOf[Val.Null]
           } yield (k, createMember{recSingle(value)})
 
-          new Val.Obj(obj.pos, mutable.LinkedHashMap(kvs:_*), _ => (), null)
+          new Val.Obj(obj.pos, mutable.LinkedHashMap(kvs:_*), null, null)
 
         case _ => v
       }
@@ -291,7 +291,7 @@ object Std {
             )
           ))
         },
-        _ => (),
+        null,
         null
       )
     },
@@ -806,7 +806,7 @@ object Std {
               .mapValues { v =>
                 Val.Obj.Member(false, Expr.Member.Visibility.Normal, (_, _, _, _) => recursiveTransform(v))
               }
-            new Val.Obj(pos, transformedValue , (x: Val.Obj) => (), null)
+            new Val.Obj(pos, transformedValue , null, null)
         }
       }
       recursiveTransform(ujson.read(str))
@@ -828,7 +828,7 @@ object Std {
             v = rec(o.value(k, pos.fileScope.noOffsetPos)(ev))
             if filter(v)
           }yield (k, Val.Obj.Member(false, Visibility.Normal, (_, _, _, _) => v))
-          new Val.Obj(pos, mutable.LinkedHashMap() ++ bindings, _ => (), null)
+          new Val.Obj(pos, mutable.LinkedHashMap() ++ bindings, null, null)
         case a: Val.Arr =>
           Val.Arr(pos, a.value.map(x => rec(x.force)).filter(filter).map(x => (() => x): Val.Lazy))
         case _ => x
@@ -890,7 +890,7 @@ object Std {
         )
       )
     ),
-    _ => (),
+    null,
     null
   )
 

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -349,7 +349,7 @@ object Std {
       while(i < a.length) {
         if(ev.equal(a(i).force, value)) {
           val finalI = i
-          b.addOne(() => Val.Num(pos, finalI))
+          b.+=(() => Val.Num(pos, finalI))
         }
         i += 1
       }
@@ -790,12 +790,12 @@ object Std {
       while(i < str.length) {
         if(str.charAt(i) == c) {
           val finalStr = Val.Str(pos, str.substring(start, i))
-          b.addOne(() => finalStr)
+          b.+=(() => finalStr)
           start = i+1
         }
         i += 1
       }
-      b.addOne(() => Val.Str(pos, str.substring(start, math.min(i, str.length))))
+      b.+=(() => Val.Str(pos, str.substring(start, math.min(i, str.length))))
       Val.Arr(pos, b.result())
     }),
     builtin("splitLimit", "str", "c", "maxSplits"){ (pos, ev, fs, str: String, c: String, maxSplits: Int) =>

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -188,15 +188,6 @@ object Val{
       } else throw new MatchError((l, r))
     }
 
-    @tailrec def valueCached(k: String): Option[Boolean] = this.value0.get(k) match{
-      case Some(m) => Some(m.cached)
-
-      case None => this.`super` match{
-        case null => None
-        case s => s.valueCached(k)
-      }
-    }
-
     def valueRaw(k: String,
                  self: Obj,
                  pos: Position,
@@ -432,10 +423,7 @@ class ValScope(val dollar0: Val.Obj,
                val super0: Val.Obj,
                bindings0: Array[Val.Lazy]) {
 
-  def bindings(k: Int): Option[Val.Lazy] = bindings0(k) match{
-    case null => None
-    case v => Some(v)
-  }
+  def bindings(k: Int): Val.Lazy = bindings0(k)
 
   def extend(newBindingsI: Array[Expr.Bind] = null,
              newBindingsF: Array[(Val.Obj, Val.Obj) => Val.Lazy] = null,
@@ -465,31 +453,21 @@ class ValScope(val dollar0: Val.Obj,
   def extendSimple(newBindingsI: Array[Int],
                    newBindingsV: Array[Val.Lazy]) = {
     if(newBindingsI == null || newBindingsI.length == 0) this
-    else new ValScope(
-      dollar0,
-      self0,
-      super0,
-      {
-        val b = bindings0.clone()
-        var i = 0
-        while(i < newBindingsI.length) {
-          b(newBindingsI(i)) = newBindingsV(i)
-          i += 1
-        }
-        b
+    else {
+      val b = bindings0.clone()
+      var i = 0
+      while(i < newBindingsI.length) {
+        b(newBindingsI(i)) = newBindingsV(i)
+        i += 1
       }
-    )
+      new ValScope(dollar0, self0, super0, b)
+    }
   }
 
   def extendSimple(newBindingI: Int,
-                   newBindingV: Val.Lazy) = new ValScope(
-    dollar0,
-    self0,
-    super0,
-    {
-      val b = bindings0.clone()
-      b(newBindingI) = newBindingV
-      b
-    }
-  )
+                   newBindingV: Val.Lazy) = {
+    val b = bindings0.clone()
+    b(newBindingI) = newBindingV
+    new ValScope(dollar0, self0, super0, b)
+  }
 }

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -86,17 +86,14 @@ object Val{
     def getSuper = `super`
 
     @tailrec def triggerAllAsserts(obj: Val.Obj): Unit = {
-      triggerAsserts(obj)
-      `super` match {
-        case null =>
-        case s => s.triggerAllAsserts(obj)
-      }
+      if(triggerAsserts != null) triggerAsserts(obj)
+      if(`super` != null) `super`.triggerAllAsserts(obj)
     }
 
     def addSuper(pos: Position, lhs: Val.Obj): Val.Obj = {
       `super` match{
-        case null => new Val.Obj(pos, value0, _ => (), lhs)
-        case x => new Val.Obj(pos, value0, _ => (), x.addSuper(pos, lhs))
+        case null => new Val.Obj(pos, value0, null, lhs)
+        case x => new Val.Obj(pos, value0, null, x.addSuper(pos, lhs))
       }
     }
 

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -204,12 +204,13 @@ object Val{
         case null =>
           if(s == null) null else s.valueRaw(k, self, pos, addTo, addKey)
         case m =>
+          val vv = m.invoke(self, s, pos.fileScope, evaluator)
           val v = if(s != null && m.add) {
             s.valueRaw(k, self, pos, null, null) match {
-              case null => m.invoke(self, s, pos.fileScope, evaluator)
-              case supValue => mergeMember(supValue, m.invoke(self, s, pos.fileScope, evaluator), pos)
+              case null => vv
+              case supValue => mergeMember(supValue, vv, pos)
             }
-          } else m.invoke(self, s, pos.fileScope, evaluator)
+          } else vv
           if(addTo != null && m.cached) addTo(addKey) = v
           v
       }

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -419,7 +419,7 @@ class ValScope(val dollar0: Val.Obj,
     case v => Some(v)
   }
 
-  def extend(newBindingsI: Array[Int] = null,
+  def extend(newBindingsI: Array[Expr.Bind] = null,
              newBindingsF: Array[(Val.Obj, Val.Obj) => Val.Lazy] = null,
              newDollar: Val.Obj = null,
              newSelf: Val.Obj = null,
@@ -436,7 +436,7 @@ class ValScope(val dollar0: Val.Obj,
         val b = bindings0.clone()
         var i = 0
         while(i < newBindingsI.length) {
-          b(newBindingsI(i)) = newBindingsF(i).apply(self, sup)
+          b(newBindingsI(i).name) = newBindingsF(i).apply(self, sup)
           i += 1
         }
         b

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -106,8 +106,8 @@ object Val{
 
     def prettyName = "object"
 
-    private def gatherVisibleKeys(mapping: util.LinkedHashMap[String, java.lang.Boolean]): Unit = {
-      if(`super` != null) `super`.gatherVisibleKeys(mapping)
+    private def gatherKeys(mapping: util.LinkedHashMap[String, java.lang.Boolean]): Unit = {
+      if(`super` != null) `super`.gatherKeys(mapping)
       value0.forEach { (k, m) =>
         val vis = m.visibility
         if(!mapping.containsKey(k)) mapping.put(k, vis == Visibility.Hidden)
@@ -116,33 +116,23 @@ object Val{
       }
     }
 
-    lazy val visibleKeys = {
+    private lazy val allKeys = {
       val m = new util.LinkedHashMap[String, java.lang.Boolean]
-      gatherVisibleKeys(m)
+      gatherKeys(m)
       m
     }
 
-    def getVisibleKeyNamesArray = visibleKeys.keySet().toArray(new Array[String](visibleKeys.size()))
+    @inline def hasKeys = !allKeys.isEmpty
 
-    def getVisibleKeysNonHiddenCount = {
-      var c = 0
-      visibleKeys.values().forEach(b => if(b == java.lang.Boolean.FALSE) c += 1)
-      c
-    }
+    @inline def containsKey(k: String): Boolean = allKeys.containsKey(k)
 
-    def getVisibleKeys: Array[(String, java.lang.Boolean)] = {
-      val a = new Array[(String, java.lang.Boolean)](visibleKeys.size())
-      var i = 0
-      visibleKeys.forEach { (k, b) =>
-        a(i) = (k, b)
-        i += 1
-      }
-      a
-    }
+    @inline def containsVisibleKey(k: String): Boolean = allKeys.get(k) == java.lang.Boolean.FALSE
 
-    def getVisibleKeysNonHidden: Array[String] = {
+    lazy val allKeyNames: Array[String] = allKeys.keySet().toArray(new Array[String](allKeys.size()))
+
+    lazy val visibleKeyNames: Array[String] = {
       val buf = mutable.ArrayBuilder.make[String]
-      visibleKeys.forEach((k, b) => if(b == java.lang.Boolean.FALSE) buf += k)
+      allKeys.forEach((k, b) => if(b == java.lang.Boolean.FALSE) buf += k)
       buf.result()
     }
 

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -261,18 +261,25 @@ object Val{
         var max = -1
         val builder = new Array[(Int, (Option[Val.Obj], Option[Val.Obj]) => Lazy)](defaultArgsBindings.size + passedArgsBindings.size)
         var idx = 0
-        for(t <- defaultArgsBindings) {
+
+        var defaultBindingsIdx = 0
+        while (defaultBindingsIdx < defaultArgsBindings.size) {
+          val t = defaultArgsBindings(defaultBindingsIdx)
           val (i, v) = t
           if (i > max) max = i
           builder(idx) = (i, (self: Option[Val.Obj], sup: Option[Val.Obj]) => v)
           idx += 1
+          defaultBindingsIdx += 1
         }
 
-        for(t <- passedArgsBindings) {
+        var passedArgsBindingsIdx = 0
+        while(passedArgsBindingsIdx < passedArgsBindings.size) {
+          val t = passedArgsBindings(passedArgsBindingsIdx)
           val (i, v) = t
           if (i > max) max = i
           builder(idx) = (i, (self: Option[Val.Obj], sup: Option[Val.Obj]) => v)
           idx += 1
+          passedArgsBindingsIdx += 1
         }
 
         defSiteScopes match{

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -348,7 +348,10 @@ trait EvalScope extends EvalErrorScope{
 
   def materialize(v: Val): ujson.Value
 
+  def equal(x: Val, y: Val): Boolean
+
   val emptyMaterializeFileScope = new FileScope(wd / "(materialize)", Map())
+  val emptyMaterializeFileScopePos = new Position(emptyMaterializeFileScope, -1)
 
   val preserveOrder: Boolean = false
 }

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -39,11 +39,13 @@ object Val{
     * evaluated dictionary values, array contents, or function parameters
     * are all wrapped in [[Lazy]] and only truly evaluated on-demand
     */
-  class Lazy(calc0: => Val){
-    lazy val force = calc0
-  }
-  object Lazy{
-    def apply(calc0: => Val) = new Lazy(calc0)
+  abstract class Lazy {
+    private[this] var cached: Val = null
+    def compute(): Val
+    def force: Val = {
+      if(cached == null) cached = compute()
+      cached
+    }
   }
 
   def bool(pos: Position, b: Boolean) = if (b) True(pos) else False(pos)
@@ -219,7 +221,7 @@ object Val{
         val arr = new Array[Lazy](params.defaultsOnly.length)
         while (idx < params.defaultsOnly.length) {
           val default = params.defaultsOnly(idx)
-          arr(idx) = Lazy(evalDefault(default, newScope, evaluator))
+          arr(idx) = () => evalDefault(default, newScope, evaluator)
           idx += 1
         }
         arr

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -259,17 +259,20 @@ object Val{
 
       lazy val newScope: ValScope = {
         var max = -1
-        val builder = Array.newBuilder[(Int, (Option[Val.Obj], Option[Val.Obj]) => Lazy)]
-        for(t <- defaultArgsBindings){
+        val builder = new Array[(Int, (Option[Val.Obj], Option[Val.Obj]) => Lazy)](defaultArgsBindings.size + passedArgsBindings.size)
+        var idx = 0
+        for(t <- defaultArgsBindings) {
           val (i, v) = t
           if (i > max) max = i
-          builder += (i, (self: Option[Val.Obj], sup: Option[Val.Obj]) => v)
+          builder(idx) = (i, (self: Option[Val.Obj], sup: Option[Val.Obj]) => v)
+          idx += 1
         }
 
-        for(t <- passedArgsBindings){
+        for(t <- passedArgsBindings) {
           val (i, v) = t
           if (i > max) max = i
-          builder += (i, (self: Option[Val.Obj], sup: Option[Val.Obj]) => v)
+          builder(idx) = (i, (self: Option[Val.Obj], sup: Option[Val.Obj]) => v)
+          idx += 1
         }
 
         defSiteScopes match{
@@ -279,11 +282,11 @@ object Val{
             None,
             {
               val arr = new Array[Lazy](max + 1)
-              for((i, v) <- builder.result()) arr(i) = v(null, None)
+              for((i, v) <- builder) arr(i) = v(null, None)
               arr
             }
           )
-          case Some((s, fs)) => s.extend(builder.result())
+          case Some((s, fs)) => s.extend(builder)
         }
       }
 

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -15,7 +15,7 @@ import scala.reflect.ClassTag
   * except evaluation of object attributes and array contents are lazy, and
   * the tree can contain functions.
   */
-sealed trait Val{
+sealed abstract class Val {
   def prettyName: String
   def cast[T: ClassTag: PrettyNamed] =
     if (implicitly[ClassTag[T]].runtimeClass.isInstance(this)) this.asInstanceOf[T]
@@ -48,24 +48,27 @@ object Val{
     }
   }
 
+  abstract class Literal extends Val with Expr
+  abstract class Bool extends Literal
+
   def bool(pos: Position, b: Boolean) = if (b) True(pos) else False(pos)
-  sealed trait Bool extends Val{
-  }
-  case class True(pos: Position) extends Bool{
+
+  case class True(pos: Position) extends Bool {
     def prettyName = "boolean"
   }
-  case class False(pos: Position) extends Bool{
+  case class False(pos: Position) extends Bool {
     def prettyName = "boolean"
   }
-  case class Null(pos: Position) extends Val{
+  case class Null(pos: Position) extends Literal {
     def prettyName = "null"
   }
-  case class Str(pos: Position, value: String) extends Val{
+  case class Str(pos: Position, value: String) extends Literal {
     def prettyName = "string"
   }
-  case class Num(pos: Position, value: Double) extends Val{
+  case class Num(pos: Position, value: Double) extends Literal {
     def prettyName = "number"
   }
+
   case class Arr(pos: Position, value: Array[Lazy]) extends Val{
     def prettyName = "array"
   }

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -66,7 +66,7 @@ object Val{
   case class Num(pos: Position, value: Double) extends Val{
     def prettyName = "number"
   }
-  case class Arr(pos: Position, value: Seq[Lazy]) extends Val{
+  case class Arr(pos: Position, value: Array[Lazy]) extends Val{
     def prettyName = "array"
   }
   object Obj{

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -219,13 +219,12 @@ object Val{
   case class Func(pos: Position,
                   defSiteValScope: ValScope,
                   params: Params,
-                  evalRhs: (ValScope, String, EvalScope, FileScope, Position) => Val,
+                  evalRhs: (ValScope, EvalScope, FileScope, Position) => Val,
                   evalDefault: (Expr, ValScope, EvalScope) => Val = null) extends Val {
 
     def prettyName = "function"
 
     def apply(argNames: Array[String], argVals: Array[Lazy],
-              thisFile: String,
               outerPos: Position)
              (implicit evaluator: EvalScope) = {
 
@@ -254,7 +253,6 @@ object Val{
         )
       } else params.indices // Don't cut down to size to avoid copying. The correct size is argVals.length!
 
-      val defaultArgsBindingIndices = params.defaultsOnlyIndices
       val funDefFileScope: FileScope = pos match { case null => outerPos.fileScope case p => p.fileScope }
 
       val newScope: ValScope = {
@@ -264,6 +262,7 @@ object Val{
             case s => s.extendSimple(passedArgsBindingsI, argVals)
           }
         } else {
+          val defaultArgsBindingIndices = params.defaultsOnlyIndices
           lazy val newScope: ValScope = {
             val defaultArgsBindings = new Array[Lazy](params.defaultsOnly.length)
             var idx = 0
@@ -282,7 +281,7 @@ object Val{
         }
       }
 
-      evalRhs(newScope, thisFile, evaluator, funDefFileScope, outerPos)
+      evalRhs(newScope, evaluator, funDefFileScope, outerPos)
     }
 
     def validateFunctionCall(passedArgsBindingsI: Array[Int],

--- a/sjsonnet/test/src-jvm-native/sjsonnet/ErrorTests.scala
+++ b/sjsonnet/test/src-jvm-native/sjsonnet/ErrorTests.scala
@@ -255,7 +255,7 @@ object ErrorTests extends TestSuite{
 
     test("import_wrong_nr_args") - checkImports(
       """|sjsonnet.Error: Function parameter y not bound in call
-         |    at .(sjsonnet/test/resources/imports/defsite.jsonnet:4:23)
+         |    at .(sjsonnet/test/resources/imports/error.import_wrong_nr_args.jsonnet:3:6)
          |    at .(sjsonnet/test/resources/imports/error.import_wrong_nr_args.jsonnet:3:6)
          |""".stripMargin
     )

--- a/sjsonnet/test/src-jvm-native/sjsonnet/MainTests.scala
+++ b/sjsonnet/test/src-jvm-native/sjsonnet/MainTests.scala
@@ -16,9 +16,9 @@ object MainTests extends TestSuite {
       val outF = File.createTempFile("sjsonnet", ".json")
       val out = new ByteArrayOutputStream()
       val pout = new PrintStream(out)
-      SjsonnetMain.main0(Array(source), collection.mutable.Map.empty, System.in, pout, System.err, os.pwd, None)
+      SjsonnetMain.main0(Array(source), collection.mutable.HashMap.empty, System.in, pout, System.err, os.pwd, None)
       pout.flush()
-      SjsonnetMain.main0(Array("-o", outF.getAbsolutePath, source), collection.mutable.Map.empty, System.in, System.out, System.err, os.pwd, None)
+      SjsonnetMain.main0(Array("-o", outF.getAbsolutePath, source), collection.mutable.HashMap.empty, System.in, System.out, System.err, os.pwd, None)
       val stdoutBytes = out.toByteArray
       val fileBytes = os.read(os.Path(outF)).getBytes
       // stdout mode uses println so it has an extra platform-specific line separator at the end

--- a/sjsonnet/test/src/sjsonnet/DummyPath.scala
+++ b/sjsonnet/test/src/sjsonnet/DummyPath.scala
@@ -20,4 +20,11 @@ case class DummyPath(segments: String*) extends Path{
   def renderOffsetStr(offset: Int, loadedFileContents: mutable.HashMap[Path, Array[Int]]): String = {
     segments.mkString("/") + ":" + offset
   }
+
+  override def equals(other: Any): Boolean = other match {
+    case DummyPath(s @ _*) => segments == s
+    case _ => false
+  }
+
+  override def hashCode: Int = segments.hashCode()
 }

--- a/sjsonnet/test/src/sjsonnet/DummyPath.scala
+++ b/sjsonnet/test/src/sjsonnet/DummyPath.scala
@@ -17,7 +17,7 @@ case class DummyPath(segments: String*) extends Path{
 
   def /(s: String): Path = DummyPath(segments :+ s:_*)
 
-  def renderOffsetStr(offset: Int, loadedFileContents: mutable.Map[Path, Array[Int]]): String = {
+  def renderOffsetStr(offset: Int, loadedFileContents: mutable.HashMap[Path, Array[Int]]): String = {
     segments.mkString("/") + ":" + offset
   }
 }

--- a/sjsonnet/test/src/sjsonnet/FormatTests.scala
+++ b/sjsonnet/test/src/sjsonnet/FormatTests.scala
@@ -15,6 +15,7 @@ object FormatTests extends TestSuite{
         def wd: Path = DummyPath()
         def visitExpr(expr: Expr)(implicit scope: ValScope): Val = ???
         def materialize(v: Val): Value = ???
+        def equal(x: Val, y: Val): Boolean = ???
       }
     )
     assert(formatted == expected)

--- a/sjsonnet/test/src/sjsonnet/FormatTests.scala
+++ b/sjsonnet/test/src/sjsonnet/FormatTests.scala
@@ -4,17 +4,16 @@ import ujson.Value
 import utest._
 
 object FormatTests extends TestSuite{
-  val dummyPos = new Position(DummyPath("(unknown)"), -1)
+  val dummyPos = new Position(new FileScope(DummyPath("(unknown)"), Map.empty), -1)
 
   def check(fmt: String, jsonStr: String, expected: String) = {
     val json = ujson.read(jsonStr)
     val formatted = Format.format(fmt, Materializer.reverse(null, json), dummyPos)(
-      new FileScope(dummyPos.currentFile, Map.empty),
       new EvalScope{
         def extVars: Map[String, Value] = Map()
         def loadCachedSource(p: Path): Option[String] = None
         def wd: Path = DummyPath()
-        def visitExpr(expr: Expr)(implicit scope: ValScope, fileScope: FileScope): Val = ???
+        def visitExpr(expr: Expr)(implicit scope: ValScope): Val = ???
         def materialize(v: Val): Value = ???
       }
     )

--- a/sjsonnet/test/src/sjsonnet/FormatTests.scala
+++ b/sjsonnet/test/src/sjsonnet/FormatTests.scala
@@ -4,10 +4,12 @@ import ujson.Value
 import utest._
 
 object FormatTests extends TestSuite{
+  val dummyPos = new Position(DummyPath("(unknown)"), -1)
+
   def check(fmt: String, jsonStr: String, expected: String) = {
     val json = ujson.read(jsonStr)
-    val formatted = Format.format(fmt, Materializer.reverse(null, json), -1)(
-      new FileScope(DummyPath("(unknown)"), Map.empty),
+    val formatted = Format.format(fmt, Materializer.reverse(null, json), dummyPos)(
+      new FileScope(dummyPos.currentFile, Map.empty),
       new EvalScope{
         def extVars: Map[String, Value] = Map()
         def loadCachedSource(p: Path): Option[String] = None

--- a/sjsonnet/test/src/sjsonnet/ParserTests.scala
+++ b/sjsonnet/test/src/sjsonnet/ParserTests.scala
@@ -2,6 +2,7 @@ package sjsonnet
 import utest._
 import Expr._
 import fastparse.Parsed
+import Val.{True, Num}
 object ParserTests extends TestSuite{
   def parse(s: String) = fastparse.parse(s, new Parser(null).document(_)).get.value._1
   def parseErr(s: String) = fastparse.parse(s, new Parser(null).document(_), verboseFailures = true).asInstanceOf[Parsed.Failure].msg

--- a/sjsonnet/test/src/sjsonnet/ParserTests.scala
+++ b/sjsonnet/test/src/sjsonnet/ParserTests.scala
@@ -5,18 +5,20 @@ import fastparse.Parsed
 object ParserTests extends TestSuite{
   def parse(s: String) = fastparse.parse(s, new Parser(null).document(_)).get.value._1
   def parseErr(s: String) = fastparse.parse(s, new Parser(null).document(_), verboseFailures = true).asInstanceOf[Parsed.Failure].msg
+  val dummyFS = new FileScope(null, Map.empty)
+  def pos(i: Int) = new Position(dummyFS, i)
   def tests = Tests{
     test("hello") {
-      parse("true") ==> True(Position(null, 0))
+      parse("true") ==> True(pos(0))
 
       parse("123 + 456 + 789") ==>
-        BinaryOp(Position(null, 10), BinaryOp(Position(null, 4), Num(Position(null, 0), 123), BinaryOp.`+`, Num(Position(null, 6), 456)), BinaryOp.`+`, Num(Position(null, 12), 789))
+        BinaryOp(pos(10), BinaryOp(pos(4), Num(pos(0), 123), BinaryOp.`+`, Num(pos(6), 456)), BinaryOp.`+`, Num(pos(12), 789))
 
       parse("1 * 2 + 3") ==>
-        BinaryOp(Position(null, 6), BinaryOp(Position(null, 2), Num(Position(null, 0), 1), BinaryOp.`*`, Num(Position(null, 4), 2)), BinaryOp.`+`, Num(Position(null, 8), 3))
+        BinaryOp(pos(6), BinaryOp(pos(2), Num(pos(0), 1), BinaryOp.`*`, Num(pos(4), 2)), BinaryOp.`+`, Num(pos(8), 3))
 
       parse("1 + 2 * 3") ==>
-        BinaryOp(Position(null, 2), Num(Position(null, 0), 1), BinaryOp.`+`, BinaryOp(Position(null, 6), Num(Position(null, 4), 2), BinaryOp.`*`, Num(Position(null, 8), 3)))
+        BinaryOp(pos(2), Num(pos(0), 1), BinaryOp.`+`, BinaryOp(pos(6), Num(pos(4), 2), BinaryOp.`*`, Num(pos(8), 3)))
     }
     test("duplicateFields") {
       parseErr("{ a: 1, a: 2 }") ==> """Expected no duplicate field: a:1:14, found "}""""

--- a/sjsonnet/test/src/sjsonnet/ParserTests.scala
+++ b/sjsonnet/test/src/sjsonnet/ParserTests.scala
@@ -3,20 +3,20 @@ import utest._
 import Expr._
 import fastparse.Parsed
 object ParserTests extends TestSuite{
-  def parse(s: String) = fastparse.parse(s, Parser.document(_)).get.value._1
-  def parseErr(s: String) = fastparse.parse(s, Parser.document(_), verboseFailures = true).asInstanceOf[Parsed.Failure].msg
+  def parse(s: String) = fastparse.parse(s, new Parser(null).document(_)).get.value._1
+  def parseErr(s: String) = fastparse.parse(s, new Parser(null).document(_), verboseFailures = true).asInstanceOf[Parsed.Failure].msg
   def tests = Tests{
     test("hello") {
-      parse("true") ==> True(0)
+      parse("true") ==> True(Position(null, 0))
 
       parse("123 + 456 + 789") ==>
-        BinaryOp(10, BinaryOp(4, Num(0, 123), BinaryOp.`+`, Num(6, 456)), BinaryOp.`+`, Num(12, 789))
+        BinaryOp(Position(null, 10), BinaryOp(Position(null, 4), Num(Position(null, 0), 123), BinaryOp.`+`, Num(Position(null, 6), 456)), BinaryOp.`+`, Num(Position(null, 12), 789))
 
       parse("1 * 2 + 3") ==>
-        BinaryOp(6, BinaryOp(2, Num(0, 1), BinaryOp.`*`, Num(4, 2)), BinaryOp.`+`, Num(8, 3))
+        BinaryOp(Position(null, 6), BinaryOp(Position(null, 2), Num(Position(null, 0), 1), BinaryOp.`*`, Num(Position(null, 4), 2)), BinaryOp.`+`, Num(Position(null, 8), 3))
 
       parse("1 + 2 * 3") ==>
-        BinaryOp(2, Num(0, 1), BinaryOp.`+`, BinaryOp(6, Num(4, 2), BinaryOp.`*`, Num(8, 3)))
+        BinaryOp(Position(null, 2), Num(Position(null, 0), 1), BinaryOp.`+`, BinaryOp(Position(null, 6), Num(Position(null, 4), 2), BinaryOp.`*`, Num(Position(null, 8), 3)))
     }
     test("duplicateFields") {
       parseErr("{ a: 1, a: 2 }") ==> """Expected no duplicate field: a:1:14, found "}""""

--- a/sjsonnet/test/src/sjsonnet/Std0150FunctionsTests.scala
+++ b/sjsonnet/test/src/sjsonnet/Std0150FunctionsTests.scala
@@ -36,5 +36,10 @@ object Std0150FunctionsTests extends TestSuite {
       eval("std.repeat('ab', 4)") ==> ujson.Str("abababab")
       eval("std.repeat('a', 0)") ==> ujson.Str("")
     }
+
+    test("join") {
+      eval("std.join(' ', ['', 'foo'])") ==> ujson.Str(" foo")
+      eval("std.join(' ', [null, 'foo'])") ==> ujson.Str("foo")
+    }
   }
 }


### PR DESCRIPTION
This is the collection of changes that @ahirreddy and I made to improve Sjsonnet performance.

- I added an sbt build for building on Scala 2.13 JVM only, in order to simplify testing and benchmarking. This includes a JMH benchmark (which relies on Databricks-internal Jsonnet code for the numbers I'm quoting here; YMMV when running it with other test sources).
- Acyclic is disabled in the Mill build because it caused a compiler crash
- I left the full set of commits, we may or may not want to squash these when merging, but they might come in handy if any problems show up afterwards.
- The changes touch most of the code, we left no stone unturned.

Performance baseline for me was Ahir's branch (which should already be 1/3 faster than the current release) running on Zulu 11:

```
[info] Benchmark           Mode  Cnt     Score    Error  Units
[info] MainBenchmark.main  avgt   20  2592.522 ± 46.356  ms/op
```

Switching to OpenJDK 16:

```
[info] Benchmark           Mode  Cnt     Score    Error  Units
[info] MainBenchmark.main  avgt   20  2113.235 ± 80.190  ms/op
```

And my various improvements on top of that:

```
after apply / func simplification:

[info] Benchmark           Mode  Cnt     Score    Error  Units
[info] MainBenchmark.main  avgt   20  1940.899 ± 23.091  ms/op

after pos cleanup:

[info] Benchmark           Mode  Cnt     Score    Error  Units
[info] MainBenchmark.main  avgt   20  1864.302 ± 16.638  ms/op

scopes with arrays:

[info] Benchmark           Mode  Cnt     Score    Error  Units
[info] MainBenchmark.main  avgt   20  1778.695 ± 32.388  ms/op

scope option unwrapping:

[info] Benchmark           Mode  Cnt     Score    Error  Units
[info] MainBenchmark.main  avgt   20  1695.916 ± 16.999  ms/op

array in arr:

[info] Benchmark           Mode  Cnt     Score    Error  Units
[info] MainBenchmark.main  avgt   20  1607.315 ± 21.366  ms/op

improve scope handling:

[info] Benchmark           Mode  Cnt     Score    Error  Units
[info] MainBenchmark.main  avgt   20  1572.612 ± 25.555  ms/op

remove filescope threading:

[info] Benchmark           Mode  Cnt     Score    Error  Units
[info] MainBenchmark.main  avgt   20  1540.017 ± 14.426  ms/op

simplify:

[info] Benchmark           Mode  Cnt     Score    Error  Units
[info] MainBenchmark.main  avgt   20  1529.828 ± 11.489  ms/op

Val$Obj optimization:

[info] Benchmark           Mode  Cnt     Score    Error  Units
[info] MainBenchmark.main  avgt   20  1510.550 ± 13.998  ms/op

Stricter Val$Func:

[info] Benchmark           Mode  Cnt     Score    Error  Units
[info] MainBenchmark.main  avgt   20  1450.644 ± 21.938  ms/op

Fast path for simple function calls:

[info] Benchmark           Mode  Cnt     Score    Error  Units
[info] MainBenchmark.main  avgt   20  1324.096 ± 12.077  ms/op

Cache visible keys:

[info] Benchmark           Mode  Cnt     Score   Error  Units
[info] MainBenchmark.main  avgt   20  1151.553 ± 9.346  ms/op

Simplify scope handling:

[info] Benchmark           Mode  Cnt     Score    Error  Units
[info] MainBenchmark.main  avgt   20  1036.262 ± 15.039  ms/op

Val literals:

[info] Benchmark           Mode  Cnt    Score   Error  Units
[info] MainBenchmark.main  avgt   20  996.629 ± 9.548  ms/op

Remove Parened:

[info] Benchmark           Mode  Cnt    Score    Error  Units
[info] MainBenchmark.main  avgt   20  985.715 ± 10.770  ms/op

Java LinkedHashMap:

[info] Benchmark           Mode  Cnt    Score   Error  Units
[info] MainBenchmark.main  avgt   20  977.546 ± 7.460  ms/op

Improved BinaryOp handling:

[info] Benchmark           Mode  Cnt    Score    Error  Units
[info] MainBenchmark.main  avgt   20  966.175 ± 12.388  ms/op

Remove more Options:

[info] Benchmark           Mode  Cnt    Score    Error  Units
[info] MainBenchmark.main  avgt   20  965.484 ± 15.138  ms/op

Improve Std:

[info] Benchmark           Mode  Cnt    Score    Error  Units
[info] MainBenchmark.main  avgt   20  809.635 ± 10.877  ms/op

Equality checks without Materializer:

[info] Benchmark           Mode  Cnt    Score    Error  Units
[info] MainBenchmark.main  avgt   20  789.823 ± 11.598  ms/op

Simplify member handling:

[info] Benchmark           Mode  Cnt    Score   Error  Units
[info] MainBenchmark.main  avgt  160  785.889 ± 5.099  ms/op

[info] Benchmark           Mode  Cnt    Score   Error  Units
[info] MainBenchmark.main  avgt  160  778.887 ± 4.786  ms/op

[info] Benchmark           Mode  Cnt    Score   Error  Units
[info] MainBenchmark.main  avgt  160  768.794 ± 3.908  ms/op

Improved equality:

[info] Benchmark           Mode  Cnt    Score   Error  Units
[info] MainBenchmark.main  avgt  160  763.693 ± 3.704  ms/op

Optimize super handling:

[info] Benchmark           Mode  Cnt    Score   Error  Units
[info] MainBenchmark.main  avgt  160  754.915 ± 7.295  ms/op

Static objects

[info] Benchmark           Mode  Cnt    Score   Error  Units
[info] MainBenchmark.main  avgt  160  751.757 ± 6.697  ms/op
```

Hottest methods in the final state:
<img width="766" alt="Screen Shot 2021-04-06 at 5 35 02 PM" src="https://user-images.githubusercontent.com/54262/113737609-78f34300-96fe-11eb-9e1b-2e724d4107f6.png">

High-level overview of important changes:

- In most cases anything that removes allocations and indirections is faster. Obvious candidates for removal are tuples, Options and boxed primitives. For example, an `Array[(Int, Option[T])]` has an extra `Tuple2`, an extra boxed `Integer` and potentially an extra `Some` per element. Replacing it by two separate arrays `Array[Int]` and `Array[T]` (using `null` instead of `None`) is always going to be faster. There's not even an argument to be made for better locality when using the tupled version because the tuple contains references. Overall locality is worse (in the new version at least the `Int`s are colocated). Many commits in this PR are concerned with removing more and more unnecessary objects.
- Picking the fastest collection types between Scala and Java. We're now using a mishmash of Java and Scala types for performance reasons: `java.util.BitSet` and `java.util.LinkedHashMap` but `scala.collection.mutable.HashMap`. The choice is easier for sequence types: Just use plain arrays.
- Use primitive array iteration over higher-order functions like `map`. The scalac optimizer could inline all of these calls but we can't allow inlining from the standard library because of binary compatibility requirements, so we have to do the rewriting manually.
- Improved position handling. This falls under removing allocations. Previously positions were tracked in the parser as Int offsets in the source file. They got combined with file names at each evaluation to create a `Position` object. An AST node can be evaluated many times so it is better to create the `Position` objects directly in the parser. This is also more correct. An offset is always tied to a specific file.
- Rewriting `Lazy`. The old approach relied on the usual Scala mechanisms:
  ```
  class Lazy(f: => Val) { lazy val force: Val = f }
  ```
  This has 3 potential performance issues: We have to allocate 2 objects every time (a subclass of `Function0` for the thunk, plus the actual `Lazy`), the `lazy val` requires a separate `Boolean` flag to keep track of the state, and `lazy val` uses thread-safe double-check locking. We can cut the allocations in half by making `Lazy` a SAM type, and use our own state handling to encode a missing value as `null` (because we know that `f` can never return `null`) and omit the locking (because we don't need thread-safety).
- Let dispatch work for you, not against you. Virtual calls should target class types, not interface types, wherever possible. Matching on types should always use effectively final class types. Big `match` expressions like in `visitExpr` and `visitBinaryOp` are very efficient. The Scala compiler will remove the tuples and you end up with a nice table dispatch on final class types. We are avoiding separate handling of special cases (like the lazy `and` and `or` operators) because a single table-based dispatch is faster.
- Add fast paths. Function calls don't need to be validated if number of args matches number of params and there are no named params. The scope doesn't even have to be populated with potential default values because we already know they are not going to be used. This makes a large number of function calls vastly faster.
- Allow the parser to produce literal `Val`s. There is no need to have the parser emit, for example, an `Expr.Str(s)`, only to get it turned into a `Val.Str(s)` immediately by the evaluator. All literals are emitted directly as `Val`s and the evaluator can skip right over them.
- Simplify the AST. For example, `Expr.Parened(e)` was used for an expression in parentheses. This information is not needed for evaluating the expression. The result is the same as evaluating `e` directly, so we don't even have to produce the node first.
- Improve standard library abstractions. The Jsonnet standard library uses a set of `builtin` methods to avoid some boilerplate. These had a common `builtin0` abstraction for arbitrary arities, which required wrapping values in arrays. We only need 3 different arities and avoiding this abstraction actually makes the code simpler (in addition to removing the unnecessary arrays). For the most common functions we do not use `builtin` anymore at all. A direct implementation with a bit more boilerplate is even faster.
- Don't materialize to JSON only to check equality of two values. We can at least avoid the unnecessary allocations with a dedicated equality check method, and if the values are not equal, we can shortcut the evaluation.
- Optimize common standard library functions. For example, `String.split(Char)` quotes the char into a regular expression which then gets compiled just so it can reuse the regular expression engine for splitting. This can be implemented much more efficiently.