### PR TITLE
Fix thread-safety bug in Obj.getAllKeys

### DIFF
--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -194,8 +194,10 @@ object Val{
 
     private def getAllKeys = {
       if(allKeys == null) {
-        allKeys = new util.LinkedHashMap[String, java.lang.Boolean]
+        val allKeys = new util.LinkedHashMap[String, java.lang.Boolean]
         gatherKeys(allKeys)
+        // Only assign to field after initialization is complete to allow unsynchronized multi-threaded use:
+        this.allKeys = allKeys
       }
       allKeys
     }


### PR DESCRIPTION
This PR fixes a thread-safety bug in Val.obj.getAllKeys, similar to the previous fix in https://github.com/databricks/sjsonnet/pull/136. It looks like this particular site was overlooked in that earlier PR.

I spotted this potential issue while reading through the code, not via actual use.