### PR TITLE
Improve std.get and error messages

### DIFF
--- a/bench/src/main/scala/sjsonnet/ProfilingEvaluator.scala
+++ b/bench/src/main/scala/sjsonnet/ProfilingEvaluator.scala
@@ -157,7 +157,7 @@ class ProfilingEvaluator(resolver: CachedResolver,
     new Std().functions.foreachEntry((n, f) => names.put(f, n))
     val m = new mutable.HashMap[String, BuiltinBox]
     def add(b: ExprBox, func: Val.Builtin): Unit = {
-      val n = names.getOrDefault(func, func.getClass.getName)
+      val n = names.getOrDefault(func, func.functionName)
       val bb = m.getOrElseUpdate(n, new BuiltinBox(n))
       bb.time += b.time
       bb.count += b.count

--- a/sjsonnet/src/sjsonnet/Expr.scala
+++ b/sjsonnet/src/sjsonnet/Expr.scala
@@ -130,9 +130,15 @@ object Expr{
   case class Apply1(pos: Position, value: Expr, a1: Expr) extends Expr
   case class Apply2(pos: Position, value: Expr, a1: Expr, a2: Expr) extends Expr
   case class Apply3(pos: Position, value: Expr, a1: Expr, a2: Expr, a3: Expr) extends Expr
-  case class ApplyBuiltin(pos: Position, func: Val.Builtin, argExprs: Array[Expr]) extends Expr
-  case class ApplyBuiltin1(pos: Position, func: Val.Builtin1, a1: Expr) extends Expr
-  case class ApplyBuiltin2(pos: Position, func: Val.Builtin2, a1: Expr, a2: Expr) extends Expr
+  case class ApplyBuiltin(pos: Position, func: Val.Builtin, argExprs: Array[Expr]) extends Expr {
+    override def exprErrorString: String = s"std.${func.functionName}"
+  }
+  case class ApplyBuiltin1(pos: Position, func: Val.Builtin1, a1: Expr) extends Expr {
+    override def exprErrorString: String = s"std.${func.functionName}"
+  }
+  case class ApplyBuiltin2(pos: Position, func: Val.Builtin2, a1: Expr, a2: Expr) extends Expr {
+    override def exprErrorString: String = s"std.${func.functionName}"
+  }
   case class Select(pos: Position, value: Expr, name: String) extends Expr {
     override def exprErrorString: String = s"${super.exprErrorString} $name"
   }

--- a/sjsonnet/src/sjsonnet/Format.scala
+++ b/sjsonnet/src/sjsonnet/Format.scala
@@ -273,7 +273,7 @@ object Format{
     if (formatted.precision.contains(0) && !formatted.alternate) None else Some(fracLengths)
   }
 
-  class PartialApplyFmt(fmt: String) extends Val.Builtin1("values") {
+  class PartialApplyFmt(fmt: String) extends Val.Builtin1("format", "values") {
     val (leading, chunks) = fastparse.parse(fmt, format(_)).get.value
     def evalRhs(values0: Val, ev: EvalScope, pos: Position): Val =
       Val.Str(pos, format(leading, chunks, values0, pos)(ev))

--- a/sjsonnet/test/src-jvm-native/sjsonnet/ErrorTests.scala
+++ b/sjsonnet/test/src-jvm-native/sjsonnet/ErrorTests.scala
@@ -313,7 +313,7 @@ object ErrorTests extends TestSuite{
     test("format_func") - check(
       """|sjsonnet.Error: Cannot format function value
          |    at [Function].(sjsonnet/test/resources/db/error.format_func.jsonnet:1:9)
-         |    at [ApplyBuiltin1].(sjsonnet/test/resources/db/error.format_func.jsonnet:1:7)
+         |    at [std.format].(sjsonnet/test/resources/db/error.format_func.jsonnet:1:7)
          |""".stripMargin,
       suite = "db"
     )


### PR DESCRIPTION
This PR does 2 things:

It improves std.get() to only compute default when it's needed.

and it makes builtin error more readable
Before

```
bazel-bin/bazel/jsonnet/sjsonnet.jar -e 'std.get(["a", "b"], "a", null)'
sjsonnet.Error: Wrong parameter type: expected Object, got array
    at [ApplyBuiltin].(<exec>:1:8)
```

after
```
bazel-bin/bazel/jsonnet/sjsonnet.jar -e 'std.get(["a", "b"], "a", null)'
sjsonnet.Error: Wrong parameter type: expected Object, got array
    at [std.get].(<exec>:1:8)
````
