### PR TITLE
Stop manifesting functions with no arguments in objects by default

### DIFF
--- a/sjsonnet/src/sjsonnet/Interpreter.scala
+++ b/sjsonnet/src/sjsonnet/Interpreter.scala
@@ -107,7 +107,7 @@ class Interpreter(extVars: Map[String, String],
             override def evalDefault(expr: Expr, vs: ValScope, es: EvalScope) = {
               evaluator.visitExpr(expr)(if (tlaExpressions.exists(_ eq expr)) ValScope.empty else vs)
             }
-          }
+          }.apply0(f.pos)(evaluator)
         case x => x
       }
     } yield res

--- a/sjsonnet/src/sjsonnet/Materializer.scala
+++ b/sjsonnet/src/sjsonnet/Materializer.scala
@@ -56,14 +56,13 @@ abstract class Materializer {
       case Val.True(pos) => storePos(pos); visitor.visitTrue(-1)
       case Val.False(pos) => storePos(pos); visitor.visitFalse(-1)
       case Val.Null(pos) => storePos(pos); visitor.visitNull(-1)
-      case f: Val.Func =>
-        apply0(
-          f.apply(Materializer.emptyLazyArray, null, evaluator.emptyMaterializeFileScopePos),
-          visitor
-        )
+      case _: Val.Func =>
+        Error.fail("Couldn't manifest function as JSON")
+      case _ =>
+        Error.fail("Unknown value type " + v.prettyName)
     }
 
-  }catch {case e: StackOverflowError =>
+  }catch {case _: StackOverflowError =>
     Error.fail("Stackoverflow while materializing, possibly due to recursive value")
   }
 

--- a/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
+++ b/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
@@ -1,7 +1,7 @@
 package sjsonnet
 
 import utest._
-import TestUtils.{eval, evalErr}
+import TestUtils.{eval, eval0, evalErr}
 object EvaluatorTests extends TestSuite{
 
 
@@ -30,6 +30,8 @@ object EvaluatorTests extends TestSuite{
       eval("local f(x) = function() true; f(42)") ==> ujson.True
       eval("local f(x) = function() true; f(42) == true") ==> ujson.False
       eval("local f(x) = function() true; f(42)() == true") ==> ujson.True
+      assert(evalErr("{foo: function() true}").startsWith("sjsonnet.Error: Couldn't manifest function as JSON"))
+      eval("{foo: (function() true)()}") ==> ujson.Obj{"foo" -> ujson.True}
     }
     test("members") {
       eval("{local x = 1, x: x}['x']") ==> ujson.Num(1)


### PR DESCRIPTION
This is inline with go-jsonnet's behavior.

This behavior difference made TLA vars working properly in sjsonnet - I moved this part to the interpreter.
This fixes #168 