### PR TITLE
Fix upper array bounds handling

### DIFF
--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -268,9 +268,9 @@ class Evaluator(resolver: CachedResolver,
     val pos = e.pos
     (visitExpr(e.value), visitExpr(e.index)) match {
       case (v: Val.Arr, i: Val.Num) =>
-        if (i.value >= v.length) Error.fail(s"array bounds error: ${i.value} not within [0, ${v.length})", pos)
         val int = i.value.toInt
         if (int != i.value) Error.fail("array index was not integer: " + i.value, pos)
+        if (int >= v.length) Error.fail(s"array bounds error: ${int} not within [0, ${v.length})", pos)
         v.force(int)
       case (v: Val.Str, i: Val.Num) => Val.Str(pos, new String(Array(v.value(i.value.toInt))))
       case (v: Val.Obj, i: Val.Str) =>

--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -268,7 +268,7 @@ class Evaluator(resolver: CachedResolver,
     val pos = e.pos
     (visitExpr(e.value), visitExpr(e.index)) match {
       case (v: Val.Arr, i: Val.Num) =>
-        if (i.value > v.length) Error.fail(s"array bounds error: ${i.value} not within [0, ${v.length})", pos)
+        if (i.value >= v.length) Error.fail(s"array bounds error: ${i.value} not within [0, ${v.length})", pos)
         val int = i.value.toInt
         if (int != i.value) Error.fail("array index was not integer: " + i.value, pos)
         v.force(int)

--- a/sjsonnet/test/src-jvm-native/sjsonnet/ErrorTests.scala
+++ b/sjsonnet/test/src-jvm-native/sjsonnet/ErrorTests.scala
@@ -92,7 +92,7 @@ object ErrorTests extends TestSuite{
         |""".stripMargin
     )
     test("array_large_index") - check(
-      """sjsonnet.Error: array bounds error: 1.8446744073709552E19 not within [0, 3)
+      """sjsonnet.Error: array index was not integer: 1.8446744073709552E19
         |    at [Lookup].(sjsonnet/test/resources/test_suite/error.array_large_index.jsonnet:17:10)
         |""".stripMargin
     )

--- a/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
+++ b/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
@@ -25,6 +25,9 @@ object EvaluatorTests extends TestSuite{
     test("arrays") {
       eval("[1, [2, 3], 4][1][0]") ==> ujson.Num(2)
       eval("([1, 2, 3] + [4, 5, 6])[3]") ==> ujson.Num(4)
+      evalErr("[][0]") ==>
+      """sjsonnet.Error: array bounds error: 0.0 not within [0, 0)
+        |at [Lookup].(:1:3)""".stripMargin
     }
     test("functions") {
       eval("(function(x) x)(1)") ==> ujson.Num(1)

--- a/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
+++ b/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
@@ -26,7 +26,7 @@ object EvaluatorTests extends TestSuite{
       eval("[1, [2, 3], 4][1][0]") ==> ujson.Num(2)
       eval("([1, 2, 3] + [4, 5, 6])[3]") ==> ujson.Num(4)
       evalErr("[][0]") ==>
-      """sjsonnet.Error: array bounds error: 0.0 not within [0, 0)
+      """sjsonnet.Error: array bounds error: 0 not within [0, 0)
         |at [Lookup].(:1:3)""".stripMargin
     }
     test("functions") {


### PR DESCRIPTION
`a[a.length]` was not detected correctly, leading to an internal error instead of the expected error message