### PR TITLE
fix: Use different chars for synthetic paths.

### DIFF
--- a/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMain.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMain.scala
@@ -179,7 +179,7 @@ object SjsonnetMain {
                      std: Val.Obj = new Std().Std): Either[String, String] = {
 
     val (jsonnetCode, path) =
-      if (config.exec.value) (file, wd / "<exec>")
+      if (config.exec.value) (file, wd / "\uFE64exec\uFE65")
       else {
         val p = os.Path(file, wd)
         (os.read(p), p)

--- a/sjsonnet/src/sjsonnet/Interpreter.scala
+++ b/sjsonnet/src/sjsonnet/Interpreter.scala
@@ -40,7 +40,7 @@ class Interpreter(extVars: Map[String, String],
 
 
   def parseVar(k: String, v: String) = {
-    resolver.parse(wd / s"<$k>", StaticResolvedFile(v))(evaluator).fold(throw _, _._1)
+    resolver.parse(wd / s"\uFE64$k\uFE65", StaticResolvedFile(v))(evaluator).fold(throw _, _._1)
   }
 
   lazy val evaluator: Evaluator = createEvaluator(


### PR DESCRIPTION
this fixes --exec, --tla-str and --ext-str on windows as < and > are illegal file name characters.

fixes #200