### PR TITLE
chore: bump scala to make it compiles on Java 21

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -4,7 +4,7 @@ import contrib.jmh.JmhModule
 
 val sjsonnetVersion = "0.4.13"
 
-val scalaVersions = Seq("2.12.18", "2.13.12")
+val scalaVersions = Seq("2.12.20", "2.13.15")
 
 trait SjsonnetCrossModule extends CrossScalaModule with PublishModule {
   def crossValue: String


### PR DESCRIPTION
Motivation:
When compiles it on JDK21, it needs newer version of Scala

Result:
compiles with Java 21 successfully

refs: https://github.com/databricks/sjsonnet/issues/228