### PR TITLE
Implement quote_keys flag for std functions manifestYamlDoc/manifestY…

### DIFF
--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -953,33 +953,45 @@ object Std {
     "manifestJsonEx" -> ManifestJsonEx,
     builtinWithDefaults("manifestYamlDoc",
                         "v" -> null,
-                        "indent_array_in_object" -> Val.False(dummyPos)){ (args, pos, ev) =>
+                        "indent_array_in_object" -> Val.False(dummyPos),
+                        "quote_keys" -> Val.True(dummyPos)){ (args, pos, ev) =>
       val v = args(0)
       val indentArrayInObject = args(1)  match {
           case Val.False(_) => false
           case Val.True(_) => true
           case _ => Error.fail("indent_array_in_object has to be a boolean, got" + v.getClass)
         }
+      val quoteKeys = args(2) match {
+        case Val.False(_) => false
+        case Val.True(_) => true
+        case _ => Error.fail("quote_keys has to be a boolean, got " + v.getClass)
+      }
       Materializer.apply0(
         v,
-        new YamlRenderer(indentArrayInObject = indentArrayInObject)
+        new YamlRenderer(indentArrayInObject = indentArrayInObject, quoteKeys = quoteKeys)
       )(ev).toString
     },
     builtinWithDefaults("manifestYamlStream",
                         "v" -> null,
-                        "indent_array_in_object" -> Val.False(dummyPos)){ (args, pos, ev) =>
+                        "indent_array_in_object" -> Val.False(dummyPos),
+                        "quote_keys" -> Val.True(dummyPos)){ (args, pos, ev) =>
       val v = args(0)
       val indentArrayInObject = args(1)  match {
         case Val.False(_) => false
         case Val.True(_) => true
         case _ => Error.fail("indent_array_in_object has to be a boolean, got" + v.getClass)
       }
+      val quoteKeys = args(2) match {
+        case Val.False(_) => false
+        case Val.True(_) => true
+        case _ => Error.fail("quote_keys has to be a boolean, got " + v.getClass)
+      }
       v match {
         case arr: Val.Arr => arr.asLazyArray
           .map { item =>
             Materializer.apply0(
               item.force,
-              new YamlRenderer(indentArrayInObject = indentArrayInObject)
+              new YamlRenderer(indentArrayInObject = indentArrayInObject, quoteKeys = quoteKeys)
             )(ev).toString()
           }
           .mkString("---\n", "\n---\n", "\n...\n")

--- a/sjsonnet/src/sjsonnet/YamlRenderer.scala
+++ b/sjsonnet/src/sjsonnet/YamlRenderer.scala
@@ -8,7 +8,7 @@ import upickle.core.{ArrVisitor, ObjVisitor}
 
 
 class YamlRenderer(_out: StringWriter = new java.io.StringWriter(), indentArrayInObject: Boolean = false,
-                   indent: Int = 2) extends BaseCharRenderer(_out, indent){
+                   quoteKeys: Boolean = true, indent: Int = 2) extends BaseCharRenderer(_out, indent){
   var newlineBuffered = false
   var dashBuffered = false
   var afterKey = false
@@ -27,6 +27,15 @@ class YamlRenderer(_out: StringWriter = new java.io.StringWriter(), indentArrayI
     while(i < len) {
       elemBuilder.appendUnsafeC(s.charAt(i))
       i += 1
+    }
+  }
+
+  private[this] def removeQuoteKey(): Unit = {
+    // refer to quote_keys parameter in https://jsonnet.org/ref/stdlib.html, only unquote keys
+    if (!quoteKeys && !afterKey) {
+      val key = elemBuilder.makeString()
+      elemBuilder.reset()
+      elemBuilder.appendAll(key.toCharArray, 1, key.length - 2);
     }
   }
 
@@ -49,6 +58,7 @@ class YamlRenderer(_out: StringWriter = new java.io.StringWriter(), indentArrayI
       depth -= 1
     } else {
       upickle.core.RenderUtils.escapeChar(unicodeCharBuilder, elemBuilder, s, true)
+      removeQuoteKey()
     }
     flushCharBuilder()
     _out

--- a/sjsonnet/test/src/sjsonnet/YamlRendererTests.scala
+++ b/sjsonnet/test/src/sjsonnet/YamlRendererTests.scala
@@ -30,7 +30,11 @@ object YamlRendererTests extends TestSuite{
         """- "a":
           |  - 1""".stripMargin
     }
-
+    test("noQuote") {
+      ujson.transform(ujson.Obj("k0" -> "v0", "k1" -> "(\\d+)"), new YamlRenderer(quoteKeys = false)).toString ==>
+      """k0: "v0"
+        |k1: "(\\d+)"""".stripMargin
+    }
   }
 
 }


### PR DESCRIPTION
…amlStream to match official jsonnet doc

### Purpose
This PR creates a flag documented in jsonnet official site std library: https://jsonnet.org/ref/stdlib.html for function
`manifestYamlDoc` and `manifestYamlStream`, it will allow us to generate yaml without quoting the keys.

### Test
* Tested via unit tests.
* compile sjsonnet using `./mill -i show "sjsonnet[2.13.4]".jvm.assembly` and run again a locally created test.jsonnet to output YAML via flag `--yaml-out`
