### PR TITLE
Static Object Optimizations

### DIFF
--- a/bench/src/main/scala/sjsonnet/MainBenchmark.scala
+++ b/bench/src/main/scala/sjsonnet/MainBenchmark.scala
@@ -43,10 +43,10 @@ object MainBenchmark {
 }
 
 @BenchmarkMode(Array(Mode.AverageTime))
-@Fork(1)
+@Fork(4)
 @Threads(1)
-@Warmup(iterations = 5)
-@Measurement(iterations = 10)
+@Warmup(iterations = 30)
+@Measurement(iterations = 40)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 class MainBenchmark {
@@ -74,6 +74,10 @@ class MainBenchmark {
 @Measurement(iterations = 10)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
+// This is a dummy benchmark to see how much memory is used by the interpreter.
+// You're meant to execute it, and once it prints "sleeping" you can attach yourkit and take a heap
+// dump. Because we store the cache, the parsed objects will have strong references - and thus will
+// be in the heap dump.
 class MemoryBenchmark {
 
   val dummyOut = MainBenchmark.createDummyOut

--- a/bench/src/main/scala/sjsonnet/MainBenchmark.scala
+++ b/bench/src/main/scala/sjsonnet/MainBenchmark.scala
@@ -66,3 +66,34 @@ class MainBenchmark {
     ))
   }
 }
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(1)
+@Threads(1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 10)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+class MemoryBenchmark {
+
+  val dummyOut = MainBenchmark.createDummyOut
+
+  val cache = new DefaultParseCache
+
+  @Benchmark
+  def main(bh: Blackhole): Unit = {
+    bh.consume {
+      SjsonnetMain.main0(
+        MainBenchmark.mainArgs,
+        cache,
+        System.in,
+        dummyOut,
+        System.err,
+        os.pwd,
+        None
+      )
+    }
+    println("sleeping")
+    Thread.sleep(10000000)
+  }
+}

