### PR TITLE
Optimize std.findSubstr and std.flattenArrays

### DIFF
--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -463,15 +463,15 @@ class Std {
 
   private object FlattenArrays extends Val.Builtin1("arrs") {
     def evalRhs(arrs: Val, ev: EvalScope, pos: Position): Val = {
-      val out = new mutable.ArrayBuilder.ofRef[Lazy]
+      val out = new mutable.ArrayBuffer[Lazy]
       for(x <- arrs.asArr) {
         x match{
           case Val.Null(_) => // do nothing
-          case v: Val.Arr => out.addAll(v.asLazyArray)
+          case v: Val.Arr => out.appendAll(v.asLazyArray)
           case x => Error.fail("Cannot call flattenArrays on " + x)
         }
       }
-      new Val.Arr(pos, out.result())
+      new Val.Arr(pos, out.toArray)
     }
   }
   private object Reverse extends Val.Builtin1("arrs") {

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -922,13 +922,16 @@ class Std {
     builtin("findSubstr", "pat", "str") { (pos, ev, pat: String, str: String) =>
       if (pat.length == 0) new Val.Arr(pos, emptyLazyArray)
       else {
-        val indices = mutable.ArrayBuffer[Int]()
         var matchIndex = str.indexOf(pat)
-        while (0 <= matchIndex && matchIndex < str.length) {
-          indices.append(matchIndex)
-          matchIndex = str.indexOf(pat, matchIndex + 1)
+        if (matchIndex == -1) new Val.Arr(pos, emptyLazyArray)
+        else {
+          val indices = new mutable.ArrayBuilder.ofRef[Val.Num]
+          while (0 <= matchIndex && matchIndex < str.length) {
+            indices.+=(Val.Num(pos, matchIndex))
+            matchIndex = str.indexOf(pat, matchIndex + 1)
+          }
+          new Val.Arr(pos, indices.result())
         }
-        new Val.Arr(pos, indices.map(x => Val.Num(pos, x)).toArray)
       }
     },
     "substr" -> Substr,

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -463,15 +463,15 @@ class Std {
 
   private object FlattenArrays extends Val.Builtin1("arrs") {
     def evalRhs(arrs: Val, ev: EvalScope, pos: Position): Val = {
-      val out = new mutable.ArrayBuffer[Lazy]
+      val out = new mutable.ArrayBuilder.ofRef[Lazy]
       for(x <- arrs.asArr) {
         x match{
           case Val.Null(_) => // do nothing
-          case v: Val.Arr => out.appendAll(v.asLazyArray)
+          case v: Val.Arr => out.addAll(v.asLazyArray)
           case x => Error.fail("Cannot call flattenArrays on " + x)
         }
       }
-      new Val.Arr(pos, out.toArray)
+      new Val.Arr(pos, out.result())
     }
   }
   private object Reverse extends Val.Builtin1("arrs") {

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -467,7 +467,7 @@ class Std {
       for(x <- arrs.asArr) {
         x match{
           case Val.Null(_) => // do nothing
-          case v: Val.Arr => out.addAll(v.asLazyArray)
+          case v: Val.Arr => out ++= v.asLazyArray
           case x => Error.fail("Cannot call flattenArrays on " + x)
         }
       }


### PR DESCRIPTION
This PR implements small performance optimizations for two built-in functions:

- **std.findSubstr**:
  - Skip array allocation in case of no matches. This is a common scenario because `findSubstr` is often used to implement "string contains" checks.
  - Use `ArrayBuilder` instead of `ArrayBuffer`: in this context we only need to append and don't need to update, remove, or inspect the elements that we've written, and for those requirements ArrayBuilder is cheaper to instantiate and cheaper to invoke.
  - Store `Val.Num` into the array builder rather than storing indices then mapping the result into an output array: this saves an array allocation and iteration.
- **std.flattenArrays**:
  - Apply a similar ArrayBuffer -> ArrayBuilder replacement.