### PR TITLE
Fix corner case for YAML parsing with primitive types

### DIFF
--- a/sjsonnet/src-jvm/sjsonnet/Platform.scala
+++ b/sjsonnet/src-jvm/sjsonnet/Platform.scala
@@ -29,7 +29,7 @@ object Platform {
   }
 
   /**
-   *  Valid compression levels are 0 (no compression) to 9 (maximum compression).
+   * Valid compression levels are 0 (no compression) to 9 (maximum compression).
    */
   def xzBytes(b: Array[Byte], compressionLevel: Option[Int]): String = {
     val outputStream: ByteArrayOutputStream = new ByteArrayOutputStream(b.length)
@@ -51,14 +51,14 @@ object Platform {
 
   def yamlToJson(yamlString: String): String = {
     try {
-      val yaml = new Yaml(new SafeConstructor(new LoaderOptions())).loadAll(yamlString)
-          .asInstanceOf[java.lang.Iterable[java.util.Collection[Object]]].asScala.toSeq
+      val yaml = new Yaml(new SafeConstructor(new LoaderOptions())).loadAll(yamlString).asScala.toSeq
       yaml.size match {
         case 0 => "{}"
-        case 1 if yaml.head.isInstanceOf[java.util.Map[String, Object]] =>
-          new JSONObject(yaml.head.asInstanceOf[java.util.Map[String, Object]]).toString()
-        case 1 if yaml.head.isInstanceOf[java.util.List[Object]] =>
-          new JSONArray(yaml.head.asInstanceOf[java.util.List[Object]]).toString()
+        case 1 => yaml.head match {
+          case m: java.util.Map[_, _] => new JSONObject(m).toString()
+          case l: java.util.List[_] => new JSONArray(l).toString()
+          case _ => new JSONArray(yaml.asJava).get(0).toString
+        }
         case _ => new JSONArray(yaml.asJava).toString()
       }
     } catch {
@@ -70,7 +70,7 @@ object Platform {
   private def computeHash(algorithm: String, s: String) = {
     java.security.MessageDigest.getInstance(algorithm)
       .digest(s.getBytes("UTF-8"))
-      .map{ b => String.format("%02x", (b & 0xff).asInstanceOf[Integer])}
+      .map { b => String.format("%02x", (b & 0xff).asInstanceOf[Integer]) }
       .mkString
   }
 

--- a/sjsonnet/src/sjsonnet/Materializer.scala
+++ b/sjsonnet/src/sjsonnet/Materializer.scala
@@ -59,8 +59,10 @@ abstract class Materializer {
       case Val.Null(pos) => storePos(pos); visitor.visitNull(-1)
       case s: Val.Func =>
         Error.fail("Couldn't manifest function with params [" + s.params.names.mkString(",") + "]", v.pos)
+      case vv: Val =>
+        Error.fail("Unknown value type " + vv.prettyName, vv.pos)
       case _ =>
-        Error.fail("Unknown value type", v.pos)
+        Error.fail("Unknown value type " + v)
     }
   } catch {
     case _: StackOverflowError =>

--- a/sjsonnet/test/src-jvm/sjsonnet/ParseYamlTests.scala
+++ b/sjsonnet/test/src-jvm/sjsonnet/ParseYamlTests.scala
@@ -7,10 +7,12 @@ object ParseYamlTests extends TestSuite {
   def tests: Tests = Tests {
     test {
       eval("std.parseYaml('foo: bar')") ==> ujson.Value("""{"foo":"bar"}""")
+      eval("std.parseYaml('- foo: bar')") ==> ujson.Value("""[{"foo":"bar"}]""")
     }
     test {
       eval("std.parseYaml('')") ==> ujson.Value("""{}""")
-      }
+      eval("std.parseYaml(\"0777\")") ==> ujson.Value("""511""")
+    }
     test {
       eval("std.parseYaml('foo: bar\n---\nbar: baz\n')") ==> ujson.Value("""[{"foo": "bar"}, {"bar": "baz"}]""")
     }


### PR DESCRIPTION
I was looking at https://github.com/google/jsonnet/issues/1109 and realized that we did not parse yaml correctly for primitive types:

`std.parseYaml("0777")` returned `[511]` instead of `511` (something that other implementations of jsonnet do)
