### PR TITLE
Add support for warnings and --no-static-errors

### DIFF
--- a/bench/src/main/scala/sjsonnet/ProfilingEvaluator.scala
+++ b/bench/src/main/scala/sjsonnet/ProfilingEvaluator.scala
@@ -8,11 +8,9 @@ import scala.jdk.CollectionConverters._
 class ProfilingEvaluator(resolver: CachedResolver,
                          extVars: Map[String, ujson.Value],
                          wd: Path,
-                         preserveOrder: Boolean = false,
-                         strict: Boolean,
-                         noStaticErrors: Boolean,
+                         settings: Settings,
                          warn: Error => Unit)
-  extends Evaluator(resolver, extVars, wd, preserveOrder, strict, noStaticErrors, warn) {
+  extends Evaluator(resolver, extVars, wd, settings, warn) {
 
   trait Box {
     def name: String

--- a/bench/src/main/scala/sjsonnet/ProfilingEvaluator.scala
+++ b/bench/src/main/scala/sjsonnet/ProfilingEvaluator.scala
@@ -9,8 +9,10 @@ class ProfilingEvaluator(resolver: CachedResolver,
                          extVars: Map[String, ujson.Value],
                          wd: Path,
                          preserveOrder: Boolean = false,
-                         strict: Boolean)
-  extends Evaluator(resolver, extVars, wd, preserveOrder, strict) {
+                         strict: Boolean,
+                         noStaticErrors: Boolean,
+                         warn: Error => Unit)
+  extends Evaluator(resolver, extVars, wd, preserveOrder, strict, noStaticErrors, warn) {
 
   trait Box {
     def name: String

--- a/bench/src/main/scala/sjsonnet/RunProfiler.scala
+++ b/bench/src/main/scala/sjsonnet/RunProfiler.scala
@@ -15,9 +15,8 @@ object RunProfiler extends App {
     importer = SjsonnetMain.resolveImport(config.jpaths.map(os.Path(_, wd)).map(OsPath(_)), None),
   ) {
     override def createEvaluator(resolver: CachedResolver, extVars: Map[String, ujson.Value], wd: Path,
-                                 preserveOrder: Boolean, strict: Boolean, noStaticErrors: Boolean,
-                                 warn: Error => Unit): Evaluator =
-      new ProfilingEvaluator(resolver, extVars, wd, preserveOrder, strict, noStaticErrors, warn)
+                                 settings: Settings, warn: Error => Unit): Evaluator =
+      new ProfilingEvaluator(resolver, extVars, wd, settings, warn)
   }
   val profiler = interp.evaluator.asInstanceOf[ProfilingEvaluator]
 

--- a/bench/src/main/scala/sjsonnet/RunProfiler.scala
+++ b/bench/src/main/scala/sjsonnet/RunProfiler.scala
@@ -15,8 +15,9 @@ object RunProfiler extends App {
     importer = SjsonnetMain.resolveImport(config.jpaths.map(os.Path(_, wd)).map(OsPath(_)), None),
   ) {
     override def createEvaluator(resolver: CachedResolver, extVars: Map[String, ujson.Value], wd: Path,
-                                 preserveOrder: Boolean, strict: Boolean): Evaluator =
-      new ProfilingEvaluator(resolver, extVars, wd, preserveOrder, strict)
+                                 preserveOrder: Boolean, strict: Boolean, noStaticErrors: Boolean,
+                                 warn: Error => Unit): Evaluator =
+      new ProfilingEvaluator(resolver, extVars, wd, preserveOrder, strict, noStaticErrors, warn)
   }
   val profiler = interp.evaluator.asInstanceOf[ProfilingEvaluator]
 

--- a/sjsonnet/server/src/sjsonnet/SjsonnetServerMain.scala
+++ b/sjsonnet/server/src/sjsonnet/SjsonnetServerMain.scala
@@ -24,7 +24,7 @@ trait SjsonnetServerMain[T]{
             wd: os.Path): (Boolean, Option[T])
 }
 
-object SjsonnetServerMain extends SjsonnetServerMain[collection.mutable.HashMap[(Path, String), Either[String, (Expr, FileScope)]]]{
+object SjsonnetServerMain extends SjsonnetServerMain[collection.mutable.HashMap[(Path, String), Either[Error, (Expr, FileScope)]]]{
   def main(args0: Array[String]): Unit = {
     // Disable SIGINT interrupt signal in the Mill server.
     //
@@ -45,7 +45,7 @@ object SjsonnetServerMain extends SjsonnetServerMain[collection.mutable.HashMap[
     ).run()
   }
   def main0(args: Array[String],
-            stateCache: Option[collection.mutable.HashMap[(Path, String), Either[String, (Expr, FileScope)]]],
+            stateCache: Option[collection.mutable.HashMap[(Path, String), Either[Error, (Expr, FileScope)]]],
             mainInteractive: Boolean,
             stdin: InputStream,
             stdout: PrintStream,
@@ -55,7 +55,7 @@ object SjsonnetServerMain extends SjsonnetServerMain[collection.mutable.HashMap[
             wd: os.Path) = {
 
     val stateCache2 = stateCache.getOrElse{
-      val p = collection.mutable.HashMap[(Path, String), Either[String, (Expr, FileScope)]]()
+      val p = collection.mutable.HashMap[(Path, String), Either[Error, (Expr, FileScope)]]()
       this.stateCache = Some(p)
       p
     }

--- a/sjsonnet/src-js/sjsonnet/SjsonnetMain.scala
+++ b/sjsonnet/src-js/sjsonnet/SjsonnetMain.scala
@@ -6,7 +6,7 @@ import scala.scalajs.js.annotation.{JSExport, JSExportTopLevel}
 
 @JSExportTopLevel("SjsonnetMain")
 object SjsonnetMain {
-  def createParseCache() = collection.mutable.HashMap[(Path, String), Either[String, (Expr, FileScope)]]()
+  def createParseCache() = collection.mutable.HashMap[(Path, String), Either[Error, (Expr, FileScope)]]()
   @JSExport
   def interpret(text: String,
                 extVars: js.Any,

--- a/sjsonnet/src-js/sjsonnet/SjsonnetMain.scala
+++ b/sjsonnet/src-js/sjsonnet/SjsonnetMain.scala
@@ -28,7 +28,7 @@ object SjsonnetMain {
         def read(path: Path): Option[String] =
           Option(importLoader(path.asInstanceOf[JsVirtualPath].path))
       },
-      preserveOrder,
+      new Settings(preserveOrder = preserveOrder),
       parseCache = createParseCache()
     )
     interp.interpret0(text, JsVirtualPath("(memory)"), ujson.WebJson.Builder) match{

--- a/sjsonnet/src-jvm-native/sjsonnet/Config.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/Config.scala
@@ -113,4 +113,9 @@ case class Config(
     doc = "Turn static errors into warnings"
   )
   noStaticErrors: Flag = Flag(),
+  @arg(
+    name = "fatal-warnings",
+    doc = "Fail if any warnings were emitted"
+  )
+  fatalWarnings: Flag = Flag(),
 )

--- a/sjsonnet/src-jvm-native/sjsonnet/Config.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/Config.scala
@@ -107,5 +107,10 @@ case class Config(
     name = "yaml-debug",
     doc = "Generate source line comments in the output YAML doc to make it easier to figure out where values come from."
   )
-  yamlDebug: Flag = Flag()
+  yamlDebug: Flag = Flag(),
+  @arg(
+    name = "no-static-errors",
+    doc = "Turn static errors into warnings"
+  )
+  noStaticErrors: Flag = Flag(),
 )

--- a/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMain.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMain.scala
@@ -187,12 +187,14 @@ object SjsonnetMain {
         }
         case None => resolveImport(config.jpaths.map(os.Path(_, wd)).map(OsPath(_)), allowedInputs)
       },
-      preserveOrder = config.preserveOrder.value,
-      strict = config.strict.value,
+      settings = new Settings(
+        preserveOrder = config.preserveOrder.value,
+        strict = config.strict.value,
+        noStaticErrors = config.noStaticErrors.value,
+      ),
       storePos = if (config.yamlDebug.value) currentPos = _ else null,
       parseCache,
-      warnLogger,
-      config.noStaticErrors.value
+      warnLogger
     )
 
     (config.multi, config.yamlStream.value) match {

--- a/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMain.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMain.scala
@@ -43,10 +43,6 @@ object SjsonnetMain {
     System.exit(exitCode)
   }
 
-  private def warn(out: PrintStream, msg: String): Unit = {
-    out.println("[warning] "+msg)
-  }
-
   def main0(args: Array[String],
             parseCache: collection.mutable.HashMap[(Path, String), Either[Error, (Expr, FileScope)]],
             stdin: InputStream,
@@ -55,6 +51,12 @@ object SjsonnetMain {
             wd: os.Path,
             allowedInputs: Option[Set[os.Path]] = None,
             importer: Option[(Path, String) => Option[os.Path]] = None): Int = {
+
+    var hasWarnings = false
+    def warn(msg: String): Unit = {
+      hasWarnings = true
+      stderr.println("[warning] "+msg)
+    }
 
     val parser = mainargs.ParserForClass[Config]
     val name = s"Sjsonnet ${sjsonnet.Version.version}"
@@ -70,8 +72,12 @@ object SjsonnetMain {
           Left("error: -i/--interactive must be passed in as the first argument")
         }else Right(config.file)
       }
-      outputStr <- mainConfigured(file, config, parseCache, wd, allowedInputs, importer, warn(stderr, _))
-    } yield outputStr
+      outputStr <- mainConfigured(file, config, parseCache, wd, allowedInputs, importer, warn)
+      res <- {
+        if(hasWarnings && config.fatalWarnings.value) Left("")
+        else Right(outputStr)
+      }
+    } yield res
 
     result match{
       case Left(err) =>

--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -18,9 +18,7 @@ import scala.collection.mutable
 class Evaluator(resolver: CachedResolver,
                 val extVars: Map[String, ujson.Value],
                 val wd: Path,
-                val preserveOrder: Boolean = false,
-                val strict: Boolean = false,
-                val noStaticErrors: Boolean = false,
+                val settings: Settings,
                 warnLogger: Error => Unit = null) extends EvalScope {
   implicit def evalScope: EvalScope = this
   def importer: CachedImporter = resolver

--- a/sjsonnet/src/sjsonnet/Interpreter.scala
+++ b/sjsonnet/src/sjsonnet/Interpreter.scala
@@ -15,12 +15,10 @@ class Interpreter(extVars: Map[String, ujson.Value],
                   tlaVars: Map[String, ujson.Value],
                   wd: Path,
                   importer: Importer,
-                  preserveOrder: Boolean = false,
-                  strict: Boolean = false,
+                  settings: Settings = Settings.default,
                   storePos: Position => Unit = null,
                   val parseCache: mutable.HashMap[(Path, String), Either[Error, (Expr, FileScope)]] = new mutable.HashMap,
                   warnLogger: (String => Unit) = null,
-                  noStaticErrors: Boolean = false,
                   ) { self =>
 
   val resolver = new CachedResolver(importer, parseCache) {
@@ -31,11 +29,10 @@ class Interpreter(extVars: Map[String, ujson.Value],
   private def warn(e: Error): Unit = warnLogger("[warning] " + formatError(e))
 
   def createEvaluator(resolver: CachedResolver, extVars: Map[String, ujson.Value], wd: Path,
-                      preserveOrder: Boolean, strict: Boolean, noStaticErrors: Boolean,
-                      warn: Error => Unit): Evaluator =
-    new Evaluator(resolver, extVars, wd, preserveOrder, strict, noStaticErrors, warn)
+                      settings: Settings, warn: Error => Unit): Evaluator =
+    new Evaluator(resolver, extVars, wd, settings, warn)
 
-  val evaluator: Evaluator = createEvaluator(resolver, extVars, wd, preserveOrder, strict, noStaticErrors, warn)
+  val evaluator: Evaluator = createEvaluator(resolver, extVars, wd, settings, warn)
 
   def formatError(e: Error): String = {
     val s = new StringWriter()

--- a/sjsonnet/src/sjsonnet/Materializer.scala
+++ b/sjsonnet/src/sjsonnet/Materializer.scala
@@ -26,7 +26,7 @@ abstract class Materializer {
         storePos(obj.pos)
         obj.triggerAllAsserts(obj)
         val objVisitor = visitor.visitObject(obj.visibleKeyNames.length , -1)
-        obj.foreachElement(!evaluator.preserveOrder, evaluator.emptyMaterializeFileScopePos) { (k, v) =>
+        obj.foreachElement(!evaluator.settings.preserveOrder, evaluator.emptyMaterializeFileScopePos) { (k, v) =>
           storePos(v)
           objVisitor.visitKeyValue(objVisitor.visitKey(-1).visitString(k, -1))
           objVisitor.visitValue(

--- a/sjsonnet/src/sjsonnet/Settings.scala
+++ b/sjsonnet/src/sjsonnet/Settings.scala
@@ -1,0 +1,13 @@
+package sjsonnet
+
+/** Settings for the interpreter. This is a subset of Config which is used in the inner layers
+ * of the interpreters and shared between all platforms.  */
+class Settings(
+  val preserveOrder: Boolean = false,
+  val strict: Boolean = false,
+  val noStaticErrors: Boolean = false,
+)
+
+object Settings {
+  val default = new Settings()
+}

--- a/sjsonnet/src/sjsonnet/StaticOptimizer.scala
+++ b/sjsonnet/src/sjsonnet/StaticOptimizer.scala
@@ -10,7 +10,7 @@ class StaticOptimizer(ev: EvalScope) extends ScopedExprTransform {
 
   def failOrWarn(msg: String, expr: Expr): Expr = {
     val e = new StaticError(msg, new sjsonnet.Error.Frame(expr.pos, expr.exprErrorString)(ev) :: Nil, None)
-    if(ev.noStaticErrors) {
+    if(ev.settings.noStaticErrors) {
       ev.warn(e)
       expr
     } else throw e
@@ -77,7 +77,7 @@ class StaticOptimizer(ev: EvalScope) extends ScopedExprTransform {
 
   private def check(e: Expr): Expr = {
     e match {
-      case ObjExtend(pos, base, ext) if ev.strict && isObjLiteral(base) =>
+      case ObjExtend(pos, base, ext) if ev.settings.strict && isObjLiteral(base) =>
         StaticError.fail("Adjacent object literals not allowed in strict mode - Use '+' to concatenate objects", e)(ev)
       case _ =>
     }

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -1325,7 +1325,7 @@ object Std {
     maybeSortKeys(ev, v1.allKeyNames)
   
   @inline private[this] def maybeSortKeys(ev: EvalScope, keys: Array[String]): Array[String] =
-    if(ev.preserveOrder) keys else keys.sorted
+    if(ev.settings.preserveOrder) keys else keys.sorted
 
   def getObjValuesFromKeys(pos: Position, ev: EvalScope, v1: Val.Obj, keys: Array[String]): Val.Arr =
     new Val.Arr(pos, keys.map { k =>

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -515,4 +515,6 @@ abstract class EvalScope extends EvalErrorScope {
 
   def preserveOrder: Boolean
   def strict: Boolean
+  def noStaticErrors: Boolean
+  def warn(e: Error): Unit
 }

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -513,8 +513,6 @@ abstract class EvalScope extends EvalErrorScope {
   val emptyMaterializeFileScope = new FileScope(wd / "(materialize)")
   val emptyMaterializeFileScopePos = new Position(emptyMaterializeFileScope, -1)
 
-  def preserveOrder: Boolean
-  def strict: Boolean
-  def noStaticErrors: Boolean
+  def settings: Settings
   def warn(e: Error): Unit
 }

--- a/sjsonnet/test/resources/db/unused_illegal_var.jsonnet
+++ b/sjsonnet/test/resources/db/unused_illegal_var.jsonnet
@@ -1,0 +1,2 @@
+local x = bad;
+true

--- a/sjsonnet/test/src-jvm-native/sjsonnet/ErrorTests.scala
+++ b/sjsonnet/test/src-jvm-native/sjsonnet/ErrorTests.scala
@@ -12,7 +12,7 @@ object ErrorTests extends TestSuite{
       OsPath(os.pwd),
       importer = sjsonnet.SjsonnetMain.resolveImport(Array.empty[Path]),
       warnLogger = (msg: String) => out.append(msg).append('\n'),
-      noStaticErrors = noStaticErrors
+      settings = new Settings(noStaticErrors = noStaticErrors),
     )
     interp.interpret(os.read(p), OsPath(p)).left.map(s => out.toString + s)
   }

--- a/sjsonnet/test/src-jvm-native/sjsonnet/ErrorTests.scala
+++ b/sjsonnet/test/src-jvm-native/sjsonnet/ErrorTests.scala
@@ -4,23 +4,26 @@ import utest._
 
 object ErrorTests extends TestSuite{
   val testSuiteRoot = os.pwd / "sjsonnet" / "test" / "resources" / "test_suite"
-  def eval(p: os.Path) = {
+  def eval(p: os.Path, noStaticErrors: Boolean) = {
+    val out = new StringBuffer()
     val interp = new Interpreter(
       Map(),
       Map(),
       OsPath(os.pwd),
       importer = sjsonnet.SjsonnetMain.resolveImport(Array.empty[Path]),
+      warnLogger = (msg: String) => out.append(msg).append('\n'),
+      noStaticErrors = noStaticErrors
     )
-    interp.interpret(os.read(p), OsPath(p))
+    interp.interpret(os.read(p), OsPath(p)).left.map(s => out.toString + s)
   }
-  def check(expected: String)(implicit tp: utest.framework.TestPath) = {
-    val res = eval(testSuiteRoot / s"error.${tp.value.mkString(".")}.jsonnet")
+  def check(expected: String, noStaticErrors: Boolean = false)(implicit tp: utest.framework.TestPath) = {
+    val res = eval(testSuiteRoot / s"error.${tp.value.mkString(".")}.jsonnet", noStaticErrors)
 
     assert(res == Left(expected))
   }
 
   def checkImports(expected: String)(implicit tp: utest.framework.TestPath) = {
-    val res = eval(os.pwd / "sjsonnet" / "test" / "resources" / "imports" / s"error.${tp.value.mkString(".")}.jsonnet")
+    val res = eval(os.pwd / "sjsonnet" / "test" / "resources" / "imports" / s"error.${tp.value.mkString(".")}.jsonnet", false)
 
     assert(res == Left(expected))
   }
@@ -114,11 +117,22 @@ object ErrorTests extends TestSuite{
         |    at [ForSpec].(sjsonnet/test/resources/test_suite/error.comprehension_spec_object2.jsonnet:17:13)
         |""".stripMargin
     )
-    test("computed_field_scope") - check(
-      """sjsonnet.StaticError: Unknown variable: x
-        |    at [Id x].(sjsonnet/test/resources/test_suite/error.computed_field_scope.jsonnet:17:21)
-        |""".stripMargin
-    )
+    test("computed_field_scope") - {
+      check(
+        """sjsonnet.StaticError: Unknown variable: x
+          |    at [Id x].(sjsonnet/test/resources/test_suite/error.computed_field_scope.jsonnet:17:21)
+          |""".stripMargin
+      )
+      check(
+        """[warning] sjsonnet.StaticError: Unknown variable: x
+          |    at [Id x].(sjsonnet/test/resources/test_suite/error.computed_field_scope.jsonnet:17:21)
+          |
+          |sjsonnet.Error: Unknown variable: x
+          |    at [Id x].(sjsonnet/test/resources/test_suite/error.computed_field_scope.jsonnet:17:21)
+          |""".stripMargin,
+        noStaticErrors = true
+      )
+    }
     test("divide_zero") - check(
       """sjsonnet.Error: division by zero
         |    at [BinaryOp /].(sjsonnet/test/resources/test_suite/error.divide_zero.jsonnet:17:5)
@@ -170,12 +184,24 @@ object ErrorTests extends TestSuite{
         |    at [Import].(sjsonnet/test/resources/test_suite/error.import_folder_slash.jsonnet:17:1)
         |""".stripMargin
     )
-    "import_static-check-failure" - check(
-      """sjsonnet.StaticError: Unknown variable: x
-        |    at [Id x].(sjsonnet/test/resources/test_suite/lib/static_check_failure.jsonnet:2:1)
-        |    at [Import].(sjsonnet/test/resources/test_suite/error.import_static-check-failure.jsonnet:1:1)
-        |""".stripMargin
-    )
+    "import_static-check-failure" - {
+      check(
+        """sjsonnet.StaticError: Unknown variable: x
+          |    at [Id x].(sjsonnet/test/resources/test_suite/lib/static_check_failure.jsonnet:2:1)
+          |    at [Import].(sjsonnet/test/resources/test_suite/error.import_static-check-failure.jsonnet:1:1)
+          |""".stripMargin
+      )
+      check(
+        """[warning] sjsonnet.StaticError: Unknown variable: x
+          |    at [Id x].(sjsonnet/test/resources/test_suite/lib/static_check_failure.jsonnet:2:1)
+          |
+          |sjsonnet.Error: Unknown variable: x
+          |    at [Id x].(sjsonnet/test/resources/test_suite/lib/static_check_failure.jsonnet:2:1)
+          |    at [Import].(sjsonnet/test/resources/test_suite/error.import_static-check-failure.jsonnet:1:1)
+          |""".stripMargin,
+        noStaticErrors = true
+      )
+    }
     "import_syntax-error" - check(
       """sjsonnet.ParseError: Expected "\"":2:1, found ""
         |    at .(sjsonnet/test/resources/test_suite/lib/syntax_error.jsonnet:2:1)

--- a/sjsonnet/test/src-jvm-native/sjsonnet/MainTests.scala
+++ b/sjsonnet/test/src-jvm-native/sjsonnet/MainTests.scala
@@ -7,12 +7,14 @@ import utest._
 
 object MainTests extends TestSuite {
 
-  val testSuiteRoot = os.pwd / "sjsonnet" / "test" / "resources" / "test_suite"
+  val testSuiteRoot = os.pwd / "sjsonnet" / "test" / "resources"
+  // stdout mode uses println so it has an extra platform-specific line separator at the end
+  val eol = System.getProperty("line.separator")
 
   val tests = Tests {
     // Compare writing to stdout with writing to a file
     test("writeToFile") {
-      val source = (testSuiteRoot / "local.jsonnet").toString()
+      val source = (testSuiteRoot / "test_suite" / "local.jsonnet").toString()
       val outF = File.createTempFile("sjsonnet", ".json")
       val out = new ByteArrayOutputStream()
       val pout = new PrintStream(out)
@@ -21,12 +23,29 @@ object MainTests extends TestSuite {
       SjsonnetMain.main0(Array("-o", outF.getAbsolutePath, source), collection.mutable.HashMap.empty, System.in, System.out, System.err, os.pwd, None)
       val stdoutBytes = out.toByteArray
       val fileBytes = os.read(os.Path(outF)).getBytes
-      // stdout mode uses println so it has an extra platform-specific line separator at the end
-      val eol = System.getProperty("line.separator").getBytes
 
       //println(stdoutBytes.map(_.toInt).mkString(","))
       //println(fileBytes.map(_.toInt).mkString(","))
-      assert(Arrays.equals(fileBytes ++ eol, stdoutBytes))
+      assert(Arrays.equals(fileBytes ++ eol.getBytes, stdoutBytes))
     }
+
+    test("warnings") {
+      val source = (testSuiteRoot / "db" / "unused_illegal_var.jsonnet").toString()
+      val (res1, out1, err1) = runMain(Seq(source))
+      val (res2, out2, err2) = runMain(Seq("--no-static-errors", source))
+      val (res3, out3, err3) = runMain(Seq("--no-static-errors", "--fatal-warnings", source))
+      assert(res1 == 1, res2 == 0, res3 == 1)
+      assert(out1.isEmpty, out2 == "true" + eol, out3.isEmpty)
+      assert(!err1.isEmpty, !err2.isEmpty, !err3.isEmpty)
+    }
+  }
+
+  def runMain(args: Seq[String]): (Int, String, String) = {
+    val err = new ByteArrayOutputStream()
+    val perr = new PrintStream(err, true, "UTF-8")
+    val out = new ByteArrayOutputStream()
+    val pout = new PrintStream(out, true, "UTF-8")
+    val res = SjsonnetMain.main0(args.toArray, collection.mutable.HashMap.empty, System.in, pout, perr, os.pwd, None)
+    (res, new String(out.toByteArray, "UTF-8"), new String(err.toByteArray, "UTF-8"))
   }
 }

--- a/sjsonnet/test/src/sjsonnet/FormatTests.scala
+++ b/sjsonnet/test/src/sjsonnet/FormatTests.scala
@@ -11,15 +11,12 @@ object FormatTests extends TestSuite{
     val formatted = Format.format(fmt, Materializer.reverse(null, json), dummyPos)(
       new EvalScope{
         def extVars: Map[String, Value] = Map()
-        def loadCachedSource(p: Path): Option[String] = None
         def wd: Path = DummyPath()
         def visitExpr(expr: Expr)(implicit scope: ValScope): Val = ???
         def materialize(v: Val): Value = ???
         def equal(x: Val, y: Val): Boolean = ???
         def importer: sjsonnet.CachedImporter = ???
-        def preserveOrder = false
-        def strict = false
-        def noStaticErrors = false
+        def settings = Settings.default
         def warn(e: Error) = ()
       }
     )

--- a/sjsonnet/test/src/sjsonnet/FormatTests.scala
+++ b/sjsonnet/test/src/sjsonnet/FormatTests.scala
@@ -19,6 +19,8 @@ object FormatTests extends TestSuite{
         def importer: sjsonnet.CachedImporter = ???
         def preserveOrder = false
         def strict = false
+        def noStaticErrors = false
+        def warn(e: Error) = ()
       }
     )
     assert(formatted == expected)

--- a/sjsonnet/test/src/sjsonnet/TestUtils.scala
+++ b/sjsonnet/test/src/sjsonnet/TestUtils.scala
@@ -7,8 +7,7 @@ object TestUtils {
       Map(),
       DummyPath(),
       Importer.empty,
-      preserveOrder = preserveOrder,
-      strict = strict
+      new Settings(preserveOrder = preserveOrder, strict = strict)
     ).interpret(s, DummyPath("(memory)")) match {
       case Right(x) => x
       case Left(e) => throw new Exception(e)


### PR DESCRIPTION
Warnings could prove useful in the long run if we want to add linting. `--no-static-errors` is provided for migrating from the previous version but should be removed again in the long term because the specification requires static error handling. Since warnings are not thrown they do not get a full stack trace. Only the actual position of the warning is reported.