### PR TITLE
Fix performance regression in split by avoiding allocating substring per char

### DIFF
--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -566,20 +566,19 @@ class Std {
     var sz = 0
     var i = 0
     var start = 0
-    breakable {
-      while (i < str.length) {
-        if (maxSplits >= 0 && sz >= maxSplits) {
-          break
-        }
-        if (str.slice(i, i + cStr.length) == cStr) {
-          val finalStr = Val.Str(pos, str.slice(start, i))
-          b.+=(finalStr)
-          start = i + cStr.length
-          sz += 1
-        }
+
+    while (i <= str.length - cStr.length && (maxSplits < 0 || sz < maxSplits)) {
+      if (str.startsWith(cStr, i)) {
+        val finalStr = Val.Str(pos, str.substring(start, i))
+        b.+=(finalStr)
+        start = i + cStr.length
+        sz += 1
+        i += cStr.length
+      } else {
         i += 1
       }
     }
+
     b.+=(Val.Str(pos, str.substring(start)))
     sz += 1
     b.result()

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -578,7 +578,6 @@ class Std {
         i += 1
       }
     }
-
     b.+=(Val.Str(pos, str.substring(start)))
     sz += 1
     b.result()

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -9,7 +9,6 @@ import sjsonnet.Expr.Member.Visibility
 
 import scala.collection.Searching._
 import scala.collection.mutable
-import scala.util.control.Breaks.{break, breakable}
 import scala.util.matching.Regex
 
 /**


### PR DESCRIPTION
This PR fixes a performance regression from #227 / 4c85bde425b51103a95efce272fa0e4fb1bd51dd which I overlooked in review:

When generalizing the optimized non-Pattern-based split code, that commit introduced a `.substring()` on each character, producing tons of garbage.

Instead, I think we can do a `.startsWith(splitPattern, i)`: this should be much faster because it will avoid unnecessary garbage string creation (plus I'm pretty sure that `startsWith` is optimized in modern JDKs).

I also removed the use of `breakable` and replaced it with an update to the `while` condition.