### PR TITLE
Fix Description of `-J`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,7 @@ usage: sjsonnet [sjsonnet-options] script-file
 
   -i, --interactive  Run Mill in interactive mode, suitable for opening REPLs and taking user input
   -n, --indent       How much to indent your output JSON
-  -J, --jpath        Specify an additional library search dir (right-most wins)
+  -J, --jpath        Specify an additional library search dir (left-most wins)
   -o, --output-file  Write to the output file rather than stdout
   ...
 

--- a/sjsonnet/src-jvm-native/sjsonnet/Config.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/Config.scala
@@ -11,7 +11,7 @@ case class Config(
   interactive: Flag = Flag(),
   @arg(
     name = "jpath", short = 'J',
-    doc = "Specify an additional library search dir (right-most wins)"
+    doc = "Specify an additional library search dir (left-most wins)"
   )
   jpaths: List[String] = Nil,
   @arg(


### PR DESCRIPTION
The `-J` parameter of `sjsonnet appears to prefer **left-hand** files over right-hand files. This change in behavior happened between `0.3.0` and `0.3.1`, so I think it makes sense to change the documentation, not the behavior.[1]

I think that the change happened in https://github.com/databricks/sjsonnet/pull/107, but I'm not 100% sure if I'm reading the Scala correctly. The previous implementation seems to prepend values to the `jpath` variable [2].

[1]:
Create the following files:
```
/tmp/a/file.jsonnet {value: "a"}
/tmp/b/file.jsonnet {value: "b"}
/tmp/c/file.jsonnet {value: "c"}
```
and `~/dumb.jsonnet`:
```
local file = import "file.jsonnet";

{
whoami : file.value
}
```
Run the following commands

```
curl -L https://github.com/databricks/sjsonnet/releases/download/0.3.0/sjsonnet.jar  > /tmp/sjsonnet30.jar; chmod +x /tmp/sjsonnet30.jar
curl -L https://github.com/databricks/sjsonnet/releases/download/0.3.1/sjsonnet.jar  > /tmp/sjsonnet31.jar; chmod +x /tmp/sjsonnet31.jar

$ /tmp/sjsonnet31.jar /home/ian.rodney/dumb.jsonnet -J /tmp/c/ -J /tmp/a/ -J /tmp/b/ 
{
   "whoami": "c"
}
$ /tmp/sjsonnet30.jar /home/ian.rodney/dumb.jsonnet -J /tmp/c/ -J /tmp/a/ -J /tmp/b/ 
{
   "whoami": "b"
}

```

[2]:
```
    Arg[Config, String](
      "jpath", Some('J'),
      "Specify an additional library search dir (right-most wins)",
      (c, v) => c.copy(jpaths = v :: c.jpaths)
    ),
```