### PR TITLE
allow custom trace callback

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -1,7 +1,7 @@
 import mill._, scalalib._, publish._, scalajslib._, scalanativelib._, scalanativelib.api._
 val sjsonnetVersion = "0.4.7"
 
-object sjsonnet extends Cross[SjsonnetModule]("2.12.13", "2.13.4")
+object sjsonnet extends Cross[SjsonnetModule]("2.12.13", "2.13.12")
 class SjsonnetModule(val crossScalaVersion: String) extends Module {
   def millSourcePath = super.millSourcePath / os.up
   trait SjsonnetJvmNative extends SjsonnetCrossModule {

--- a/readme.md
+++ b/readme.md
@@ -250,6 +250,13 @@ Since the Sjsonnet client still has 0.2-0.3s of overhead, if using Sjsonnet
 heavily it is still better to include it in your JVM classpath and invoke it
 programmatically via `new Interpreter(...).interpret(...)`.
 
+## Testing
+
+To run unittests:
+```bash
+./mill "sjsonnet[2.13.12].jvm.test"
+```
+
 ## Publishing
 
 To publish, make sure the version number in `build.sc` is correct, then run the following commands:

--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -19,11 +19,20 @@ class Evaluator(resolver: CachedResolver,
                 val extVars: String => Option[Expr],
                 val wd: Path,
                 val settings: Settings,
-                warnLogger: Error => Unit = null) extends EvalScope {
+                warnLogger: Error => Unit = null,
+                traceLogger: (String, Position) => Unit = null) extends EvalScope {
   implicit def evalScope: EvalScope = this
   def importer: CachedImporter = resolver
 
   def warn(e: Error): Unit = if(warnLogger != null) warnLogger(e)
+
+  def trace(s: String, pos: Position): Unit = {
+    if (traceLogger != null) {
+      traceLogger(s, pos)
+    } else {
+      System.err.println(s"TRACE: ${pos.fileScope.currentFileLastPathElement} $s")
+    }
+  }
 
   def materialize(v: Val): Value = Materializer.apply(v)
   val cachedImports = collection.mutable.HashMap.empty[Path, Val]

--- a/sjsonnet/src/sjsonnet/Interpreter.scala
+++ b/sjsonnet/src/sjsonnet/Interpreter.scala
@@ -18,7 +18,8 @@ class Interpreter(extVars: Map[String, String],
                   settings: Settings = Settings.default,
                   storePos: Position => Unit = null,
                   warnLogger: (String => Unit) = null,
-                  std: Val.Obj = new Std().Std
+                  std: Val.Obj = new Std().Std,
+                  traceLogger: (String, Position) => Unit = null
                   ) { self =>
 
   val resolver = new CachedResolver(importer, parseCache, settings.strictImportSyntax) {
@@ -29,8 +30,8 @@ class Interpreter(extVars: Map[String, String],
   private def warn(e: Error): Unit = warnLogger("[warning] " + formatError(e))
 
   def createEvaluator(resolver: CachedResolver, extVars: String => Option[Expr], wd: Path,
-                      settings: Settings, warn: Error => Unit): Evaluator =
-    new Evaluator(resolver, extVars, wd, settings, warn)
+                      settings: Settings, warn: Error => Unit, trace: (String, Position) => Unit = null): Evaluator =
+    new Evaluator(resolver, extVars, wd, settings, warn, trace)
 
 
   def parseVar(k: String, v: String) = {
@@ -43,7 +44,8 @@ class Interpreter(extVars: Map[String, String],
     k => extVars.get(k).map(v => parseVar(s"ext-var $k", v)),
     wd,
     settings,
-    warn
+    warn,
+    traceLogger
   )
 
   evaluator // force the lazy val

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -533,7 +533,7 @@ class Std {
 
   private object Trace extends Val.Builtin2("str", "rest") {
     def evalRhs(str: Val, rest: Val, ev: EvalScope, pos: Position): Val = {
-      System.err.println(s"TRACE: ${pos.fileScope.currentFileLastPathElement} " + str.asString)
+      ev.trace(str.asString, pos)
       rest
     }
   }

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -527,4 +527,5 @@ abstract class EvalScope extends EvalErrorScope {
 
   def settings: Settings
   def warn(e: Error): Unit
+  def trace(s: String, pos: Position): Unit
 }

--- a/sjsonnet/test/src/sjsonnet/FormatTests.scala
+++ b/sjsonnet/test/src/sjsonnet/FormatTests.scala
@@ -18,6 +18,7 @@ object FormatTests extends TestSuite{
         def importer: sjsonnet.CachedImporter = ???
         def settings = Settings.default
         def warn(e: Error) = ()
+        def trace(s: String, pos: Position) = ()
       }
     )
     assert(formatted == expected)

--- a/sjsonnet/test/src/sjsonnet/Std0150FunctionsTests.scala
+++ b/sjsonnet/test/src/sjsonnet/Std0150FunctionsTests.scala
@@ -158,5 +158,13 @@ object Std0150FunctionsTests extends TestSuite {
       eval("""std.reverse([1])""") ==> ujson.Arr(1)
       eval("""std.reverse(["1", true, null])""") ==> ujson.Arr(ujson.Null, true, "1")
     }
+
+    test("trace"){
+      var output: String = ""
+      eval("""std.trace("asdf", true)""", traceLogger=(s: String, p: Position) => {
+        output = s
+      }) ==> ujson.True
+      output ==> "asdf"
+    }
   }
 }

--- a/sjsonnet/test/src/sjsonnet/TestUtils.scala
+++ b/sjsonnet/test/src/sjsonnet/TestUtils.scala
@@ -5,7 +5,8 @@ object TestUtils {
             preserveOrder: Boolean = false,
             strict: Boolean = false,
             noDuplicateKeysInComprehension: Boolean = false,
-            strictInheritedAssertions: Boolean = false) = {
+            strictInheritedAssertions: Boolean = false,
+            traceLogger: (String, Position) => Unit = null) = {
     new Interpreter(
       Map(),
       Map(),
@@ -17,7 +18,8 @@ object TestUtils {
         strict = strict,
         noDuplicateKeysInComprehension = noDuplicateKeysInComprehension,
         strictInheritedAssertions = strictInheritedAssertions
-      )
+      ),
+      traceLogger = traceLogger
     ).interpret(s, DummyPath("(memory)"))
   }
 
@@ -25,8 +27,9 @@ object TestUtils {
            preserveOrder: Boolean = false,
            strict: Boolean = false,
            noDuplicateKeysInComprehension: Boolean = false,
-           strictInheritedAssertions: Boolean = false) = {
-    eval0(s, preserveOrder, strict, noDuplicateKeysInComprehension, strictInheritedAssertions) match {
+           strictInheritedAssertions: Boolean = false,
+           traceLogger: (String, Position) => Unit = null) = {
+    eval0(s, preserveOrder, strict, noDuplicateKeysInComprehension, strictInheritedAssertions, traceLogger) match {
       case Right(x) => x
       case Left(e) => throw new Exception(e)
     }


### PR DESCRIPTION
This adds the option to provide the interpreter with a custom callback for `std.trace`, instead of only logging to stderr. This will allow for capturing structured trace output for linting.