### PR TITLE
Fix usage of - in stripChars with the introduction of RE2

### DIFF
--- a/sjsonnet/src-native/sjsonnet/Platform.scala
+++ b/sjsonnet/src-native/sjsonnet/Platform.scala
@@ -4,7 +4,7 @@ import java.io.{ByteArrayOutputStream, File}
 import java.util
 import java.util.Base64
 import java.util.zip.GZIPOutputStream
-import java.util.regex.Pattern
+import scala.scalanative.regex.Pattern
 
 object Platform {
   def gzipBytes(b: Array[Byte]): String = {

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -483,14 +483,26 @@ class Std(private val additionalNativeFunctions: Map[String, Val.Builtin] = Map.
   }
 
   private object StripUtils {
+    private val dashPattern = Platform.getPatternFromCache("-")
+
+    private def cleanupPattern(chars: String): String = {
+      val matcher = dashPattern.matcher(chars)
+      if (matcher.find()) {
+        matcher.replaceAll("") + "-"
+      } else {
+        chars
+      }
+    }
+
     private def getLeadingPattern(chars: String): String = "^[" + Platform.regexQuote(chars) + "]+"
 
     private def getTrailingPattern(chars: String): String = "[" + Platform.regexQuote(chars) + "]+$"
 
     def unspecializedStrip(str: String, chars: String, left: Boolean, right: Boolean): String = {
       var s = str
-      if (right) s = Platform.getPatternFromCache(getTrailingPattern(chars)).matcher(s).replaceAll("")
-      if (left) s = Platform.getPatternFromCache(getLeadingPattern(chars)).matcher(s).replaceAll("")
+      val cleanedUpPattern = cleanupPattern(chars)
+      if (right) s = Platform.getPatternFromCache(getTrailingPattern(cleanedUpPattern)).matcher(s).replaceAll("")
+      if (left) s = Platform.getPatternFromCache(getLeadingPattern(cleanedUpPattern)).matcher(s).replaceAll("")
       s
     }
 
@@ -500,8 +512,9 @@ class Std(private val additionalNativeFunctions: Map[String, Val.Builtin] = Map.
       right: Boolean,
       functionName: String
     ) extends Val.Builtin1(functionName, "str") {
-      private[this] val leftPattern = Platform.getPatternFromCache(getLeadingPattern(chars))
-      private[this] val rightPattern = Platform.getPatternFromCache(getTrailingPattern(chars))
+      private[this] val cleanedUpPattern = cleanupPattern(chars)
+      private[this] val leftPattern = Platform.getPatternFromCache(getLeadingPattern(cleanedUpPattern))
+      private[this] val rightPattern = Platform.getPatternFromCache(getTrailingPattern(cleanedUpPattern))
 
       def evalRhs(str: Val, ev: EvalScope, pos: Position): Val = {
         var s = str.asString

--- a/sjsonnet/test/src/sjsonnet/StdStripCharsTests.scala
+++ b/sjsonnet/test/src/sjsonnet/StdStripCharsTests.scala
@@ -1,7 +1,7 @@
 package sjsonnet
 
+import sjsonnet.TestUtils.eval
 import utest._
-import TestUtils.eval
 object StdStripCharsTests extends TestSuite {
 
   def tests = Tests {
@@ -10,6 +10,7 @@ object StdStripCharsTests extends TestSuite {
       eval("std.rstripChars(\"aaabbbbcccc\", \"ac\")").toString() ==> """"aaabbbb""""
       eval("std.rstripChars(\"cacabbbbaacc\", \"ac\")").toString() ==> """"cacabbbb""""
       eval("std.rstripChars(\"cacabbcacabbaacc\", \"ac\")").toString() ==> """"cacabbcacabb""""
+      eval("std.rstripChars(\"cacabbcacabb-aacc\", \"a-c\")").toString() ==> """"cacabbcacabb""""
 
       eval("""std.rstripChars("cacabbcacabb[aacc]", "ac[]$%^&*(")""").toString() ==> """"cacabbcacabb""""
     }
@@ -17,6 +18,7 @@ object StdStripCharsTests extends TestSuite {
       eval("std.lstripChars(\" test test test \", \" \")").toString() ==> """"test test test """"
       eval("std.lstripChars(\"aaabbbbcccc\", \"ac\")").toString() ==> """"bbbbcccc""""
       eval("std.lstripChars(\"cacabbcacabbaacc\", \"ac\")").toString() ==> """"bbcacabbaacc""""
+      eval("std.lstripChars(\"-cacabbcacabbaacc\", \"a-c\")").toString() ==> """"bbcacabbaacc""""
 
       eval("std.lstripChars(\"[]aaabbbbcccc\", \"[ac]\")").toString() ==> """"bbbbcccc""""
 
@@ -25,6 +27,7 @@ object StdStripCharsTests extends TestSuite {
       eval("std.stripChars(\" test test test \", \" \")").toString() ==> """"test test test""""
       eval("std.stripChars(\"aaabbbbcccc\", \"ac\")").toString() ==> """"bbbb""""
       eval("std.stripChars(\"cacabbcacabbaacc\", \"ac\")").toString() ==> """"bbcacabb""""
+      eval("std.stripChars(\"c-acabbca-cabbaacc-\", \"a-c\")").toString() ==> """"bbca-cabb""""
 
       eval("std.stripChars(\"[aaabbbbcccc]\", \"ac[]\")").toString() ==> """"bbbb""""
     }


### PR DESCRIPTION
With this PR, I fix a regression introduced with the migration to RE2.

- If there's a - in the chars in the *stripchars functions, we move it to the end
- explicitely use RE2 with scala native (instead of the thin wrapper around it), which then allows us to
- Enable stripchars test cases for jvm, js & native.