### PR TITLE
fix: std.manifestJsonMinified and empty arrays/objects.

### DIFF
--- a/sjsonnet/src/sjsonnet/Renderer.scala
+++ b/sjsonnet/src/sjsonnet/Renderer.scala
@@ -177,7 +177,7 @@ class PythonRenderer(out: Writer = new java.io.StringWriter(),
   }
 }
 
-/** Renderer used by std.manifestJson and std.manifestJsonEx */
+/** Renderer used by std.manifestJson, std.manifestJsonMinified, and std.manifestJsonEx */
 case class MaterializeJsonRenderer(indent: Int = 4, escapeUnicode: Boolean = false, out: StringWriter = new StringWriter())
   extends BaseCharRenderer(out, indent, escapeUnicode) {
 
@@ -187,7 +187,7 @@ case class MaterializeJsonRenderer(indent: Int = 4, escapeUnicode: Boolean = fal
 
     depth += 1
     // account for rendering differences of whitespaces in ujson and jsonnet manifestJson
-    if(length == 0) elemBuilder.append('\n') else renderIndent()
+    if (length == 0 && indent != -1) elemBuilder.append('\n') else renderIndent()
     def subVisitor = MaterializeJsonRenderer.this
     def visitValue(v: StringWriter, index: Int): Unit = {
       flushBuffer()
@@ -208,7 +208,7 @@ case class MaterializeJsonRenderer(indent: Int = 4, escapeUnicode: Boolean = fal
     elemBuilder.append('{')
     depth += 1
     // account for rendering differences of whitespaces in ujson and jsonnet manifestJson
-    if(length == 0) elemBuilder.append('\n') else renderIndent()
+    if (length == 0 && indent != -1) elemBuilder.append('\n') else renderIndent()
     def subVisitor = MaterializeJsonRenderer.this
     def visitKey(index: Int) = MaterializeJsonRenderer.this
     def visitKeyValue(s: Any): Unit = {

--- a/sjsonnet/test/src/sjsonnet/Std0150FunctionsTests.scala
+++ b/sjsonnet/test/src/sjsonnet/Std0150FunctionsTests.scala
@@ -49,8 +49,8 @@ object Std0150FunctionsTests extends TestSuite {
     }
 
     test("manifestJsonMinified"){
-      eval("""std.manifestJsonMinified( { x: [1, 2, 3, true, false, null, "string\nstring"], y: { a: 1, b: 2, c: [1, 2] }, })""") ==>
-        ujson.Str("{\"x\":[1,2,3,true,false,null,\"string\\nstring\"],\"y\":{\"a\":1,\"b\":2,\"c\":[1,2]}}")
+      eval("""std.manifestJsonMinified( { x: [1, 2, 3, true, false, null, "string\nstring", []], y: { a: 1, b: 2, c: [1, 2], d: {} }, })""") ==>
+        ujson.Str("{\"x\":[1,2,3,true,false,null,\"string\\nstring\",[]],\"y\":{\"a\":1,\"b\":2,\"c\":[1,2],\"d\":{}}}")
     }
 
     test("manifestXmlJsonml"){


### PR DESCRIPTION
Problem: std.manifestJsonMinified was producing newlines in empty arrays or empty objects:
```
$ jsonnet -e 'std.manifestJsonMinified({a:[],b:{}})'
"{\"a\":[],\"b\":{}}"

$ sjsonnet-0.4.10 -e 'std.manifestJsonMinified({a:[],b:{}})'
"{\"a\":[\n],\"b\":{\n}}"
```

Fix that and update the tests too.