### PR TITLE
Optimize lstripChars, rstripChars, and stripChars via specialization

### DIFF
--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -446,14 +446,14 @@ class Std {
         try {
           val pattern = Pattern.compile(from.value, Pattern.LITERAL)
           val quotedTo = java.util.regex.Matcher.quoteReplacement(to.value)
-          (new SpecStringReplace(pattern, quotedTo), Array(str))
+          (new SpecStrReplace(pattern, quotedTo), Array(str))
         } catch {
           case _: Exception => null
         }
       case _ => null
     }
 
-    private class SpecStringReplace(from: Pattern, quotedTo: String) extends Val.Builtin1("strReplace", "str") {
+    private class SpecStrReplace(from: Pattern, quotedTo: String) extends Val.Builtin1("strReplace", "str") {
       override def evalRhs(arg1: Val, ev: EvalScope, pos: Position): Val = {
         Val.Str(pos, from.matcher(arg1.asString).replaceAll(quotedTo))
       }

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -453,7 +453,7 @@ class Std {
       case _ => null
     }
 
-    private class SpecStringReplace(from: Pattern, quotedTo: String) extends Val.Builtin1("str") {
+    private class SpecStringReplace(from: Pattern, quotedTo: String) extends Val.Builtin1("strReplace", "str") {
       override def evalRhs(arg1: Val, ev: EvalScope, pos: Position): Val = {
         Val.Str(pos, from.matcher(arg1.asString).replaceAll(quotedTo))
       }
@@ -471,6 +471,82 @@ class Std {
     private class SpecFrom(from: Pattern) extends Val.Builtin2("strReplaceAll", "str", "to") {
       def evalRhs(str: Val, to: Val, ev: EvalScope, pos: Position): Val =
         Val.Str(pos, from.matcher(str.asString).replaceAll(to.asString))
+    }
+  }
+
+  private object StripUtils {
+    private def getLeadingPattern(chars: String): Pattern =
+      Pattern.compile("^[" + Regex.quote(chars) + "]+")
+
+    private def getTrailingPattern(chars: String): Pattern =
+      Pattern.compile("[" + Regex.quote(chars) + "]+$")
+
+    def unspecializedStrip(str: String, chars: String, left: Boolean, right: Boolean): String = {
+      var s = str
+      if (right) s = getTrailingPattern(chars).matcher(s).replaceAll("")
+      if (left) s = getLeadingPattern(chars).matcher(s).replaceAll("")
+      s
+    }
+
+    private class SpecStrip(
+      chars: String,
+      left: Boolean,
+      right: Boolean,
+      functionName: String
+    ) extends Val.Builtin1(functionName, "str") {
+      private[this] val leftPattern = getLeadingPattern(chars)
+      private[this] val rightPattern = getTrailingPattern(chars)
+
+      def evalRhs(str: Val, ev: EvalScope, pos: Position): Val = {
+        var s = str.asString
+        if (right) s = rightPattern.matcher(s).replaceAll("")
+        if (left) s = leftPattern.matcher(s).replaceAll("")
+        Val.Str(pos, s)
+      }
+    }
+
+    def trySpecialize(str: Expr, chars: Val.Str, left: Boolean, right: Boolean, name: String): (Val.Builtin, Array[Expr]) = {
+      try {
+        (new SpecStrip(chars.value, left, right, name), Array(str))
+      } catch {
+        case _: Exception => null
+      }
+    }
+  }
+
+  object StripChars extends Val.Builtin2("stripChars", "str", "chars") {
+    def evalRhs(str: Val, chars: Val, ev: EvalScope, pos: Position): Val = {
+      Val.Str(pos, StripUtils.unspecializedStrip(str.asString, chars.asString, left = true, right = true))
+    }
+
+    override def specialize(args: Array[Expr]): (Val.Builtin, Array[Expr]) = args match {
+      case Array(str, chars: Val.Str) =>
+        StripUtils.trySpecialize(str, chars, left = true, right = true, functionName)
+      case _ => null
+    }
+  }
+
+  object LStripChars extends Val.Builtin2("lstripChars", "str", "chars") {
+    def evalRhs(str: Val, chars: Val, ev: EvalScope, pos: Position): Val = {
+      Val.Str(pos, StripUtils.unspecializedStrip(str.asString, chars.asString,  left = true, right = false))
+    }
+
+    override def specialize(args: Array[Expr]): (Val.Builtin, Array[Expr]) = args match {
+      case Array(str, chars: Val.Str) =>
+        StripUtils.trySpecialize(str, chars, left = true, right = false, functionName)
+      case _ => null
+    }
+  }
+
+  object RStripChars extends Val.Builtin2("rstripChars", "str", "chars") {
+    def evalRhs(str: Val, chars: Val, ev: EvalScope, pos: Position): Val = {
+      Val.Str(pos, StripUtils.unspecializedStrip(str.asString, chars.asString, left = false, right = true))
+    }
+
+    override def specialize(args: Array[Expr]): (Val.Builtin, Array[Expr]) = args match {
+      case Array(str, chars: Val.Str) =>
+        StripUtils.trySpecialize(str, chars, left = false, right = true, functionName)
+      case _ => null
     }
   }
 
@@ -1043,16 +1119,9 @@ class Std {
     builtin(Char_),
     builtin(StrReplace),
     builtin(StrReplaceAll),
-
-    builtin("rstripChars", "str", "chars"){ (pos, ev, str: String, chars: String) =>
-      str.replaceAll("[" + Regex.quote(chars) + "]+$", "")
-    },
-    builtin("lstripChars", "str", "chars"){ (pos, ev, str: String, chars: String) =>
-      str.replaceAll("^[" + Regex.quote(chars) + "]+", "")
-    },
-    builtin("stripChars", "str", "chars"){ (pos, ev, str: String, chars: String) =>
-      str.replaceAll("[" + Regex.quote(chars) + "]+$", "").replaceAll("^[" + Regex.quote(chars) + "]+", "")
-    },
+    builtin(RStripChars),
+    builtin(LStripChars),
+    builtin(StripChars),
     builtin(Join),
     builtin(Member),
 

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -440,24 +440,6 @@ class Std {
   private object StrReplace extends Val.Builtin3("strReplace", "str", "from", "to") {
     def evalRhs(str: Val, from: Val, to: Val, ev: EvalScope, pos: Position): Val =
       Val.Str(pos, str.asString.replace(from.asString, to.asString))
-
-    override def specialize(args: Array[Expr]): (Val.Builtin, Array[Expr]) = args match {
-      case Array(str, from: Val.Str, to: Val.Str) =>
-        try {
-          val pattern = Pattern.compile(from.value, Pattern.LITERAL)
-          val quotedTo = java.util.regex.Matcher.quoteReplacement(to.value)
-          (new SpecStrReplace(pattern, quotedTo), Array(str))
-        } catch {
-          case _: Exception => null
-        }
-      case _ => null
-    }
-
-    private class SpecStrReplace(from: Pattern, quotedTo: String) extends Val.Builtin1("strReplace", "str") {
-      override def evalRhs(arg1: Val, ev: EvalScope, pos: Position): Val = {
-        Val.Str(pos, from.matcher(arg1.asString).replaceAll(quotedTo))
-      }
-    }
   }
 
   private object StrReplaceAll extends Val.Builtin3("strReplaceAll", "str", "from", "to") {

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -440,6 +440,24 @@ class Std {
   private object StrReplace extends Val.Builtin3("strReplace", "str", "from", "to") {
     def evalRhs(str: Val, from: Val, to: Val, ev: EvalScope, pos: Position): Val =
       Val.Str(pos, str.asString.replace(from.asString, to.asString))
+
+    override def specialize(args: Array[Expr]): (Val.Builtin, Array[Expr]) = args match {
+      case Array(str, from: Val.Str, to: Val.Str) =>
+        try {
+          val pattern = Pattern.compile(from.value, Pattern.LITERAL)
+          val quotedTo = java.util.regex.Matcher.quoteReplacement(to.value)
+          (new SpecStringReplace(pattern, quotedTo), Array(str))
+        } catch {
+          case _: Exception => null
+        }
+      case _ => null
+    }
+
+    private class SpecStringReplace(from: Pattern, quotedTo: String) extends Val.Builtin1("str") {
+      override def evalRhs(arg1: Val, ev: EvalScope, pos: Position): Val = {
+        Val.Str(pos, from.matcher(arg1.asString).replaceAll(quotedTo))
+      }
+    }
   }
 
   private object StrReplaceAll extends Val.Builtin3("strReplaceAll", "str", "from", "to") {


### PR DESCRIPTION
This PR optimizes `lstripChars` / `rstripChars` / `stripChars` built-in functions by using the specialization framework from #119 / 0bd255a7486f4889b06581afeac8058548995cf3 to pre-compile and re-use `Pattern` instances when the replacement / strip arguments are constants.

In Java, `String.replaceAll()` compiles and uses a `Pattern` under the hood and this is relatively expensive; specialization lets us save this cost when the `chars`-to-be-stripped are constant.

## Testing


**Correctness**: ran all tests with a manual change to disable static function application optimizations (a prerequisite required to achieve full test coverage, as the static application prevents specialization from kicking in during most tests). In a followup, I think we should explore adding flags for optimizer features and running all tests with/without optimization.

**Performance**: ran benchmarks on a large file and with this change I save ~11% of allocated bytes and ~8% of wall time. I ran that same file through `RunProfiler` and saw a large speedup in `stripChars`, costing ~619ns/call before and ~154ns/call after.