### PR TITLE
*New* Add UUID Function

### DIFF
--- a/sjsonnet/src-js/sjsonnet/Platform.scala
+++ b/sjsonnet/src-js/sjsonnet/Platform.scala
@@ -12,6 +12,9 @@ object Platform {
   def xzString(s: String): String = {
     throw new Exception("XZ not implemented in Scala.js")
   }
+  def uuid(length: Int): String = {
+    throw new Exception("UUID not implemented in Scala.js")
+  }
   def md5(s: String): String = {
     throw new Exception("MD5 not implemented in Scala.js")
   }

--- a/sjsonnet/src-jvm/sjsonnet/Platform.scala
+++ b/sjsonnet/src-jvm/sjsonnet/Platform.scala
@@ -31,6 +31,9 @@ object Platform {
   def xzString(s: String): String = {
     xzBytes(s.getBytes())
   }
+  def uuid(length: Int): String = {
+    java.util.UUID.randomUUID.toString.take(length)
+  }
   def md5(s: String): String = {
     java.security.MessageDigest.getInstance("MD5")
       .digest(s.getBytes("UTF-8"))

--- a/sjsonnet/src-native/sjsonnet/Platform.scala
+++ b/sjsonnet/src-native/sjsonnet/Platform.scala
@@ -12,6 +12,9 @@ object Platform {
   def xzString(s: String): String = {
     throw new Exception("XZ not implemented in Scala Native")
   }
+  def uuid(length: Int): String = {
+    throw new Exception("UUID not implemented in Scala Native")
+  }
   def md5(s: String): String = {
     throw new Exception("MD5 not implemented in Scala Native")
   }

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -1043,6 +1043,13 @@ object Std {
       }
     },
 
+    builtin("uuid", "v"){ (pos, ev, v: Val) =>
+      v match{
+        case Val.Num(_, value) => Platform.uuid(value.toInt)
+        case x => Error.fail("Cannot generate UUID string. Invalid length: " + x.prettyName)
+      }
+    },
+
     "encodeUTF8" -> EncodeUTF8,
     "decodeUTF8" -> DecodeUTF8,
 


### PR DESCRIPTION
## What changes are proposed in this PR?

In this PR we are adding a new standard function to return a random UUID string. This could be used to tag the different k8s resources if they are all being deployed as a list (kind: List). Kubernetes creates a separate UUID for each individual resource even if they are all getting deployed together and we have a use-case where we want to identify everything getting deployed as part of the same list.