### PR TITLE
chore: Rename then to `then` in IfElse expr

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.4
+sbt.version=1.10.0

--- a/sjsonnet/src/sjsonnet/Expr.scala
+++ b/sjsonnet/src/sjsonnet/Expr.scala
@@ -1,7 +1,6 @@
 package sjsonnet
 
-import java.util.{Arrays, BitSet}
-import scala.collection.mutable
+import java.util.Arrays
 
 /**
   * [[Expr]]s are the parsed syntax trees of a Jsonnet program. They model the
@@ -149,7 +148,7 @@ object Expr{
                    end: Option[Expr],
                    stride: Option[Expr]) extends Expr
   case class Function(pos: Position, params: Params, body: Expr) extends Expr
-  case class IfElse(pos: Position, cond: Expr, then: Expr, `else`: Expr) extends Expr
+  case class IfElse(pos: Position, cond: Expr, `then`: Expr, `else`: Expr) extends Expr
 
   sealed trait CompSpec extends Expr
   case class IfSpec(pos: Position, cond: Expr) extends CompSpec


### PR DESCRIPTION
Motivation:

`then` is a keyword in Scala 3 now.