### PR TITLE
Fix a bug leading to the truncation of the data returned by std.gzip and std.xz

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val sjsonnetVersion = "0.4.12"
+val sjsonnetVersion = "0.4.12.1"
 
 scalaVersion in Global := "2.13.4"
 

--- a/build.sc
+++ b/build.sc
@@ -1,5 +1,5 @@
 import mill._, scalalib._, publish._, scalajslib._, scalanativelib._, scalanativelib.api._
-val sjsonnetVersion = "0.4.12"
+val sjsonnetVersion = "0.4.12.1"
 
 object sjsonnet extends Cross[SjsonnetModule]("2.12.13", "2.13.4")
 class SjsonnetModule(val crossScalaVersion: String) extends Module {

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ Sjsonnet can be used from Java:
 <dependency>
     <groupId>com.databricks</groupId>
     <artifactId>sjsonnet_2.13</artifactId>
-    <version>0.4.12</version>
+    <version>0.4.12.1</version>
 </dependency>
 ```
 
@@ -30,8 +30,8 @@ sjsonnet.SjsonnetMain.main0(
 From Scala:
 
 ```scala
-"com.databricks" %% "sjsonnet" % "0.4.12" // SBT
-ivy"com.databricks::sjsonnet:0.4.12" // Mill
+"com.databricks" %% "sjsonnet" % "0.4.12.1" // SBT
+ivy"com.databricks::sjsonnet:0.4.12.1" // Mill
 ```
 
 ```scala
@@ -48,10 +48,10 @@ sjsonnet.SjsonnetMain.main0(
 
 As a standalone executable assembly:
 
-- <https://github.com/databricks/sjsonnet/releases/download/0.4.12/sjsonnet.jar>
+- <https://github.com/databricks/sjsonnet/releases/download/0.4.12.1/sjsonnet.jar>
 
 ```bash
-$ curl -L https://github.com/databricks/sjsonnet/releases/download/0.4.12/sjsonnet-0.4.12.jar > sjsonnet.jar
+$ curl -L https://github.com/databricks/sjsonnet/releases/download/0.4.12.1/sjsonnet-0.4.12.1.jar > sjsonnet.jar
 
 $ chmod +x sjsonnet.jar
 
@@ -71,7 +71,7 @@ $ ./sjsonnet.jar foo.jsonnet
 Or from Javascript:
 
 ```javascript
-$ curl -L https://github.com/databricks/sjsonnet/releases/download/0.4.12/sjsonnet-0.4.12.js > sjsonnet.js
+$ curl -L https://github.com/databricks/sjsonnet/releases/download/0.4.12/sjsonnet-0.4.12.1.js > sjsonnet.js
 
 $ node
 
@@ -279,6 +279,9 @@ Please ensure that you are publishing with JDK 8, e.g. via
 to ensure the output bytecode remains compatible with users on older JVMs.
 
 ## Changelog
+
+### 0.4.12.1
+- Fix a bug leading to the truncation of the data returned by `std.gzip` and `std.xz` [#221](https://github.com/databricks/sjsonnet/pull/221).
 
 ### 0.4.12
 - Fix a bug introduced with 0.4.11 with synthetic paths [#215](https://github.com/databricks/sjsonnet/pull/215)

--- a/sjsonnet/src-jvm/sjsonnet/Platform.scala
+++ b/sjsonnet/src-jvm/sjsonnet/Platform.scala
@@ -17,12 +17,13 @@ object Platform {
     val gzip: GZIPOutputStream = new GZIPOutputStream(outputStream)
     try {
       gzip.write(b)
-      Base64.getEncoder.encodeToString(outputStream.toByteArray)
     } finally {
       gzip.close()
       outputStream.close()
     }
+    Base64.getEncoder.encodeToString(outputStream.toByteArray)
   }
+
   def gzipString(s: String): String = {
     gzipBytes(s.getBytes())
   }
@@ -37,11 +38,11 @@ object Platform {
     val xz: XZOutputStream = new XZOutputStream(outputStream, new LZMA2Options(level))
     try {
       xz.write(b)
-      Base64.getEncoder.encodeToString(outputStream.toByteArray)
     } finally {
       xz.close()
       outputStream.close()
     }
+    Base64.getEncoder.encodeToString(outputStream.toByteArray)
   }
 
   def xzString(s: String, compressionLevel: Option[Int]): String = {

--- a/sjsonnet/test/src-jvm/sjsonnet/StdGzipTests.scala
+++ b/sjsonnet/test/src-jvm/sjsonnet/StdGzipTests.scala
@@ -1,0 +1,14 @@
+package sjsonnet
+
+import sjsonnet.TestUtils.eval
+import utest._
+
+object StdGzipTests extends TestSuite {
+  val tests = Tests {
+    test("gzip"){
+      eval("""std.gzip([1, 2])""") ==> ujson.Str("H4sIAAAAAAAAAGNkAgCSQsy2AgAAAA==")
+      eval("""std.gzip("hi")""") ==> ujson.Str("H4sIAAAAAAAAAMvIBACsKpPYAgAAAA==")
+    }
+  }
+}
+

--- a/sjsonnet/test/src-jvm/sjsonnet/StdXzTests.scala
+++ b/sjsonnet/test/src-jvm/sjsonnet/StdXzTests.scala
@@ -6,10 +6,10 @@ import TestUtils.eval
 object StdXzTests extends TestSuite {
   val tests = Tests {
     test("xz"){
-      eval("""std.xz([1, 2])""")
-      eval("""std.xz("hi")""")
-      eval("""std.xz([1, 2], compressionLevel = 0)""")
-      eval("""std.xz("hi", compressionLevel = 1)""")
+      eval("""std.xz([1, 2])""") ==> ujson.Str("/Td6WFoAAATm1rRGAgAhARYAAAB0L+WjAQABAQIAAADRC9qlUgJ94gABGgLcLqV+H7bzfQEAAAAABFla")
+      eval("""std.xz("hi")""") ==> ujson.Str("/Td6WFoAAATm1rRGAgAhARYAAAB0L+WjAQABaGkAAAD+qTgRvMqlSAABGgLcLqV+H7bzfQEAAAAABFla")
+      eval("""std.xz([1, 2], compressionLevel = 0)""") ==> ujson.Str("/Td6WFoAAATm1rRGAgAhAQwAAACPmEGcAQABAQIAAADRC9qlUgJ94gABGgLcLqV+H7bzfQEAAAAABFla")
+      eval("""std.xz("hi", compressionLevel = 1)""") ==> ujson.Str("/Td6WFoAAATm1rRGAgAhARAAAACocI6GAQABaGkAAAD+qTgRvMqlSAABGgLcLqV+H7bzfQEAAAAABFla")
       val ex = intercept[Exception] {
         // Compression level 10 is invalid
         eval("""std.xz("hi", 10)""")


### PR DESCRIPTION
The output of std.gzip and std.xz was truncated because the output stream was closed after being read and encoded into base64.

This regression was introduced in https://github.com/databricks/sjsonnet/pull/210