--- a/bench/src/main/scala/sjsonnet/MainBenchmark.scala
+++ b/bench/src/main/scala/sjsonnet/MainBenchmark.scala
@@ -8,9 +8,12 @@ import org.openjdk.jmh.infra._
 
 object MainBenchmark {
   val mainArgs = Array[String](
-    "../../universe2/rulemanager/deploy/rulemanager.jsonnet",
+    // "../../universe/rulemanager/deploy/rulemanager.jsonnet",
+    "../../universe2/kubernetes/admission-controller/gatekeeper/deploy/gatekeeper.jsonnet",
     "-J", "../../universe2",
     "-J", "../../universe2/mt-shards/dev/az-westus-c2",
+    "-J", "../../universe2/bazel-bin",
+    "--ext-code", "isKubecfg=false"
   )
 
   def findFiles(): (IndexedSeq[(Path, String)], EvalScope) = {
@@ -40,10 +43,10 @@ object MainBenchmark {
 }
 
 @BenchmarkMode(Array(Mode.AverageTime))
-@Fork(4)
+@Fork(1)
 @Threads(1)
-@Warmup(iterations = 30)
-@Measurement(iterations = 40)
+@Warmup(iterations = 5)
+@Measurement(iterations = 10)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 class MainBenchmark {

--- a/bench/src/main/scala/sjsonnet/OptimizerBenchmark.scala
+++ b/bench/src/main/scala/sjsonnet/OptimizerBenchmark.scala
@@ -3,7 +3,7 @@ package sjsonnet
 import java.io.StringWriter
 import java.util.concurrent.TimeUnit
 
-import scala.collection.mutable.HashMap
+import scala.collection.mutable
 
 import fastparse.Parsed.Success
 import org.openjdk.jmh.annotations._
@@ -28,13 +28,13 @@ class OptimizerBenchmark {
   def setup(): Unit = {
     val (allFiles, ev) = MainBenchmark.findFiles()
     this.inputs = allFiles.map { case (p, s) =>
-      fastparse.parse(s, new Parser(p, true, HashMap.empty, HashMap.empty).document(_)) match {
+      fastparse.parse(s, new Parser(p, true, mutable.HashMap.empty, mutable.HashMap.empty).document(_)) match {
         case Success(v, _) => v
       }
     }
     this.ev = ev
     val static = inputs.map {
-      case (expr, fs) => ((new StaticOptimizer(ev, new Std().Std, HashMap.empty, HashMap.empty)).optimize(expr), fs)
+      case (expr, fs) => ((new StaticOptimizer(ev, new Std().Std, mutable.HashMap.empty, mutable.HashMap.empty)).optimize(expr), fs)
     }
     val countBefore, countStatic = new Counter
     inputs.foreach(t => assert(countBefore.transform(t._1) eq t._1))
@@ -47,7 +47,7 @@ class OptimizerBenchmark {
   @Benchmark
   def main(bh: Blackhole): Unit = {
     bh.consume(inputs.foreach { case (expr, fs) =>
-      bh.consume((new StaticOptimizer(ev, new Std().Std, HashMap.empty, HashMap.empty)).optimize(expr))
+      bh.consume((new StaticOptimizer(ev, new Std().Std, mutable.HashMap.empty, mutable.HashMap.empty)).optimize(expr))
     })
   }
 

--- a/bench/src/main/scala/sjsonnet/OptimizerBenchmark.scala
+++ b/bench/src/main/scala/sjsonnet/OptimizerBenchmark.scala
@@ -3,6 +3,8 @@ package sjsonnet
 import java.io.StringWriter
 import java.util.concurrent.TimeUnit
 
+import scala.collection.mutable.HashMap
+
 import fastparse.Parsed.Success
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra._
@@ -26,13 +28,13 @@ class OptimizerBenchmark {
   def setup(): Unit = {
     val (allFiles, ev) = MainBenchmark.findFiles()
     this.inputs = allFiles.map { case (p, s) =>
-      fastparse.parse(s, new Parser(p, true).document(_)) match {
+      fastparse.parse(s, new Parser(p, true, HashMap.empty, HashMap.empty).document(_)) match {
         case Success(v, _) => v
       }
     }
     this.ev = ev
     val static = inputs.map {
-      case (expr, fs) => ((new StaticOptimizer(ev, new Std().Std)).optimize(expr), fs)
+      case (expr, fs) => ((new StaticOptimizer(ev, new Std().Std, HashMap.empty, HashMap.empty)).optimize(expr), fs)
     }
     val countBefore, countStatic = new Counter
     inputs.foreach(t => assert(countBefore.transform(t._1) eq t._1))
@@ -45,7 +47,7 @@ class OptimizerBenchmark {
   @Benchmark
   def main(bh: Blackhole): Unit = {
     bh.consume(inputs.foreach { case (expr, fs) =>
-      bh.consume((new StaticOptimizer(ev, new Std().Std)).optimize(expr))
+      bh.consume((new StaticOptimizer(ev, new Std().Std, HashMap.empty, HashMap.empty)).optimize(expr))
     })
   }
 

--- a/bench/src/main/scala/sjsonnet/ParserBenchmark.scala
+++ b/bench/src/main/scala/sjsonnet/ParserBenchmark.scala
@@ -2,6 +2,8 @@ package sjsonnet
 
 import java.util.concurrent.TimeUnit
 
+import scala.collection.mutable.HashMap
+
 import fastparse.Parsed.Success
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra._
@@ -25,7 +27,7 @@ class ParserBenchmark {
   @Benchmark
   def main(bh: Blackhole): Unit = {
     bh.consume(allFiles.foreach { case (p, s) =>
-      val res = fastparse.parse(s, new Parser(p, true).document(_))
+      val res = fastparse.parse(s, new Parser(p, true, HashMap.empty, HashMap.empty).document(_))
       bh.consume(res.asInstanceOf[Success[_]])
     })
   }

--- a/readme.md
+++ b/readme.md
@@ -194,6 +194,19 @@ Profiler:
 sbt bench/run
 ```
 
+There's also a benchmark for memory usage:
+
+Execute and print stats:
+```
+sbt 'set fork in run := true' 'set javaOptions in run ++= Seq("-Xmx6G", "-XX:+UseG1GC")' 'bench/runMain sjsonnet.MemoryBenchmark'
+```
+
+Execute and pause - this is useful if you want to attach a profiler after the run and deep dive the
+object utilization.
+```
+sbt 'set fork in run := true' 'set javaOptions in run ++= Seq("-Xmx6G", "-XX:+UseG1GC")' 'bench/runMain sjsonnet.MemoryBenchmark --pause'
+```
+
 ## Laziness
 
 The Jsonnet language is _lazy_: expressions don't get evaluated unless

--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,7 @@ As a standalone executable assembly:
 - <https://github.com/databricks/sjsonnet/releases/download/0.4.7/sjsonnet.jar>
 
 ```bash
-$ curl -L https://github.com/databricks/sjsonnet/releases/download/0.4.7/sjsonnet.jar > sjsonnet.jar
+$ curl -L https://github.com/databricks/sjsonnet/releases/download/0.4.7/sjsonnet-0.4.7.jar > sjsonnet.jar
 
 $ chmod +x sjsonnet.jar
 
@@ -71,7 +71,7 @@ $ ./sjsonnet.jar foo.jsonnet
 Or from Javascript:
 
 ```javascript
-$ curl -L https://github.com/databricks/sjsonnet/releases/download/0.4.7/sjsonnet.js > sjsonnet.js
+$ curl -L https://github.com/databricks/sjsonnet/releases/download/0.4.7/sjsonnet-0.4.7.js > sjsonnet.js
 
 $ node
 

--- a/sjsonnet/src/sjsonnet/Importer.scala
+++ b/sjsonnet/src/sjsonnet/Importer.scala
@@ -44,11 +44,13 @@ class CachedImporter(parent: Importer) extends Importer {
 class CachedResolver(
   parentImporter: Importer,
   val parseCache: ParseCache,
-  strictImportSyntax: Boolean) extends CachedImporter(parentImporter) {
+  strictImportSyntax: Boolean,
+  internedStrings: mutable.HashMap[String, String],
+  internedStaticFieldSets: mutable.HashMap[Val.StaticObjectFieldSet, java.util.LinkedHashMap[String, java.lang.Boolean]]) extends CachedImporter(parentImporter) {
 
   def parse(path: Path, txt: String)(implicit ev: EvalErrorScope): Either[Error, (Expr, FileScope)] = {
     parseCache.getOrElseUpdate((path, txt), {
-      val parsed = fastparse.parse(txt, new Parser(path, strictImportSyntax).document(_)) match {
+      val parsed = fastparse.parse(txt, new Parser(path, strictImportSyntax, internedStrings, internedStaticFieldSets).document(_)) match {
         case f @ Parsed.Failure(_, _, _) =>
           val traced = f.trace()
           val pos = new Position(new FileScope(path), traced.index)

--- a/sjsonnet/src/sjsonnet/Parser.scala
+++ b/sjsonnet/src/sjsonnet/Parser.scala
@@ -50,7 +50,7 @@ class Parser(val currentFile: Path,
 
   private val fileScope = new FileScope(currentFile)
 
-  private val strings = new mutable.HashMap[String, String]
+  private[this] val strings = new mutable.HashMap[String, String]
 
   def Pos[_: P]: P[Position] = Index.map(offset => new Position(fileScope, offset))
 
@@ -335,7 +335,7 @@ class Parser(val currentFile: Path,
         val a = exprs.iterator.filter(_.isInstanceOf[Expr.Member.AssertStmt]).asInstanceOf[Iterator[Expr.Member.AssertStmt]].toArray
         if(a.isEmpty) null else a
       }
-      if(binds == null && asserts == null && fields.forall(_.isStatic)) Val.staticObject(pos, fields)
+      if(binds == null && asserts == null && fields.forall(_.isStatic)) Val.staticObject(pos, fields, strings)
       else Expr.ObjBody.MemberList(pos, binds, fields, asserts)
     case (pos, exprs, Some(comps)) =>
       val preLocals = exprs

--- a/sjsonnet/src/sjsonnet/Parser.scala
+++ b/sjsonnet/src/sjsonnet/Parser.scala
@@ -52,6 +52,8 @@ class Parser(val currentFile: Path,
 
   private[this] val strings = new mutable.HashMap[String, String]
 
+  private[this] val fieldSet = new mutable.HashMap[Val.FieldSet, java.util.Map[String, java.lang.Boolean]]
+
   def Pos[_: P]: P[Position] = Index.map(offset => new Position(fileScope, offset))
 
   def id[_: P] = P(
@@ -335,7 +337,7 @@ class Parser(val currentFile: Path,
         val a = exprs.iterator.filter(_.isInstanceOf[Expr.Member.AssertStmt]).asInstanceOf[Iterator[Expr.Member.AssertStmt]].toArray
         if(a.isEmpty) null else a
       }
-      if(binds == null && asserts == null && fields.forall(_.isStatic)) Val.staticObject(pos, fields, strings)
+      if(binds == null && asserts == null && fields.forall(_.isStatic)) Val.staticObject(pos, fields, fieldSet, strings)
       else Expr.ObjBody.MemberList(pos, binds, fields, asserts)
     case (pos, exprs, Some(comps)) =>
       val preLocals = exprs

--- a/sjsonnet/src/sjsonnet/Parser.scala
+++ b/sjsonnet/src/sjsonnet/Parser.scala
@@ -52,7 +52,7 @@ class Parser(val currentFile: Path,
 
   private[this] val strings = new mutable.HashMap[String, String]
 
-  private[this] val fieldSet = new mutable.HashMap[Val.FieldSet, java.util.Map[String, java.lang.Boolean]]
+  private[this] val fieldSet = new mutable.HashMap[Val.FieldSet, java.util.LinkedHashMap[String, java.lang.Boolean]]
 
   def Pos[_: P]: P[Position] = Index.map(offset => new Position(fileScope, offset))
 

--- a/sjsonnet/src/sjsonnet/Parser.scala
+++ b/sjsonnet/src/sjsonnet/Parser.scala
@@ -52,7 +52,7 @@ class Parser(val currentFile: Path,
 
   private[this] val strings = new mutable.HashMap[String, String]
 
-  private[this] val fieldSet = new mutable.HashMap[Val.FieldSet, java.util.LinkedHashMap[String, java.lang.Boolean]]
+  private[this] val fieldSet = new mutable.HashMap[Val.StaticObjectFieldSet, java.util.LinkedHashMap[String, java.lang.Boolean]]
 
   def Pos[_: P]: P[Position] = Index.map(offset => new Position(fileScope, offset))
 

--- a/sjsonnet/src/sjsonnet/StaticOptimizer.scala
+++ b/sjsonnet/src/sjsonnet/StaticOptimizer.scala
@@ -21,7 +21,7 @@ class StaticOptimizer(ev: EvalScope, std: Val.Obj) extends ScopedExprTransform {
   // HashMap to deduplicate strings.
   private[this] val strings = new mutable.HashMap[String, String]
 
-  private[this] val fieldSet = new mutable.HashMap[Val.FieldSet, java.util.LinkedHashMap[String, java.lang.Boolean]]
+  private[this] val fieldSet = new mutable.HashMap[Val.StaticObjectFieldSet, java.util.LinkedHashMap[String, java.lang.Boolean]]
 
   override def transform(_e: Expr): Expr = super.transform(check(_e)) match {
     case a: Apply => transformApply(a)

--- a/sjsonnet/src/sjsonnet/StaticOptimizer.scala
+++ b/sjsonnet/src/sjsonnet/StaticOptimizer.scala
@@ -21,7 +21,7 @@ class StaticOptimizer(ev: EvalScope, std: Val.Obj) extends ScopedExprTransform {
   // HashMap to deduplicate strings.
   private[this] val strings = new mutable.HashMap[String, String]
 
-  private[this] val fieldSet = new mutable.HashMap[Val.FieldSet, java.util.Map[String, java.lang.Boolean]]
+  private[this] val fieldSet = new mutable.HashMap[Val.FieldSet, java.util.LinkedHashMap[String, java.lang.Boolean]]
 
   override def transform(_e: Expr): Expr = super.transform(check(_e)) match {
     case a: Apply => transformApply(a)

--- a/sjsonnet/src/sjsonnet/StaticOptimizer.scala
+++ b/sjsonnet/src/sjsonnet/StaticOptimizer.scala
@@ -1,5 +1,7 @@
 package sjsonnet
 
+import scala.collection.mutable
+
 import Expr._
 import ScopedExprTransform._
 
@@ -15,6 +17,9 @@ class StaticOptimizer(ev: EvalScope, std: Val.Obj) extends ScopedExprTransform {
       expr
     } else throw e
   }
+
+  // HashMap to deduplicate strings.
+  private[this] val strings = new mutable.HashMap[String, String]
 
   override def transform(_e: Expr): Expr = super.transform(check(_e)) match {
     case a: Apply => transformApply(a)
@@ -61,7 +66,7 @@ class StaticOptimizer(ev: EvalScope, std: Val.Obj) extends ScopedExprTransform {
       new Val.Arr(a.pos, a.value.map(e => e.asInstanceOf[Val]))
 
     case m @ ObjBody.MemberList(pos, binds, fields, asserts) =>
-      if(binds == null && asserts == null && fields.forall(_.isStatic)) Val.staticObject(pos, fields)
+      if(binds == null && asserts == null && fields.forall(_.isStatic)) Val.staticObject(pos, fields, strings)
       else m
 
     case e => e

--- a/sjsonnet/src/sjsonnet/StaticOptimizer.scala
+++ b/sjsonnet/src/sjsonnet/StaticOptimizer.scala
@@ -21,6 +21,8 @@ class StaticOptimizer(ev: EvalScope, std: Val.Obj) extends ScopedExprTransform {
   // HashMap to deduplicate strings.
   private[this] val strings = new mutable.HashMap[String, String]
 
+  private[this] val fieldSet = new mutable.HashMap[Val.FieldSet, java.util.Map[String, java.lang.Boolean]]
+
   override def transform(_e: Expr): Expr = super.transform(check(_e)) match {
     case a: Apply => transformApply(a)
 
@@ -66,7 +68,7 @@ class StaticOptimizer(ev: EvalScope, std: Val.Obj) extends ScopedExprTransform {
       new Val.Arr(a.pos, a.value.map(e => e.asInstanceOf[Val]))
 
     case m @ ObjBody.MemberList(pos, binds, fields, asserts) =>
-      if(binds == null && asserts == null && fields.forall(_.isStatic)) Val.staticObject(pos, fields, strings)
+      if(binds == null && asserts == null && fields.forall(_.isStatic)) Val.staticObject(pos, fields, fieldSet, strings)
       else m
 
     case e => e

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -298,7 +298,7 @@ object Val{
     }
   }
 
-  final case class StaticObjectFieldSet(keys: Array[String]) {
+  final class StaticObjectFieldSet(keys: Array[String]) {
 
     override def hashCode(): Int = {
       Arrays.hashCode(keys.asInstanceOf[Array[Object]])

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -306,7 +306,7 @@ object Val{
 
     override def equals(obj: scala.Any): Boolean = {
       obj match {
-        case that: FieldSet =>
+        case that: StaticObjectFieldSet =>
           keys.sameElements(that.keys)
         case _ => false
       }
@@ -316,7 +316,7 @@ object Val{
   def staticObject(
       pos: Position,
       fields: Array[Expr.Member.Field],
-      internedKeyMaps: mutable.HashMap[FieldSet, java.util.LinkedHashMap[String, java.lang.Boolean]],
+      internedKeyMaps: mutable.HashMap[StaticObjectFieldSet, java.util.LinkedHashMap[String, java.lang.Boolean]],
       internedStrings: mutable.HashMap[String, String]): Obj = {
     // Set the initial capacity to the number of fields divided by the default load factor + 1 -
     // this ensures that we can fill up the map to the total number of fields without resizing.

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -298,7 +298,7 @@ object Val{
     }
   }
 
-  final class StaticObjectFieldSet(keys: Array[String]) {
+  final class StaticObjectFieldSet(protected val keys: Array[String]) {
 
     override def hashCode(): Int = {
       Arrays.hashCode(keys.asInstanceOf[Array[Object]])

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -298,16 +298,16 @@ object Val{
     }
   }
 
-  final case class FieldSet(keys: Array[String], bitSet: java.util.BitSet) {
+  final case class StaticObjectFieldSet(keys: Array[String]) {
 
     override def hashCode(): Int = {
-      Arrays.hashCode(keys.asInstanceOf[Array[Object]]) + bitSet.hashCode()
+      Arrays.hashCode(keys.asInstanceOf[Array[Object]])
     }
 
     override def equals(obj: scala.Any): Boolean = {
       obj match {
         case that: FieldSet =>
-          keys.sameElements(that.keys) && bitSet.equals(that.bitSet)
+          keys.sameElements(that.keys)
         case _ => false
       }
     }
@@ -326,7 +326,6 @@ object Val{
     val cache = mutable.HashMap.empty[Any, Val]
     val allKeys = new util.LinkedHashMap[String, java.lang.Boolean](capacity, hashMapDefaultLoadFactor)
     val keys = new Array[String](fields.length)
-    val bitSet = new java.util.BitSet(fields.length)
     var idx = 0
     fields.foreach {
       case Expr.Member.Field(_, Expr.FieldName.Fixed(k), _, _, _, rhs: Val.Literal) =>
@@ -334,10 +333,9 @@ object Val{
         cache.put(uniqueKey, rhs)
         allKeys.put(uniqueKey, false)
         keys(idx) = uniqueKey
-        bitSet.set(idx, false)
         idx += 1
     }
-    val fieldSet = new FieldSet(keys, bitSet)
+    val fieldSet = new StaticObjectFieldSet(keys)
     new Val.Obj(pos, null, true, null, null, cache, internedKeyMaps.getOrElseUpdate(fieldSet, allKeys))
   }
 

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -333,6 +333,7 @@ object Val{
         allKeysBuilder.addOne(uniqueKey, false)
         keys(idx) = uniqueKey
         bitSet.set(idx, false)
+        idx += 1
     }
     val fieldSet = new FieldSet(keys, bitSet)
     val allKeys = internedKeyMaps.getOrElseUpdate(fieldSet, allKeysBuilder.result().asJava)

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -320,7 +320,10 @@ object Val{
       fields: Array[Expr.Member.Field],
       internedKeyMaps: mutable.HashMap[FieldSet, java.util.Map[String, java.lang.Boolean]],
       internedStrings: mutable.HashMap[String, String]): Obj = {
-    val cache = mutable.HashMap.empty[Any, Val]
+    // Set the initial capacity to the number of fields divided by the default load factor + 1 -
+    // this ensures that we can fill up the map to the total number of fields without resizing.
+    val capacity = (fields.length / mutable.HashMap.defaultLoadFactor).toInt + 1
+    val cache = new mutable.HashMap[Any, Val](capacity, mutable.HashMap.defaultLoadFactor)
     val allKeysBuilder = immutable.VectorMap.newBuilder[String, java.lang.Boolean]
     allKeysBuilder.sizeHint(fields.length)
     val keys = new Array[String](fields.length)

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -297,13 +297,14 @@ object Val{
     }
   }
 
-  def staticObject(pos: Position, fields: Array[Expr.Member.Field]): Obj = {
+  def staticObject(pos: Position, fields: Array[Expr.Member.Field], internedStrings: mutable.HashMap[String, String]): Obj = {
     val cache = mutable.HashMap.empty[Any, Val]
     val allKeys = new util.LinkedHashMap[String, java.lang.Boolean]
     fields.foreach {
       case Expr.Member.Field(_, Expr.FieldName.Fixed(k), _, _, _, rhs: Val.Literal) =>
-        cache.put(k, rhs)
-        allKeys.put(k, false)
+        val uniqueKey = internedStrings.getOrElseUpdate(k, k)
+        cache.put(uniqueKey, rhs)
+        allKeys.put(uniqueKey, false)
     }
     new Val.Obj(pos, null, true, null, null, cache, allKeys)
   }

--- a/sjsonnet/test/src/sjsonnet/ParserTests.scala
+++ b/sjsonnet/test/src/sjsonnet/ParserTests.scala
@@ -1,13 +1,13 @@
 package sjsonnet
 
-import scala.collection.mutable.HashMap
+import scala.collection.mutable
 import utest._
 import Expr._
 import fastparse.Parsed
 import Val.{True, Num}
 object ParserTests extends TestSuite{
-  def parse(s: String, strictImportSyntax: Boolean = false) = fastparse.parse(s, new Parser(null, strictImportSyntax, HashMap.empty, HashMap.empty).document(_)).get.value._1
-  def parseErr(s: String, strictImportSyntax: Boolean = false) = fastparse.parse(s, new Parser(null, strictImportSyntax, HashMap.empty, HashMap.empty).document(_), verboseFailures = true).asInstanceOf[Parsed.Failure].msg
+  def parse(s: String, strictImportSyntax: Boolean = false) = fastparse.parse(s, new Parser(null, strictImportSyntax, mutable.HashMap.empty, mutable.HashMap.empty).document(_)).get.value._1
+  def parseErr(s: String, strictImportSyntax: Boolean = false) = fastparse.parse(s, new Parser(null, strictImportSyntax, mutable.HashMap.empty, mutable.HashMap.empty).document(_), verboseFailures = true).asInstanceOf[Parsed.Failure].msg
   val dummyFS = new FileScope(null)
   def pos(i: Int) = new Position(dummyFS, i)
   def tests = Tests{

--- a/sjsonnet/test/src/sjsonnet/ParserTests.scala
+++ b/sjsonnet/test/src/sjsonnet/ParserTests.scala
@@ -1,11 +1,13 @@
 package sjsonnet
+
+import scala.collection.mutable.HashMap
 import utest._
 import Expr._
 import fastparse.Parsed
 import Val.{True, Num}
 object ParserTests extends TestSuite{
-  def parse(s: String, strictImportSyntax: Boolean = false) = fastparse.parse(s, new Parser(null, strictImportSyntax).document(_)).get.value._1
-  def parseErr(s: String, strictImportSyntax: Boolean = false) = fastparse.parse(s, new Parser(null, strictImportSyntax).document(_), verboseFailures = true).asInstanceOf[Parsed.Failure].msg
+  def parse(s: String, strictImportSyntax: Boolean = false) = fastparse.parse(s, new Parser(null, strictImportSyntax, HashMap.empty, HashMap.empty).document(_)).get.value._1
+  def parseErr(s: String, strictImportSyntax: Boolean = false) = fastparse.parse(s, new Parser(null, strictImportSyntax, HashMap.empty, HashMap.empty).document(_), verboseFailures = true).asInstanceOf[Parsed.Failure].msg
   val dummyFS = new FileScope(null)
   def pos(i: Int) = new Position(dummyFS, i)
   def tests = Tests{


### PR DESCRIPTION
- This PR uses the Parser & StaticOptimizer thread local string interner for keys in static objects
- Similarly, we deduplicate the String -> Boolean map used to determine if a field is static.
- For static objects we also use immutable.VectorMap (with a JavaWrapper) for the field set.
- Lastly for the value cache, we size it according to the number of keys in the object this reduces unnecessary up-sizing for large objects, and more importantly removes the large number of sparse maps we previously had for small objects (the default was 16 elements)

Before: 855MB for the parsed file
![image (9)](https://github.com/databricks/sjsonnet/assets/153361/285bec71-8704-4e0b-98cd-336332e1d22c)

After: 425MB
![image (10)](https://github.com/databricks/sjsonnet/assets/153361/127f4c76-429c-4049-b881-214942368a71)
