### PR TITLE
Error handling improvements

### DIFF
--- a/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMain.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMain.scala
@@ -4,13 +4,11 @@ import java.io.{BufferedOutputStream, InputStream, OutputStreamWriter, PrintStre
 import java.nio.charset.StandardCharsets
 import java.nio.file.NoSuchFileException
 
-
-import scala.collection.mutable
 import scala.util.Try
 import scala.util.control.NonFatal
 
 object SjsonnetMain {
-  def createParseCache() = collection.mutable.HashMap[(Path, String), Either[String, (Expr, FileScope)]]()
+  def createParseCache() = collection.mutable.HashMap[(Path, String), Either[Error, (Expr, FileScope)]]()
 
   def resolveImport(searchRoots0: Seq[Path], allowedInputs: Option[Set[os.Path]] = None) = new Importer {
     def resolve(docBase: Path, importName: String): Option[Path] =
@@ -46,7 +44,7 @@ object SjsonnetMain {
   }
 
   def main0(args: Array[String],
-            parseCache: collection.mutable.HashMap[(Path, String), Either[String, (Expr, FileScope)]],
+            parseCache: collection.mutable.HashMap[(Path, String), Either[Error, (Expr, FileScope)]],
             stdin: InputStream,
             stdout: PrintStream,
             stderr: PrintStream,
@@ -129,7 +127,7 @@ object SjsonnetMain {
 
   def mainConfigured(file: String,
                      config: Config,
-                     parseCache: collection.mutable.HashMap[(Path, String), Either[String, (Expr, FileScope)]],
+                     parseCache: collection.mutable.HashMap[(Path, String), Either[Error, (Expr, FileScope)]],
                      wd: os.Path,
                      allowedInputs: Option[Set[os.Path]] = None,
                      importer: Option[(Path, String) => Option[os.Path]] = None): Either[String, String] = {

--- a/sjsonnet/src/sjsonnet/Error.scala
+++ b/sjsonnet/src/sjsonnet/Error.scala
@@ -9,50 +9,55 @@ import scala.util.control.NonFatal
   * propagating upwards. This helps provide good error messages with line
   * numbers pointing towards user code.
   */
-class Error(val msg: String,
-            val stack: List[StackTraceElement] = Nil,
-            val underlying: Option[Throwable] = None)
-  extends Exception(msg, underlying.orNull){
+class Error(val msg: String, stack: List[StackTraceElement] = Nil, underlying: Option[Throwable] = None)
+    extends Exception(msg, underlying.orNull) {
+
   setStackTrace(stack.toArray.reverse)
 
   override def fillInStackTrace: Throwable = this
 
-  def addFrame(pos: Position, wd: Path)(implicit ev: EvalErrorScope) = {
-    val newFrame = ev.prettyIndex(pos) match {
-      case None =>
-        new StackTraceElement(
-          "", "",
-          pos.currentFile.relativeToString(wd) + " offset:",
-          pos.offset
-        )
-      case Some((line, col)) =>
+  def addFrame(pos: Position, wd: Path, expr: Expr = null)(implicit ev: EvalErrorScope): Error = {
+    if(stack.isEmpty || alwaysAddPos(expr)) {
+      val cl = ""
+  //    val cl = expr match {
+  //      case null => ""
+  //      case expr => expr.getClass.getName.replaceFirst("^sjsonnet.Expr\\$(.*)", "[$1]")
+  //    }
+      val newFrame = ev.prettyIndex(pos) match {
+        case None =>
+          new StackTraceElement(
+            cl, "",
+            pos.currentFile.relativeToString(wd) + " offset:",
+            pos.offset
+          )
+        case Some((line, col)) =>
+          new StackTraceElement(
+            cl, "",
+            pos.currentFile.relativeToString(wd) + ":" + line,
+            col.toInt
+          )
+      }
+      stack match {
+        case h :: _ if h == newFrame => this
+        case _ => new Error(msg, newFrame :: stack, underlying)
+      }
+    } else this
+  }
 
-        new StackTraceElement(
-          "", "",
-          pos.currentFile.relativeToString(wd) + ":" + line,
-          col.toInt
-        )
-    }
-
-    new Error(msg, newFrame :: stack, underlying)
+  private[this] def alwaysAddPos(expr: Expr): Boolean = expr match {
+    case _: Expr.LocalExpr | _: Expr.Arr | _: Expr.ObjExtend | _: Expr.ObjBody | _: Expr.IfElse => false
+    case _ => true
   }
 }
 
-
 object Error {
-  def tryCatch[T](pos: Position)
-                 (implicit evaluator: EvalErrorScope): PartialFunction[Throwable, Nothing] = {
-    case e: Error if e.stack.isEmpty => throw e.addFrame(pos, evaluator.wd)
-    case e: Error => throw e
+  def withStackFrame[T](expr: Expr)
+                       (implicit evaluator: EvalErrorScope): PartialFunction[Throwable, Nothing] = {
+    case e: Error => throw e.addFrame(expr.pos, evaluator.wd, expr)
     case NonFatal(e) =>
-      throw new Error("Internal Error", Nil, Some(e)).addFrame(pos, evaluator.wd)
+      throw new Error("Internal Error", Nil, Some(e)).addFrame(expr.pos, evaluator.wd, expr)
   }
-  def tryCatchWrap[T](pos: Position)
-                     (implicit evaluator: EvalErrorScope): PartialFunction[Throwable, Nothing] = {
-    case e: Error => throw e.addFrame(pos, evaluator.wd)
-    case NonFatal(e) =>
-      throw new Error("Internal Error", Nil, Some(e)).addFrame(pos, evaluator.wd)
-  }
+
   def fail(msg: String, pos: Position)
           (implicit evaluator: EvalErrorScope): Nothing =
     throw new Error(msg, Nil, None).addFrame(pos, evaluator.wd)

--- a/sjsonnet/src/sjsonnet/Error.scala
+++ b/sjsonnet/src/sjsonnet/Error.scala
@@ -82,6 +82,19 @@ class ParseError(msg: String, stack: List[Error.Frame] = Nil, underlying: Option
     new ParseError(msg, stack, underlying)
 }
 
+class StaticError(msg: String, stack: List[Error.Frame] = Nil, underlying: Option[Throwable] = None)
+  extends Error(msg, stack, underlying) {
+
+  override protected[this] def copy(msg: String = msg, stack: List[Error.Frame] = stack,
+                                    underlying: Option[Throwable] = underlying) =
+    new StaticError(msg, stack, underlying)
+}
+
+object StaticError {
+  def fail(msg: String, expr: Expr)(implicit ev: EvalErrorScope): Nothing =
+    throw new StaticError(msg, new Error.Frame(expr.pos, expr.exprErrorString) :: Nil, None)
+}
+
 trait EvalErrorScope {
   def extVars: Map[String, ujson.Value]
   def importer: CachedImporter

--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -60,23 +60,8 @@ class Evaluator(resolver: CachedResolver,
       case e: Apply0 => visitApply0(e)
       case e: ImportStr => visitImportStr(e)
       case e: Expr.Error => visitError(e)
-      case e => visitInvalid(e)
     }
   } catch Error.withStackFrame(e)
-
-  def visitInvalid(e: Expr): Nothing = e match {
-    case Id(pos, name) =>
-      Error.fail("Unknown variable " + name, pos)
-
-    case Self(pos) =>
-      Error.fail("Cannot use `self` outside an object", pos)
-
-    case $(pos) =>
-      Error.fail("Cannot use `$` outside an object", pos)
-
-    case Super(pos) =>
-      Error.fail("Cannot use `super` outside an object", pos)
-  }
 
   def visitAsLazy(e: Expr)(implicit scope: ValScope): Lazy = e match {
     case v: Val => v

--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -62,7 +62,7 @@ class Evaluator(resolver: CachedResolver,
       case e: Expr.Error => visitError(e)
       case e => visitInvalid(e)
     }
-  } catch Error.tryCatch(e.pos)
+  } catch Error.withStackFrame(e)
 
   def visitInvalid(e: Expr): Nothing = e match {
     case Id(pos, name) =>
@@ -85,7 +85,7 @@ class Evaluator(resolver: CachedResolver,
 
   def visitValidId(e: ValidId)(implicit scope: ValScope): Val = {
     val ref = scope.bindings(e.nameIdx)
-    try ref.force catch Error.tryCatchWrap(e.pos)
+    ref.force
   }
 
   def visitSelect(e: Select)(implicit scope: ValScope): Val = visitExpr(e.value) match {
@@ -150,9 +150,7 @@ class Evaluator(resolver: CachedResolver,
     Error.fail(
       visitExpr(e.value) match {
         case Val.Str(_, s) => s
-        case r =>
-          try Materializer.stringify(r)
-          catch Error.tryCatchWrap(e.pos)
+        case r => Materializer.stringify(r)
       },
       e.pos
     )
@@ -193,25 +191,25 @@ class Evaluator(resolver: CachedResolver,
       argsL(idx) = visitAsLazy(args(idx))
       idx += 1
     }
-    try lhs.cast[Val.Func].apply(argsL, e.namedNames, e.pos) catch Error.tryCatchWrap(e.pos)
+    lhs.cast[Val.Func].apply(argsL, e.namedNames, e.pos)
   }
 
   private def visitApply0(e: Apply0)(implicit scope: ValScope): Val = {
     val lhs = visitExpr(e.value)
-    try lhs.cast[Val.Func].apply0(e.pos) catch Error.tryCatchWrap(e.pos)
+    lhs.cast[Val.Func].apply0(e.pos)
   }
 
   private def visitApply1(e: Apply1)(implicit scope: ValScope): Val = {
     val lhs = visitExpr(e.value)
     val l1 = visitAsLazy(e.a1)
-    try lhs.cast[Val.Func].apply1(l1, e.pos) catch Error.tryCatchWrap(e.pos)
+    lhs.cast[Val.Func].apply1(l1, e.pos)
   }
 
   private def visitApply2(e: Apply2)(implicit scope: ValScope): Val = {
     val lhs = visitExpr(e.value)
     val l1 = visitAsLazy(e.a1)
     val l2 = visitAsLazy(e.a2)
-    try lhs.cast[Val.Func].apply2(l1, l2, e.pos) catch Error.tryCatchWrap(e.pos)
+    lhs.cast[Val.Func].apply2(l1, l2, e.pos)
   }
 
   private def visitApply3(e: Apply3)(implicit scope: ValScope): Val = {
@@ -219,14 +217,14 @@ class Evaluator(resolver: CachedResolver,
     val l1 = visitAsLazy(e.a1)
     val l2 = visitAsLazy(e.a2)
     val l3 = visitAsLazy(e.a3)
-    try lhs.cast[Val.Func].apply3(l1, l2, l3, e.pos) catch Error.tryCatchWrap(e.pos)
+    lhs.cast[Val.Func].apply3(l1, l2, l3, e.pos)
   }
 
   private def visitApplyBuiltin1(e: ApplyBuiltin1)(implicit scope: ValScope) =
-    try e.func.evalRhs(visitExpr(e.a1), this, e.pos) catch Error.tryCatchWrap(e.pos)
+    e.func.evalRhs(visitExpr(e.a1), this, e.pos)
 
   private def visitApplyBuiltin2(e: ApplyBuiltin2)(implicit scope: ValScope) =
-    try e.func.evalRhs(visitExpr(e.a1), visitExpr(e.a2), this, e.pos) catch Error.tryCatchWrap(e.pos)
+    e.func.evalRhs(visitExpr(e.a1), visitExpr(e.a2), this, e.pos)
 
   private def visitApplyBuiltin(e: ApplyBuiltin)(implicit scope: ValScope) = {
     val arr = new Array[Val](e.argExprs.length)
@@ -236,7 +234,7 @@ class Evaluator(resolver: CachedResolver,
       arr(idx) = visitExpr(e.argExprs(boundIdx))
       idx += 1
     }
-    try e.func.evalRhs(arr, this, e.pos) catch Error.tryCatchWrap(e.pos)
+    e.func.evalRhs(arr, this, e.pos)
   }
 
   def visitAssert(e: AssertExpr)(implicit scope: ValScope): Val = {
@@ -276,13 +274,10 @@ class Evaluator(resolver: CachedResolver,
         if (i.value > v.length) Error.fail(s"array bounds error: ${i.value} not within [0, ${v.length})", pos)
         val int = i.value.toInt
         if (int != i.value) Error.fail("array index was not integer: " + i.value, pos)
-        try v.force(int)
-        catch Error.tryCatchWrap(pos)
+        v.force(int)
       case (v: Val.Str, i: Val.Num) => Val.Str(pos, new String(Array(v.value(i.value.toInt))))
       case (v: Val.Obj, i: Val.Str) =>
-        val ref = v.value(i.value, pos)
-        try ref
-        catch Error.tryCatchWrap(pos)
+        v.value(i.value, pos)
       case (lhs, rhs) =>
         Error.fail(s"attempted to index a ${lhs.prettyName} with ${rhs.prettyName}", pos)
     }
@@ -303,9 +298,8 @@ class Evaluator(resolver: CachedResolver,
     cachedImports.getOrElseUpdate(
       p,
       {
-        val (doc, newFileScope) = resolver.parseOrFail(e.pos, e.value, p, str)
-        try visitExpr(doc)(ValScope.empty)
-        catch Error.tryCatchWrap(e.pos)
+        val (doc, _) = resolver.parseOrFail(e.pos, e.value, p, str)
+        visitExpr(doc)(ValScope.empty)
       }
     )
   }
@@ -358,25 +352,19 @@ class Evaluator(resolver: CachedResolver,
         if (l.isInstanceOf[Val.Func] && r.isInstanceOf[Val.Func]) {
           Error.fail("cannot test equality of functions", pos)
         }
-        try Val.bool(pos, equal(l, r))
-        catch Error.tryCatchWrap(pos)
+        Val.bool(pos, equal(l, r))
 
       case Expr.BinaryOp.OP_!= =>
         if (l.isInstanceOf[Val.Func] && r.isInstanceOf[Val.Func]) {
           Error.fail("cannot test equality of functions", pos)
         }
-        try Val.bool(pos, !equal(l, r))
-        catch Error.tryCatchWrap(pos)
+        Val.bool(pos, !equal(l, r))
 
       case Expr.BinaryOp.OP_+ => (l, r) match {
         case (Val.Num(_, l), Val.Num(_, r)) => Val.Num(pos, l + r)
         case (Val.Str(_, l), Val.Str(_, r)) => Val.Str(pos, l + r)
-        case (Val.Str(_, l), r) =>
-          try Val.Str(pos, l + Materializer.stringify(r))
-          catch Error.tryCatchWrap(pos)
-        case (l, Val.Str(_, r)) =>
-          try Val.Str(pos, Materializer.stringify(l) + r)
-          catch Error.tryCatchWrap(pos)
+        case (Val.Str(_, l), r) => Val.Str(pos, l + Materializer.stringify(r))
+        case (l, Val.Str(_, r)) => Val.Str(pos, Materializer.stringify(l) + r)
         case (l: Val.Obj, r: Val.Obj) => r.addSuper(pos, l)
         case (l: Val.Arr, r: Val.Arr) => l.concat(pos, r)
         case _ => fail()
@@ -401,9 +389,7 @@ class Evaluator(resolver: CachedResolver,
 
       case Expr.BinaryOp.OP_% => (l, r) match {
         case (Val.Num(_, l), Val.Num(_, r)) => Val.Num(pos, l % r)
-        case (Val.Str(_, l), r) =>
-          try Val.Str(pos, Format.format(l, r, pos))
-          catch Error.tryCatchWrap(pos)
+        case (Val.Str(_, l), r) => Val.Str(pos, Format.format(l, r, pos))
         case _ => fail()
       }
 

--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -295,7 +295,10 @@ class Evaluator(resolver: CachedResolver,
     cachedImports.getOrElseUpdate(
       p,
       {
-        val (doc, _) = resolver.parseOrFail(e.pos, e.value, p, str)
+        val doc = resolver.parse(p, str) match {
+          case Right((expr, _)) => expr
+          case Left(err) => throw err.asSeenFrom(this)
+        }
         visitExpr(doc)(ValScope.empty)
       }
     )

--- a/sjsonnet/src/sjsonnet/Expr.scala
+++ b/sjsonnet/src/sjsonnet/Expr.scala
@@ -14,6 +14,12 @@ import scala.collection.mutable
   */
 trait Expr{
   def pos: Position
+
+  /** The name of this expression type to be shown in error messages */
+  def exprErrorString: String = {
+    val n = getClass.getName
+    if(n.startsWith("sjsonnet.Expr$")) n.substring(14) else n
+  }
 }
 object Expr{
   private final def arrStr(a: Array[_]): String = {
@@ -24,8 +30,12 @@ object Expr{
   case class Super(pos: Position) extends Expr
   case class $(pos: Position) extends Expr
 
-  case class Id(pos: Position, name: String) extends Expr
-  case class ValidId(pos: Position, name: String, nameIdx: Int) extends Expr
+  case class Id(pos: Position, name: String) extends Expr {
+    override def exprErrorString: String = s"${super.exprErrorString} $name"
+  }
+  case class ValidId(pos: Position, name: String, nameIdx: Int) extends Expr {
+    override def exprErrorString: String = s"${super.exprErrorString} $name"
+  }
   case class Arr(pos: Position, value: Array[Expr]) extends Expr {
     override def toString = s"Arr($pos, ${arrStr(value)})"
   }
@@ -62,7 +72,9 @@ object Expr{
     override def toString = s"Params(${arrStr(names)}, ${arrStr(defaultExprs)})"
   }
 
-  case class UnaryOp(pos: Position, op: Int, value: Expr) extends Expr
+  case class UnaryOp(pos: Position, op: Int, value: Expr) extends Expr {
+    override def exprErrorString: String = s"${super.exprErrorString} ${UnaryOp.name(op)}"
+  }
   object UnaryOp{
     final val OP_! = 0
     final val OP_- = 1
@@ -73,7 +85,9 @@ object Expr{
   }
   case class And(pos: Position, lhs: Expr, rhs: Expr) extends Expr
   case class Or(pos: Position, lhs: Expr, rhs: Expr) extends Expr
-  case class BinaryOp(pos: Position, lhs: Expr, op: Int, rhs: Expr) extends Expr
+  case class BinaryOp(pos: Position, lhs: Expr, op: Int, rhs: Expr) extends Expr {
+    override def exprErrorString: String = s"${super.exprErrorString} ${BinaryOp.name(op)}"
+  }
   object BinaryOp{
     final val OP_* = 0
     final val OP_/ = 1
@@ -116,8 +130,12 @@ object Expr{
   case class ApplyBuiltin(pos: Position, func: Val.Builtin, argExprs: Array[Expr]) extends Expr
   case class ApplyBuiltin1(pos: Position, func: Val.Builtin1, a1: Expr) extends Expr
   case class ApplyBuiltin2(pos: Position, func: Val.Builtin2, a1: Expr, a2: Expr) extends Expr
-  case class Select(pos: Position, value: Expr, name: String) extends Expr
-  case class SelectSuper(pos: Position, selfIdx: Int, name: String) extends Expr
+  case class Select(pos: Position, value: Expr, name: String) extends Expr {
+    override def exprErrorString: String = s"${super.exprErrorString} $name"
+  }
+  case class SelectSuper(pos: Position, selfIdx: Int, name: String) extends Expr {
+    override def exprErrorString: String = s"${super.exprErrorString} $name"
+  }
   case class InSuper(pos: Position, value: Expr, selfIdx: Int) extends Expr
   case class Lookup(pos: Position, value: Expr, index: Expr) extends Expr
   case class LookupSuper(pos: Position, selfIdx: Int, index: Expr) extends Expr

--- a/sjsonnet/src/sjsonnet/Interpreter.scala
+++ b/sjsonnet/src/sjsonnet/Interpreter.scala
@@ -99,7 +99,7 @@ class Interpreter(extVars: Map[String, ujson.Value],
       }
     try Right(m.apply0(res, visitor)(evaluator))
     catch{
-      case Error.Delegate(msg) => Left(msg)
+//      case Error.Delegate(msg) => Left(msg)
       case NonFatal(e) =>
         val s = new StringWriter()
         val p = new PrintWriter(s)

--- a/sjsonnet/src/sjsonnet/Materializer.scala
+++ b/sjsonnet/src/sjsonnet/Materializer.scala
@@ -57,7 +57,7 @@ abstract class Materializer {
     }
 
   }catch {case e: StackOverflowError =>
-    throw Error.Delegate("Stackoverflow while materializing, possibly due to recursive value")
+    Error.fail("Stackoverflow while materializing, possibly due to recursive value")
   }
 
   def reverse(pos: Position, v: ujson.Value): Val = v match{

--- a/sjsonnet/src/sjsonnet/Parser.scala
+++ b/sjsonnet/src/sjsonnet/Parser.scala
@@ -426,9 +426,7 @@ final class Position(val fileScope: FileScope, val offset: Int) {
 
 /**
   * FileScope models the per-file context that is propagated throughout the
-  * evaluation of a single Jsonnet file. Contains the current file path, as
-  * well as the mapping of local variable names to local variable array indices
-  * which is shared throughout each file.
+  * evaluation of a single Jsonnet file. Contains the current file path.
   */
 class FileScope(val currentFile: Path) {
   lazy val currentFileLastPathElement = if(currentFile == null) null else currentFile.last

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -39,12 +39,10 @@ sealed abstract class Val extends Lazy {
 
   def cast[T: ClassTag: PrettyNamed] =
     if (implicitly[ClassTag[T]].runtimeClass.isInstance(this)) this.asInstanceOf[T]
-    else throw new Error.Delegate(
-      "Expected " + implicitly[PrettyNamed[T]].s + ", found " + prettyName
-    )
+    else Error.fail("Expected " + implicitly[PrettyNamed[T]].s + ", found " + prettyName)
 
   private[this] def failAs(err: String): Nothing =
-    throw new Error.Delegate("Wrong parameter type: expected " + err + ", got " + prettyName)
+    Error.fail("Wrong parameter type: expected " + err + ", got " + prettyName)
 
   def asString: String = failAs("String")
   def asBoolean: Boolean = failAs("Boolean")

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -233,10 +233,8 @@ object Val{
       }
     }
 
-    private def renderString(v: Val)(implicit evaluator: EvalScope): String = {
-      try evaluator.materialize(v).transform(new Renderer()).toString
-      catch Error.tryCatchWrap(pos)
-    }
+    private def renderString(v: Val)(implicit evaluator: EvalScope): String =
+      evaluator.materialize(v).transform(new Renderer()).toString
 
     def mergeMember(l: Val,
                     r: Val,

--- a/sjsonnet/test/src-jvm-native/sjsonnet/ErrorTests.scala
+++ b/sjsonnet/test/src-jvm-native/sjsonnet/ErrorTests.scala
@@ -135,7 +135,9 @@ object ErrorTests extends TestSuite{
         |""".stripMargin
     )
     test("function_arg_positional_after_named") - check(
-      """Parse error: Expected no positional params after named params:19:11, found ")\n"""".stripMargin
+      """sjsonnet.ParseError: Expected no positional params after named params:19:11, found ")\n"
+        |    at .(sjsonnet/test/resources/test_suite/error.function_arg_positional_after_named.jsonnet:19:11)
+        |""".stripMargin
     )
 
     test("function_duplicate_arg") - check(
@@ -144,7 +146,9 @@ object ErrorTests extends TestSuite{
         |""".stripMargin
     )
     test("function_duplicate_param") - check(
-      """Parse error: Expected no duplicate parameter: x:17:14, found ") x\n"""".stripMargin
+      """sjsonnet.ParseError: Expected no duplicate parameter: x:17:14, found ") x\n"
+        |    at .(sjsonnet/test/resources/test_suite/error.function_duplicate_param.jsonnet:17:14)
+        |""".stripMargin
     )
     test("function_too_many_args") - check(
       """sjsonnet.Error: Too many args, function has 2 parameter(s)
@@ -173,7 +177,8 @@ object ErrorTests extends TestSuite{
         |""".stripMargin
     )
     "import_syntax-error" - check(
-      """sjsonnet.Error: Imported file "lib/syntax_error.jsonnet" had Parse error. Expected "\"":2:1, found ""
+      """sjsonnet.ParseError: Expected "\"":2:1, found ""
+        |    at .(sjsonnet/test/resources/test_suite/lib/syntax_error.jsonnet:2:1)
         |    at [Import].(sjsonnet/test/resources/test_suite/error.import_syntax-error.jsonnet:1:1)
         |""".stripMargin
     )

--- a/sjsonnet/test/src-jvm-native/sjsonnet/ErrorTests.scala
+++ b/sjsonnet/test/src-jvm-native/sjsonnet/ErrorTests.scala
@@ -115,7 +115,7 @@ object ErrorTests extends TestSuite{
         |""".stripMargin
     )
     test("computed_field_scope") - check(
-      """sjsonnet.Error: Unknown variable x
+      """sjsonnet.StaticError: Unknown variable: x
         |    at [Id x].(sjsonnet/test/resources/test_suite/error.computed_field_scope.jsonnet:17:21)
         |""".stripMargin
     )
@@ -171,7 +171,7 @@ object ErrorTests extends TestSuite{
         |""".stripMargin
     )
     "import_static-check-failure" - check(
-      """sjsonnet.Error: Unknown variable x
+      """sjsonnet.StaticError: Unknown variable: x
         |    at [Id x].(sjsonnet/test/resources/test_suite/lib/static_check_failure.jsonnet:2:1)
         |    at [Import].(sjsonnet/test/resources/test_suite/error.import_static-check-failure.jsonnet:1:1)
         |""".stripMargin

--- a/sjsonnet/test/src-jvm-native/sjsonnet/ErrorTests.scala
+++ b/sjsonnet/test/src-jvm-native/sjsonnet/ErrorTests.scala
@@ -43,6 +43,7 @@ object ErrorTests extends TestSuite{
     test("03") - check(
       """sjsonnet.Error: foo
         |    at .(sjsonnet/test/resources/test_suite/error.03.jsonnet:17:21)
+        |    at .(sjsonnet/test/resources/test_suite/error.03.jsonnet:18:7)
         |""".stripMargin
     )
     test("04") - check(
@@ -60,6 +61,7 @@ object ErrorTests extends TestSuite{
         |    at .(sjsonnet/test/resources/test_suite/error.06.jsonnet:17:15)
         |    at .(sjsonnet/test/resources/test_suite/error.06.jsonnet:18:22)
         |    at .(sjsonnet/test/resources/test_suite/error.06.jsonnet:19:2)
+        |    at .(sjsonnet/test/resources/test_suite/error.06.jsonnet:19:5)
         |""".stripMargin
     )
     test("07") - check(
@@ -68,6 +70,7 @@ object ErrorTests extends TestSuite{
         |    at .(sjsonnet/test/resources/test_suite/error.07.jsonnet:17:32)
         |    at .(sjsonnet/test/resources/test_suite/error.07.jsonnet:18:20)
         |    at .(sjsonnet/test/resources/test_suite/error.07.jsonnet:19:1)
+        |    at .(sjsonnet/test/resources/test_suite/error.07.jsonnet:19:7)
         |""".stripMargin
     )
     test("08") - check(
@@ -103,6 +106,7 @@ object ErrorTests extends TestSuite{
     test("comprehension_spec_object") - check(
       """sjsonnet.Error: In comprehension, can only iterate over array, not object
         |    at .(sjsonnet/test/resources/test_suite/error.comprehension_spec_object.jsonnet:17:15)
+        |    at .(sjsonnet/test/resources/test_suite/error.comprehension_spec_object.jsonnet:17:2)
         |""".stripMargin
     )
     test("comprehension_spec_object2") - check(
@@ -137,7 +141,6 @@ object ErrorTests extends TestSuite{
     test("function_duplicate_arg") - check(
       """sjsonnet.Error: binding parameter a second time: x
         |    at .(sjsonnet/test/resources/test_suite/error.function_duplicate_arg.jsonnet:17:21)
-        |    at .(sjsonnet/test/resources/test_suite/error.function_duplicate_arg.jsonnet:17:21)
         |""".stripMargin
     )
     test("function_duplicate_param") - check(
@@ -145,7 +148,6 @@ object ErrorTests extends TestSuite{
     )
     test("function_too_many_args") - check(
       """sjsonnet.Error: Too many args, function has 2 parameter(s)
-        |    at .(sjsonnet/test/resources/test_suite/error.function_too_many_args.jsonnet:19:4)
         |    at .(sjsonnet/test/resources/test_suite/error.function_too_many_args.jsonnet:19:4)
         |""".stripMargin
     )
@@ -235,6 +237,7 @@ object ErrorTests extends TestSuite{
     test("native_not_found") - check(
       """sjsonnet.Error: Field does not exist: native
         |    at .(sjsonnet/test/resources/test_suite/error.native_not_found.jsonnet:17:4)
+        |    at .(sjsonnet/test/resources/test_suite/error.native_not_found.jsonnet:17:11)
         |""".stripMargin
     )
     test("obj_assert") - {
@@ -242,12 +245,14 @@ object ErrorTests extends TestSuite{
         """sjsonnet.Error: Assertion failed
           |    at .(sjsonnet/test/resources/test_suite/error.obj_assert.fail1.jsonnet:20:25)
           |    at .(sjsonnet/test/resources/test_suite/error.obj_assert.fail1.jsonnet:20:38)
+          |    at .(sjsonnet/test/resources/test_suite/error.obj_assert.fail1.jsonnet:20:50)
         |""".stripMargin
       )
       test("fail2") - check(
         """sjsonnet.Error: Assertion failed: foo was not equal to bar
           |    at .(sjsonnet/test/resources/test_suite/error.obj_assert.fail2.jsonnet:20:25)
           |    at .(sjsonnet/test/resources/test_suite/error.obj_assert.fail2.jsonnet:20:74)
+          |    at .(sjsonnet/test/resources/test_suite/error.obj_assert.fail2.jsonnet:20:86)
         |""".stripMargin
       )
     }
@@ -255,13 +260,11 @@ object ErrorTests extends TestSuite{
     test("import_wrong_nr_args") - checkImports(
       """|sjsonnet.Error: Function parameter y not bound in call
          |    at .(sjsonnet/test/resources/imports/error.import_wrong_nr_args.jsonnet:3:6)
-         |    at .(sjsonnet/test/resources/imports/error.import_wrong_nr_args.jsonnet:3:6)
          |""".stripMargin
     )
 
     test("wrong_named_arg") - checkImports(
       """|sjsonnet.Error: Function has no parameter z
-         |    at .(sjsonnet/test/resources/imports/error.wrong_named_arg.jsonnet:3:6)
          |    at .(sjsonnet/test/resources/imports/error.wrong_named_arg.jsonnet:3:6)
          |""".stripMargin
     )
@@ -269,13 +272,11 @@ object ErrorTests extends TestSuite{
     test("too_many_arg") - checkImports(
       """|sjsonnet.Error: Too many args, function has 2 parameter(s)
          |    at .(sjsonnet/test/resources/imports/error.too_many_arg.jsonnet:3:6)
-         |    at .(sjsonnet/test/resources/imports/error.too_many_arg.jsonnet:3:6)
          |""".stripMargin
     )
 
     test("too_many_arg_with_named_arg") - checkImports(
       """|sjsonnet.Error: binding parameter a second time: x
-         |    at .(sjsonnet/test/resources/imports/error.too_many_arg_with_named_arg.jsonnet:2:2)
          |    at .(sjsonnet/test/resources/imports/error.too_many_arg_with_named_arg.jsonnet:2:2)
          |""".stripMargin
     )

--- a/sjsonnet/test/src-jvm-native/sjsonnet/ErrorTests.scala
+++ b/sjsonnet/test/src-jvm-native/sjsonnet/ErrorTests.scala
@@ -29,109 +29,109 @@ object ErrorTests extends TestSuite{
   val tests = Tests{
     test("01") - check(
       """sjsonnet.Error: foo
-        |    at .(sjsonnet/test/resources/test_suite/error.01.jsonnet:17:29)
-        |    at .(sjsonnet/test/resources/test_suite/error.01.jsonnet:18:36)
-        |    at .(sjsonnet/test/resources/test_suite/error.01.jsonnet:19:35)
-        |    at .(sjsonnet/test/resources/test_suite/error.01.jsonnet:20:7)
+        |    at [Error].(sjsonnet/test/resources/test_suite/error.01.jsonnet:17:29)
+        |    at [Apply1].(sjsonnet/test/resources/test_suite/error.01.jsonnet:18:36)
+        |    at [Apply1].(sjsonnet/test/resources/test_suite/error.01.jsonnet:19:35)
+        |    at [Apply1].(sjsonnet/test/resources/test_suite/error.01.jsonnet:20:7)
         |""".stripMargin
     )
     test("02") - check(
       """sjsonnet.Error: Foo.
-        |    at .(sjsonnet/test/resources/test_suite/error.02.jsonnet:17:1)
+        |    at [Error].(sjsonnet/test/resources/test_suite/error.02.jsonnet:17:1)
         |""".stripMargin
     )
     test("03") - check(
       """sjsonnet.Error: foo
-        |    at .(sjsonnet/test/resources/test_suite/error.03.jsonnet:17:21)
-        |    at .(sjsonnet/test/resources/test_suite/error.03.jsonnet:18:7)
+        |    at [Error].(sjsonnet/test/resources/test_suite/error.03.jsonnet:17:21)
+        |    at [Select x].(sjsonnet/test/resources/test_suite/error.03.jsonnet:18:7)
         |""".stripMargin
     )
     test("04") - check(
       """sjsonnet.Error: foo
-        |    at .(sjsonnet/test/resources/test_suite/error.04.jsonnet:17:21)
+        |    at [Error].(sjsonnet/test/resources/test_suite/error.04.jsonnet:17:21)
         |""".stripMargin
     )
     test("05") - check(
       """sjsonnet.Error: foo
-        |    at .(sjsonnet/test/resources/test_suite/error.05.jsonnet:17:21)
+        |    at [Error].(sjsonnet/test/resources/test_suite/error.05.jsonnet:17:21)
         |""".stripMargin
     )
     test("06") - check(
       """sjsonnet.Error: division by zero
-        |    at .(sjsonnet/test/resources/test_suite/error.06.jsonnet:17:15)
-        |    at .(sjsonnet/test/resources/test_suite/error.06.jsonnet:18:22)
-        |    at .(sjsonnet/test/resources/test_suite/error.06.jsonnet:19:2)
-        |    at .(sjsonnet/test/resources/test_suite/error.06.jsonnet:19:5)
+        |    at [BinaryOp /].(sjsonnet/test/resources/test_suite/error.06.jsonnet:17:15)
+        |    at [ValidId err].(sjsonnet/test/resources/test_suite/error.06.jsonnet:18:22)
+        |    at [Apply0].(sjsonnet/test/resources/test_suite/error.06.jsonnet:19:2)
+        |    at [BinaryOp +].(sjsonnet/test/resources/test_suite/error.06.jsonnet:19:5)
         |""".stripMargin
     )
     test("07") - check(
       """sjsonnet.Error: sarcasm
-        |    at .(sjsonnet/test/resources/test_suite/error.07.jsonnet:18:31)
-        |    at .(sjsonnet/test/resources/test_suite/error.07.jsonnet:17:32)
-        |    at .(sjsonnet/test/resources/test_suite/error.07.jsonnet:18:20)
-        |    at .(sjsonnet/test/resources/test_suite/error.07.jsonnet:19:1)
-        |    at .(sjsonnet/test/resources/test_suite/error.07.jsonnet:19:7)
+        |    at [Error].(sjsonnet/test/resources/test_suite/error.07.jsonnet:18:31)
+        |    at [Lookup].(sjsonnet/test/resources/test_suite/error.07.jsonnet:17:32)
+        |    at [Apply1].(sjsonnet/test/resources/test_suite/error.07.jsonnet:18:20)
+        |    at [ValidId toxic].(sjsonnet/test/resources/test_suite/error.07.jsonnet:19:1)
+        |    at [BinaryOp +].(sjsonnet/test/resources/test_suite/error.07.jsonnet:19:7)
         |""".stripMargin
     )
     test("08") - check(
       """sjsonnet.Error: {"a": 1, "b": 2, "c": 3}
-        |    at .(sjsonnet/test/resources/test_suite/error.08.jsonnet:18:1)
+        |    at [Error].(sjsonnet/test/resources/test_suite/error.08.jsonnet:18:1)
         |""".stripMargin
     )
     test("array_fractional_index") - check(
       """sjsonnet.Error: array index was not integer: 1.5
-        |    at .(sjsonnet/test/resources/test_suite/error.array_fractional_index.jsonnet:17:10)
+        |    at [Lookup].(sjsonnet/test/resources/test_suite/error.array_fractional_index.jsonnet:17:10)
         |""".stripMargin
     )
     test("array_index_string") - check(
       """sjsonnet.Error: attempted to index a array with string foo
-        |    at .(sjsonnet/test/resources/test_suite/error.array_index_string.jsonnet:17:10)
+        |    at [Select foo].(sjsonnet/test/resources/test_suite/error.array_index_string.jsonnet:17:10)
         |""".stripMargin
     )
     test("array_large_index") - check(
       """sjsonnet.Error: array bounds error: 1.8446744073709552E19 not within [0, 3)
-        |    at .(sjsonnet/test/resources/test_suite/error.array_large_index.jsonnet:17:10)
+        |    at [Lookup].(sjsonnet/test/resources/test_suite/error.array_large_index.jsonnet:17:10)
         |""".stripMargin
     )
     "assert.fail1" - check(
       """sjsonnet.Error: Assertion failed
-        |    at .(sjsonnet/test/resources/test_suite/error.assert.fail1.jsonnet:20:1)
+        |    at [AssertExpr].(sjsonnet/test/resources/test_suite/error.assert.fail1.jsonnet:20:1)
         |""".stripMargin
     )
     "assert.fail2" - check(
       """sjsonnet.Error: Assertion failed: foo was not equal to bar
-        |    at .(sjsonnet/test/resources/test_suite/error.assert.fail2.jsonnet:20:1)
+        |    at [AssertExpr].(sjsonnet/test/resources/test_suite/error.assert.fail2.jsonnet:20:1)
         |""".stripMargin
     )
     test("comprehension_spec_object") - check(
       """sjsonnet.Error: In comprehension, can only iterate over array, not object
-        |    at .(sjsonnet/test/resources/test_suite/error.comprehension_spec_object.jsonnet:17:15)
-        |    at .(sjsonnet/test/resources/test_suite/error.comprehension_spec_object.jsonnet:17:2)
+        |    at [ForSpec].(sjsonnet/test/resources/test_suite/error.comprehension_spec_object.jsonnet:17:4)
+        |    at [Comp].(sjsonnet/test/resources/test_suite/error.comprehension_spec_object.jsonnet:17:2)
         |""".stripMargin
     )
     test("comprehension_spec_object2") - check(
       """sjsonnet.Error: In comprehension, can only iterate over array, not object
-        |    at .(sjsonnet/test/resources/test_suite/error.comprehension_spec_object2.jsonnet:17:24)
+        |    at [ForSpec].(sjsonnet/test/resources/test_suite/error.comprehension_spec_object2.jsonnet:17:13)
         |""".stripMargin
     )
     test("computed_field_scope") - check(
       """sjsonnet.Error: Unknown variable x
-        |    at .(sjsonnet/test/resources/test_suite/error.computed_field_scope.jsonnet:17:21)
+        |    at [Id x].(sjsonnet/test/resources/test_suite/error.computed_field_scope.jsonnet:17:21)
         |""".stripMargin
     )
     test("divide_zero") - check(
       """sjsonnet.Error: division by zero
-        |    at .(sjsonnet/test/resources/test_suite/error.divide_zero.jsonnet:17:5)
+        |    at [BinaryOp /].(sjsonnet/test/resources/test_suite/error.divide_zero.jsonnet:17:5)
         |""".stripMargin
     )
     test("equality_function") - check(
       """sjsonnet.Error: cannot test equality of functions
-        |    at .(sjsonnet/test/resources/test_suite/error.equality_function.jsonnet:17:16)
+        |    at [BinaryOp ==].(sjsonnet/test/resources/test_suite/error.equality_function.jsonnet:17:16)
         |""".stripMargin
     )
     test("field_not_exist") - check(
       """sjsonnet.Error: Field does not exist: y
-        |    at .(sjsonnet/test/resources/test_suite/error.field_not_exist.jsonnet:17:9)
+        |    at [Select y].(sjsonnet/test/resources/test_suite/error.field_not_exist.jsonnet:17:9)
         |""".stripMargin
     )
     test("function_arg_positional_after_named") - check(
@@ -140,7 +140,7 @@ object ErrorTests extends TestSuite{
 
     test("function_duplicate_arg") - check(
       """sjsonnet.Error: binding parameter a second time: x
-        |    at .(sjsonnet/test/resources/test_suite/error.function_duplicate_arg.jsonnet:17:21)
+        |    at [Apply].(sjsonnet/test/resources/test_suite/error.function_duplicate_arg.jsonnet:17:21)
         |""".stripMargin
     )
     test("function_duplicate_param") - check(
@@ -148,136 +148,136 @@ object ErrorTests extends TestSuite{
     )
     test("function_too_many_args") - check(
       """sjsonnet.Error: Too many args, function has 2 parameter(s)
-        |    at .(sjsonnet/test/resources/test_suite/error.function_too_many_args.jsonnet:19:4)
+        |    at [Apply3].(sjsonnet/test/resources/test_suite/error.function_too_many_args.jsonnet:19:4)
         |""".stripMargin
     )
     test("import_empty") - check(
       """sjsonnet.Error: Couldn't import file: ""
-        |    at .(sjsonnet/test/resources/test_suite/error.import_empty.jsonnet:17:1)
+        |    at [Import].(sjsonnet/test/resources/test_suite/error.import_empty.jsonnet:17:1)
         |""".stripMargin
     )
     test("import_folder") - check(
       """sjsonnet.Error: Couldn't import file: "lib"
-        |    at .(sjsonnet/test/resources/test_suite/error.import_folder.jsonnet:17:1)
+        |    at [Import].(sjsonnet/test/resources/test_suite/error.import_folder.jsonnet:17:1)
         |""".stripMargin
     )
     test("import_folder_slash") - check(
       """sjsonnet.Error: Couldn't import file: "lib/"
-        |    at .(sjsonnet/test/resources/test_suite/error.import_folder_slash.jsonnet:17:1)
+        |    at [Import].(sjsonnet/test/resources/test_suite/error.import_folder_slash.jsonnet:17:1)
         |""".stripMargin
     )
     "import_static-check-failure" - check(
       """sjsonnet.Error: Unknown variable x
-        |    at .(sjsonnet/test/resources/test_suite/lib/static_check_failure.jsonnet:2:1)
-        |    at .(sjsonnet/test/resources/test_suite/error.import_static-check-failure.jsonnet:1:1)
+        |    at [Id x].(sjsonnet/test/resources/test_suite/lib/static_check_failure.jsonnet:2:1)
+        |    at [Import].(sjsonnet/test/resources/test_suite/error.import_static-check-failure.jsonnet:1:1)
         |""".stripMargin
     )
     "import_syntax-error" - check(
       """sjsonnet.Error: Imported file "lib/syntax_error.jsonnet" had Parse error. Expected "\"":2:1, found ""
-        |    at .(sjsonnet/test/resources/test_suite/error.import_syntax-error.jsonnet:1:1)
+        |    at [Import].(sjsonnet/test/resources/test_suite/error.import_syntax-error.jsonnet:1:1)
         |""".stripMargin
     )
     test("inside_equals_array") - check(
       """sjsonnet.Error: foobar
-        |    at .(sjsonnet/test/resources/test_suite/error.inside_equals_array.jsonnet:18:18)
-        |    at .(sjsonnet/test/resources/test_suite/error.inside_equals_array.jsonnet:19:3)
+        |    at [Error].(sjsonnet/test/resources/test_suite/error.inside_equals_array.jsonnet:18:18)
+        |    at [BinaryOp ==].(sjsonnet/test/resources/test_suite/error.inside_equals_array.jsonnet:19:3)
         |""".stripMargin
     )
     test("inside_equals_object") - check(
       """sjsonnet.Error: foobar
-        |    at .(sjsonnet/test/resources/test_suite/error.inside_equals_object.jsonnet:18:22)
-        |    at .(sjsonnet/test/resources/test_suite/error.inside_equals_object.jsonnet:19:3)
+        |    at [Error].(sjsonnet/test/resources/test_suite/error.inside_equals_object.jsonnet:18:22)
+        |    at [BinaryOp ==].(sjsonnet/test/resources/test_suite/error.inside_equals_object.jsonnet:19:3)
         |""".stripMargin
     )
     test("inside_tostring_array") - check(
       """sjsonnet.Error: foobar
-        |    at .(sjsonnet/test/resources/test_suite/error.inside_tostring_array.jsonnet:17:8)
-        |    at .(sjsonnet/test/resources/test_suite/error.inside_tostring_array.jsonnet:17:24)
+        |    at [Error].(sjsonnet/test/resources/test_suite/error.inside_tostring_array.jsonnet:17:8)
+        |    at [BinaryOp +].(sjsonnet/test/resources/test_suite/error.inside_tostring_array.jsonnet:17:24)
         |""".stripMargin
     )
     test("inside_tostring_object") - check(
       """sjsonnet.Error: foobar
-        |    at .(sjsonnet/test/resources/test_suite/error.inside_tostring_object.jsonnet:17:12)
-        |    at .(sjsonnet/test/resources/test_suite/error.inside_tostring_object.jsonnet:17:29)
+        |    at [Error].(sjsonnet/test/resources/test_suite/error.inside_tostring_object.jsonnet:17:12)
+        |    at [BinaryOp +].(sjsonnet/test/resources/test_suite/error.inside_tostring_object.jsonnet:17:29)
         |""".stripMargin
     )
     test("invariant") - {
       test("avoid_output_change") - check(
         """sjsonnet.Error: Assertion failed
-          |    at .(sjsonnet/test/resources/test_suite/error.invariant.avoid_output_change.jsonnet:18:15)
+          |    at [Assert].(sjsonnet/test/resources/test_suite/error.invariant.avoid_output_change.jsonnet:18:15)
         |""".stripMargin
       )
       test("equality") - check(
         """sjsonnet.Error: Assertion failed
-          |    at .(sjsonnet/test/resources/test_suite/error.invariant.equality.jsonnet:17:10)
-          |    at .(sjsonnet/test/resources/test_suite/error.invariant.equality.jsonnet:17:24)
+          |    at [Assert].(sjsonnet/test/resources/test_suite/error.invariant.equality.jsonnet:17:10)
+          |    at [BinaryOp ==].(sjsonnet/test/resources/test_suite/error.invariant.equality.jsonnet:17:24)
         |""".stripMargin
       )
       test("option") - check(
         """sjsonnet.Error: Assertion failed: Option "d" not in ["a","b","c"].
-          |    at .(sjsonnet/test/resources/test_suite/error.invariant.option.jsonnet:19:57)
+          |    at [Assert].(sjsonnet/test/resources/test_suite/error.invariant.option.jsonnet:19:57)
         |""".stripMargin
       )
       test("simple") - check(
         """sjsonnet.Error: Assertion failed
-          |    at .(sjsonnet/test/resources/test_suite/error.invariant.simple.jsonnet:18:10)
+          |    at [Assert].(sjsonnet/test/resources/test_suite/error.invariant.simple.jsonnet:18:10)
         |""".stripMargin
       )
       test("simple2") - check(
         """sjsonnet.Error: Assertion failed: my error message
-          |    at .(sjsonnet/test/resources/test_suite/error.invariant.simple2.jsonnet:18:12)
+          |    at [Assert].(sjsonnet/test/resources/test_suite/error.invariant.simple2.jsonnet:18:12)
         |""".stripMargin
       )
       test("simple3") - check(
         """sjsonnet.Error: my error message
-          |    at .(sjsonnet/test/resources/test_suite/error.invariant.simple3.jsonnet:18:10)
+          |    at [Error].(sjsonnet/test/resources/test_suite/error.invariant.simple3.jsonnet:18:10)
         |""".stripMargin
       )
     }
     test("native_not_found") - check(
       """sjsonnet.Error: Field does not exist: native
-        |    at .(sjsonnet/test/resources/test_suite/error.native_not_found.jsonnet:17:4)
-        |    at .(sjsonnet/test/resources/test_suite/error.native_not_found.jsonnet:17:11)
+        |    at [Select native].(sjsonnet/test/resources/test_suite/error.native_not_found.jsonnet:17:4)
+        |    at [Apply1].(sjsonnet/test/resources/test_suite/error.native_not_found.jsonnet:17:11)
         |""".stripMargin
     )
     test("obj_assert") - {
       test("fail1") - check(
         """sjsonnet.Error: Assertion failed
-          |    at .(sjsonnet/test/resources/test_suite/error.obj_assert.fail1.jsonnet:20:25)
-          |    at .(sjsonnet/test/resources/test_suite/error.obj_assert.fail1.jsonnet:20:38)
-          |    at .(sjsonnet/test/resources/test_suite/error.obj_assert.fail1.jsonnet:20:50)
+          |    at [Assert].(sjsonnet/test/resources/test_suite/error.obj_assert.fail1.jsonnet:20:25)
+          |    at [BinaryOp ==].(sjsonnet/test/resources/test_suite/error.obj_assert.fail1.jsonnet:20:38)
+          |    at [And].(sjsonnet/test/resources/test_suite/error.obj_assert.fail1.jsonnet:20:50)
         |""".stripMargin
       )
       test("fail2") - check(
         """sjsonnet.Error: Assertion failed: foo was not equal to bar
-          |    at .(sjsonnet/test/resources/test_suite/error.obj_assert.fail2.jsonnet:20:25)
-          |    at .(sjsonnet/test/resources/test_suite/error.obj_assert.fail2.jsonnet:20:74)
-          |    at .(sjsonnet/test/resources/test_suite/error.obj_assert.fail2.jsonnet:20:86)
+          |    at [Assert].(sjsonnet/test/resources/test_suite/error.obj_assert.fail2.jsonnet:20:25)
+          |    at [BinaryOp ==].(sjsonnet/test/resources/test_suite/error.obj_assert.fail2.jsonnet:20:74)
+          |    at [And].(sjsonnet/test/resources/test_suite/error.obj_assert.fail2.jsonnet:20:86)
         |""".stripMargin
       )
     }
 
     test("import_wrong_nr_args") - checkImports(
       """|sjsonnet.Error: Function parameter y not bound in call
-         |    at .(sjsonnet/test/resources/imports/error.import_wrong_nr_args.jsonnet:3:6)
+         |    at [Apply1].(sjsonnet/test/resources/imports/error.import_wrong_nr_args.jsonnet:3:6)
          |""".stripMargin
     )
 
     test("wrong_named_arg") - checkImports(
       """|sjsonnet.Error: Function has no parameter z
-         |    at .(sjsonnet/test/resources/imports/error.wrong_named_arg.jsonnet:3:6)
+         |    at [Apply].(sjsonnet/test/resources/imports/error.wrong_named_arg.jsonnet:3:6)
          |""".stripMargin
     )
 
     test("too_many_arg") - checkImports(
       """|sjsonnet.Error: Too many args, function has 2 parameter(s)
-         |    at .(sjsonnet/test/resources/imports/error.too_many_arg.jsonnet:3:6)
+         |    at [Apply].(sjsonnet/test/resources/imports/error.too_many_arg.jsonnet:3:6)
          |""".stripMargin
     )
 
     test("too_many_arg_with_named_arg") - checkImports(
       """|sjsonnet.Error: binding parameter a second time: x
-         |    at .(sjsonnet/test/resources/imports/error.too_many_arg_with_named_arg.jsonnet:2:2)
+         |    at [Apply].(sjsonnet/test/resources/imports/error.too_many_arg_with_named_arg.jsonnet:2:2)
          |""".stripMargin
     )
   }

--- a/sjsonnet/test/src-jvm/sjsonnet/ErrorTestsJvmOnly.scala
+++ b/sjsonnet/test/src-jvm/sjsonnet/ErrorTestsJvmOnly.scala
@@ -21,13 +21,16 @@ object ErrorTestsJvmOnly extends TestSuite {
 
   val tests = Tests{
     test("array_recursive_manifest") - check(
-      """Stackoverflow while materializing, possibly due to recursive value""".stripMargin
+      """sjsonnet.Error: Stackoverflow while materializing, possibly due to recursive value
+        |""".stripMargin
     )
     test("obj_recursive") - check(
-      """Stackoverflow while materializing, possibly due to recursive value""".stripMargin
+      """sjsonnet.Error: Stackoverflow while materializing, possibly due to recursive value
+        |""".stripMargin
     )
     test("obj_recursive_manifest") - check(
-      """Stackoverflow while materializing, possibly due to recursive value""".stripMargin
+      """sjsonnet.Error: Stackoverflow while materializing, possibly due to recursive value
+        |""".stripMargin
     )
   }
 }

--- a/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
+++ b/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
@@ -314,11 +314,13 @@ object EvaluatorTests extends TestSuite{
     test("strict") {
       eval("({ a: 1 } { b: 2 }).a", false) ==> ujson.Num(1)
       evalErr("({ a: 1 } { b: 2 }).a", true) ==>
-        """Adjacent object literals not allowed in strict mode - Use '+' to concatenate objects"""
+        """sjsonnet.Error: Adjacent object literals not allowed in strict mode - Use '+' to concatenate objects
+          |at .(:1:11)""".stripMargin
       eval("local x = { c: 3 }; (x { a: 1 } { b: 2 }).a", false) ==> ujson.Num(1)
       eval("local x = { c: 3 }; (x { a: 1 }).a", true) ==> ujson.Num(1)
       evalErr("local x = { c: 3 }; ({ a: 1 } { b: 2 }).a", true) ==>
-        """Adjacent object literals not allowed in strict mode - Use '+' to concatenate objects"""
+        """sjsonnet.Error: Adjacent object literals not allowed in strict mode - Use '+' to concatenate objects
+          |at .(:1:31)""".stripMargin
     }
     test("objectDeclaration") {
       eval("{ ['foo']: x for x in  []}", false) ==> ujson.Obj()

--- a/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
+++ b/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
@@ -235,19 +235,19 @@ object EvaluatorTests extends TestSuite{
       assert(ex.getMessage.contains("Function has no parameter hello"))
     }
 
-    test("nakedSelf") {
-      val ex = intercept[Exception]{eval("self.x")}
-      assert(ex.getMessage.contains("Cannot use `self` outside an object"))
-    }
-
-    test("nakedDollar") {
-      val ex = intercept[Exception]{eval("$.x")}
-      assert(ex.getMessage.contains("Cannot use `$` outside an object"))
-    }
-
-    test("nakedSuper") {
-      val ex = intercept[Exception]{eval("super.x")}
-      assert(ex.getMessage.contains("Cannot use `super` outside an object"))
+    test("unknownVariable") {
+      evalErr("x") ==>
+        """sjsonnet.StaticError: Unknown variable: x
+          |at [Id x].(:1:1)""".stripMargin
+      evalErr("self.x") ==>
+        """sjsonnet.StaticError: Can't use self outside of an object
+          |at [Self].(:1:1)""".stripMargin
+      evalErr("$.x") ==>
+        """sjsonnet.StaticError: Can't use $ outside of an object
+          |at [$].(:1:1)""".stripMargin
+      evalErr("super.x") ==>
+        """sjsonnet.StaticError: Can't use super outside of an object
+          |at [Super].(:1:1)""".stripMargin
     }
 
     test("validParam") {
@@ -314,13 +314,13 @@ object EvaluatorTests extends TestSuite{
     test("strict") {
       eval("({ a: 1 } { b: 2 }).a", false) ==> ujson.Num(1)
       evalErr("({ a: 1 } { b: 2 }).a", true) ==>
-        """sjsonnet.Error: Adjacent object literals not allowed in strict mode - Use '+' to concatenate objects
-          |at .(:1:11)""".stripMargin
+        """sjsonnet.StaticError: Adjacent object literals not allowed in strict mode - Use '+' to concatenate objects
+          |at [ObjExtend].(:1:11)""".stripMargin
       eval("local x = { c: 3 }; (x { a: 1 } { b: 2 }).a", false) ==> ujson.Num(1)
       eval("local x = { c: 3 }; (x { a: 1 }).a", true) ==> ujson.Num(1)
       evalErr("local x = { c: 3 }; ({ a: 1 } { b: 2 }).a", true) ==>
-        """sjsonnet.Error: Adjacent object literals not allowed in strict mode - Use '+' to concatenate objects
-          |at .(:1:31)""".stripMargin
+        """sjsonnet.StaticError: Adjacent object literals not allowed in strict mode - Use '+' to concatenate objects
+          |at [ObjExtend].(:1:31)""".stripMargin
     }
     test("objectDeclaration") {
       eval("{ ['foo']: x for x in  []}", false) ==> ujson.Obj()

--- a/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
+++ b/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
@@ -127,9 +127,9 @@ object EvaluatorTests extends TestSuite{
           ujson.Obj("a" -> ujson.Num(10))
         evalErr("""local x = { a: 1, b: { c: 2 }}; x { a: super.a * 10, b:: { c: super.b.c * 10 } }.b""") ==>
         """sjsonnet.Error: Attempt to use `super` when there is no super class
-          |at .(:1:68)
-          |at .(:1:70)
-          |at .(:1:73)""".stripMargin
+          |at [SelectSuper b].(:1:68)
+          |at [Select c].(:1:70)
+          |at [BinaryOp *].(:1:73)""".stripMargin
       }
     }
     test("hidden") {

--- a/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
+++ b/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
@@ -127,7 +127,9 @@ object EvaluatorTests extends TestSuite{
           ujson.Obj("a" -> ujson.Num(10))
         evalErr("""local x = { a: 1, b: { c: 2 }}; x { a: super.a * 10, b:: { c: super.b.c * 10 } }.b""") ==>
         """sjsonnet.Error: Attempt to use `super` when there is no super class
-          |at .(:1:68)""".stripMargin
+          |at .(:1:68)
+          |at .(:1:70)
+          |at .(:1:73)""".stripMargin
       }
     }
     test("hidden") {


### PR DESCRIPTION
- More consistent error handling:
  - Remove Error.Delegate
  - Skip JVM stack trace handling
  - Consistent formatting of raw delegate errors and regular positioned errors
- Unify error stack trace handling:
  Instead of sprinkling error propagation with or without stack frames all over the Evaluator and other parts of the codebase, we now do it in one place (visitExpr) with additional logic in Error.withStackFrame. Duplicate frames are skipped, an error without any stack frame always gets the current position, and all other frames are added or skipped depending on the Expr at the position.
- Add expression types to stack traces:
  This makes stack traces much more descriptive. We also change some of the reported positions / expr types to better match the semantics of the errors.
- Consistent treatment of parse errors:
  They are reported as sjsonnet.ParseError with normal stack traces instead of the previous one-liners which required customized error messages for parse errors in imported files. Errors are now stored as Error objects instead of Strings in the parse cache. This paves the way for error reporting during static evaluation and it is already required now to translate the paths in parse error stack traces to a different base directory (when reusing a cached parse error from a previous run).
- Static errors for unknown variables:
  Unknown variables and illegal self/super/$ references are now checked statically as they are supposed to be. Error messages are consistent with Google Jsonnet's.

Fixes #122