### PR TITLE
Allow assertions to take non-string error messages

### DIFF
--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -147,13 +147,12 @@ class Evaluator(resolver: CachedResolver,
   }
 
   def visitError(e: Expr.Error)(implicit scope: ValScope): Nothing = {
-    Error.fail(
-      visitExpr(e.value) match {
-        case Val.Str(_, s) => s
-        case r => Materializer.stringify(r)
-      },
-      e.pos
-    )
+    Error.fail(materializeError(visitExpr(e.value)), e.pos)
+  }
+
+  private def materializeError(value: Val) = value match {
+    case Val.Str(_, s) => s
+    case r => Materializer.stringify(r)
   }
 
   def visitUnaryOp(e: UnaryOp)(implicit scope: ValScope): Val = {
@@ -242,7 +241,7 @@ class Evaluator(resolver: CachedResolver,
       e.asserted.msg match {
         case null => Error.fail("Assertion failed", e)
         case msg =>
-          Error.fail("Assertion failed: " + visitExpr(msg).cast[Val.Str].value, e)
+          Error.fail("Assertion failed: " + materializeError(visitExpr(msg)), e)
       }
     }
     visitExpr(e.returned)

--- a/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
+++ b/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
@@ -355,5 +355,11 @@ object EvaluatorTests extends TestSuite{
       eval("""local f(x)=null; f == null""") ==> ujson.False
       eval("""local f=null; f == null""") ==> ujson.True
     }
+
+
+    test("errorNonString") {
+      assert(evalErr("""error {a: "b"}""").contains("""{"a": "b"}"""))
+      assert(evalErr("""assert 1 == 2 : { a: "b"}; 1""").contains("""{"a": "b"}"""))
+    }
   }
 }


### PR DESCRIPTION
These are meant to get materialized, similar to `error` which we already handle correctly.

Added a unit test.

Fixes https://github.com/databricks/sjsonnet/issues/146