### PR TITLE
Upgrade to Scala.js 1.8.0

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -64,6 +64,7 @@ class SjsonnetModule(val crossScalaVersion: String) extends Module {
         millSourcePath / "src-jvm-js"
       )
     }
+
     def jsEnvConfig = T(JsEnvConfig.JsDom(args = List("--dns-result-order=ipv4first")))
   }
   object native extends SjsonnetCrossModule with SjsonnetJvmNative with ScalaNativeModule{

--- a/build.sc
+++ b/build.sc
@@ -1,4 +1,4 @@
-import mill._, scalalib._, publish._, scalajslib._, scalanativelib._, scalanativelib.api._
+import mill._, scalalib._, publish._, scalajslib._, scalanativelib._, scalanativelib.api._, mill.scalajslib.api._
 val sjsonnetVersion = "0.4.3-SNAPSHOT"
 
 object sjsonnet extends Cross[SjsonnetModule]("2.12.13", "2.13.4")
@@ -64,6 +64,7 @@ class SjsonnetModule(val crossScalaVersion: String) extends Module {
         millSourcePath / "src-jvm-js"
       )
     }
+    def jsEnvConfig = T(JsEnvConfig.JsDom(args = List("--dns-result-order=ipv4first")))
   }
   object native extends SjsonnetCrossModule with SjsonnetJvmNative with ScalaNativeModule{
     def scalaNativeVersion = "0.4.0"

--- a/build.sc
+++ b/build.sc
@@ -51,7 +51,7 @@ class SjsonnetModule(val crossScalaVersion: String) extends Module {
     }
   }
   object js extends SjsonnetCrossModule with ScalaJSModule{
-    def scalaJSVersion = "1.4.0"
+    def scalaJSVersion = "1.8.0"
     def sources = T.sources(
       millSourcePath / "src",
       millSourcePath / "src-js",


### PR DESCRIPTION
The CI image was updated and we're hitting https://github.com/scala-js/scala-js-js-envs/issues/12 on 1.4.0.