### PR TITLE
Fix parsing of object key starting with `assert`

### DIFF
--- a/sjsonnet/src/sjsonnet/Parser.scala
+++ b/sjsonnet/src/sjsonnet/Parser.scala
@@ -353,7 +353,7 @@ class Parser(val currentFile: Path) {
       Expr.ObjBody.ObjComp(pos, preLocals.toArray, lhs, rhs, postLocals.toArray, comps._1, comps._2.toList)
   }
 
-  def member[_: P]: P[Expr.Member] = P( objlocal | "assert" ~~ assertStmt | field )
+  def member[_: P]: P[Expr.Member] = P( objlocal | "assert" ~~ break ~ assertStmt | field )
   def field[_: P] = P(
     (Pos ~~ fieldname ~/ "+".!.? ~ ("(" ~ params ~ ")").? ~ fieldKeySep ~/ expr).map{
       case (pos, name, plus, p, h2, e) =>

--- a/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
+++ b/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
@@ -355,5 +355,11 @@ object EvaluatorTests extends TestSuite{
       eval("""local f(x)=null; f == null""") ==> ujson.False
       eval("""local f=null; f == null""") ==> ujson.True
     }
+    test("identifierStartsWithKeyword") {
+      for(keyword <- Parser.keywords){
+        eval(s"""local ${keyword}Foo = 123; ${keyword}Foo""") ==> ujson.Num(123)
+        eval(s"""{${keyword}Foo: 123}""") ==> ujson.Obj(s"${keyword}Foo" -> ujson.Num(123))
+      }
+    }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/databricks/sjsonnet/issues/152 and https://github.com/databricks/sjsonnet/issues/65. All the other places we parse keywords are followed by a `~~ break` to ensure the keyword ends there, so `"assert"` should as well. 

Added some tests to loop through all the keywords to make sure this behavior doesn't appear for any of the other ones, in the three distinct contexts I can think of where identifiers might appear (local variable declarations, expressions, and object keys)