### PR TITLE
Make Jsonnet std lib non-global

### DIFF
--- a/sjsonnet/src/sjsonnet/Interpreter.scala
+++ b/sjsonnet/src/sjsonnet/Interpreter.scala
@@ -19,11 +19,12 @@ class Interpreter(extVars: Map[String, ujson.Value],
                   settings: Settings = Settings.default,
                   storePos: Position => Unit = null,
                   warnLogger: (String => Unit) = null,
+                  std: Val.Obj = new Std().Std
                   ) { self =>
 
   val resolver = new CachedResolver(importer, parseCache) {
     override def process(expr: Expr, fs: FileScope): Either[Error, (Expr, FileScope)] =
-      handleException(new StaticOptimizer(evaluator).optimize(expr), fs)
+      handleException(new StaticOptimizer(evaluator, std).optimize(expr), fs)
   }
 
   private def warn(e: Error): Unit = warnLogger("[warning] " + formatError(e))

--- a/sjsonnet/src/sjsonnet/StaticOptimizer.scala
+++ b/sjsonnet/src/sjsonnet/StaticOptimizer.scala
@@ -5,7 +5,7 @@ import ScopedExprTransform._
 
 /** StaticOptimizer performs necessary transformations for the evaluator (assigning ValScope
  * indices) plus additional optimizations (post-order) and static checking (pre-order). */
-class StaticOptimizer(ev: EvalScope) extends ScopedExprTransform {
+class StaticOptimizer(ev: EvalScope, std: Val.Obj) extends ScopedExprTransform {
   def optimize(e: Expr): Expr = transform(e)
 
   def failOrWarn(msg: String, expr: Expr): Expr = {
@@ -38,7 +38,7 @@ class StaticOptimizer(ev: EvalScope) extends ScopedExprTransform {
       scope.get(name) match {
         case ScopedVal(v: Val with Expr, _, _) => v
         case ScopedVal(_, _, idx) => ValidId(pos, name, idx)
-        case null if name == "std" => Std.Std
+        case null if name == "std" => std
         case _ => failOrWarn("Unknown variable: "+name, e)
       }
 

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -18,7 +18,7 @@ import scala.util.matching.Regex
   * in Scala code. Uses `builtin` and other helpers to handle the common wrapper
   * logic automatically
   */
-object Std {
+class Std {
   private val dummyPos: Position = new Position(null, 0)
   private val emptyLazyArray = new Array[Lazy](0)
 


### PR DESCRIPTION
This serves two purposes:

1. We think we're seeing race conditions where the lazily-evaluated mutable state in the std lib `Val.Obj` is causing livelocks when evaluating Jsonnet in a multithreaded environment.

2. This will allow whoever instantiates `sjsonnet.Interpreter` to customize the `std.*`, allowing people to inject their own functions. Useful if google/jsonnet has some new std lib functions that haven't been added to sjsonnet yet, or if you have some domain-specific functions you want to expose in your config