### PR TITLE
Add support for tailstrict

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ lazy val main = (project in file("sjsonnet"))
   .settings(
     Compile / scalacOptions ++= Seq("-opt:l:inline", "-opt-inline-from:sjsonnet.*,sjsonnet.**"),
     Test / fork := true,
+    Test / javaOptions += "-Xss100m",
     Test / baseDirectory := (ThisBuild / baseDirectory).value,
     libraryDependencies ++= Seq(
       "com.lihaoyi" %% "fastparse" % "2.3.3",

--- a/build.sc
+++ b/build.sc
@@ -114,7 +114,7 @@ object sjsonnet extends Module {
     def scalacOptions = Seq("-opt:l:inline", "-opt-inline-from:sjsonnet.**")
 
     object test extends ScalaTests with CrossTests {
-      def forkOptions = Seq("-Xss100m")
+      def forkArgs = Seq("-Xss100m")
       def sources = T.sources(
         this.millSourcePath / "src",
         this.millSourcePath / "src-jvm",

--- a/build.sc
+++ b/build.sc
@@ -111,7 +111,7 @@ object sjsonnet extends Module {
       ivy"org.yaml:snakeyaml::1.33",
       ivy"com.google.re2j:re2j:1.7",
     )
-    def scalacOptions = Seq("-opt:l:inline", "-opt-inline-from:sjsonnet.**")
+    def scalacOptions = Seq("-opt:l:inline", "-opt-inline-from:sjsonnet.*,sjsonnet.**")
 
     object test extends ScalaTests with CrossTests {
       def forkArgs = Seq("-Xss100m")

--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -28,7 +28,12 @@ class Evaluator(resolver: CachedResolver,
   def materialize(v: Val): Value = Materializer.apply(v)
   val cachedImports = collection.mutable.HashMap.empty[Path, Val]
 
-  def visitExpr(e: Expr)(implicit scope: ValScope): Val = try {
+  var isInTailstrictMode = false
+
+  override def tailstrict: Boolean = isInTailstrictMode
+
+
+  override def visitExpr(e: Expr)(implicit scope: ValScope): Val = try {
     e match {
       case e: ValidId => visitValidId(e)
       case e: BinaryOp => visitBinaryOp(e)
@@ -184,14 +189,24 @@ class Evaluator(resolver: CachedResolver,
 
   private def visitApply(e: Apply)(implicit scope: ValScope) = {
     val lhs = visitExpr(e.value)
-    val args = e.args
-    val argsL = new Array[Lazy](args.length)
-    var idx = 0
-    while (idx < args.length) {
-      argsL(idx) = visitAsLazy(args(idx))
-      idx += 1
+
+    if (isInTailstrictMode) {
+      lhs.cast[Val.Func].apply(e.args.map(visitExpr(_)), e.namedNames, e.pos)
+    } else if (e.tailstrict) {
+      isInTailstrictMode = true
+      val res = lhs.cast[Val.Func].apply(e.args.map(visitExpr(_)), e.namedNames, e.pos)
+      isInTailstrictMode = false
+      res
+    } else {
+      val args = e.args
+      val argsL = new Array[Lazy](args.length)
+      var idx = 0
+      while (idx < args.length) {
+        argsL(idx) = visitAsLazy(args(idx))
+        idx += 1
+      }
+      lhs.cast[Val.Func].apply(argsL, e.namedNames, e.pos)
     }
-    lhs.cast[Val.Func].apply(argsL, e.namedNames, e.pos)
   }
 
   private def visitApply0(e: Apply0)(implicit scope: ValScope): Val = {
@@ -201,23 +216,50 @@ class Evaluator(resolver: CachedResolver,
 
   private def visitApply1(e: Apply1)(implicit scope: ValScope): Val = {
     val lhs = visitExpr(e.value)
-    val l1 = visitAsLazy(e.a1)
-    lhs.cast[Val.Func].apply1(l1, e.pos)
+    if (isInTailstrictMode) {
+      lhs.cast[Val.Func].apply1(visitExpr(e.a1), e.pos)
+    } else if (e.tailstrict) {
+      isInTailstrictMode = true
+      val res = lhs.cast[Val.Func].apply1(visitExpr(e.a1), e.pos)
+      isInTailstrictMode = false
+      res
+    } else {
+      val l1 = visitAsLazy(e.a1)
+      lhs.cast[Val.Func].apply1(l1, e.pos)
+    }
   }
 
   private def visitApply2(e: Apply2)(implicit scope: ValScope): Val = {
     val lhs = visitExpr(e.value)
-    val l1 = visitAsLazy(e.a1)
-    val l2 = visitAsLazy(e.a2)
-    lhs.cast[Val.Func].apply2(l1, l2, e.pos)
+    if (isInTailstrictMode) {
+      lhs.cast[Val.Func].apply2(visitExpr(e.a1), visitExpr(e.a2), e.pos)
+    } else if (e.tailstrict) {
+      isInTailstrictMode = true
+      val res = lhs.cast[Val.Func].apply2(visitExpr(e.a1), visitExpr(e.a2), e.pos)
+      isInTailstrictMode = false
+      res
+    } else {
+      val l1 = visitAsLazy(e.a1)
+      val l2 = visitAsLazy(e.a2)
+      lhs.cast[Val.Func].apply2(l1, l2, e.pos)
+    }
   }
 
   private def visitApply3(e: Apply3)(implicit scope: ValScope): Val = {
     val lhs = visitExpr(e.value)
-    val l1 = visitAsLazy(e.a1)
-    val l2 = visitAsLazy(e.a2)
-    val l3 = visitAsLazy(e.a3)
-    lhs.cast[Val.Func].apply3(l1, l2, l3, e.pos)
+    if (isInTailstrictMode) {
+      lhs.cast[Val.Func].apply3(visitExpr(e.a1), visitExpr(e.a2), visitExpr(e.a3), e.pos)
+    } else if (e.tailstrict) {
+      isInTailstrictMode = true
+      val res = lhs.cast[Val.Func].apply3(visitExpr(e.a1), visitExpr(e.a2), visitExpr(e.a3), e.pos)
+      isInTailstrictMode = false
+      res
+    } else {
+      val l1 = visitAsLazy(e.a1)
+      val l2 = visitAsLazy(e.a2)
+      val l3 = visitAsLazy(e.a3)
+      lhs.cast[Val.Func].apply3(l1, l2, l3, e.pos)
+    }
   }
 
   private def visitApplyBuiltin1(e: ApplyBuiltin1)(implicit scope: ValScope) =
@@ -653,7 +695,8 @@ class Evaluator(resolver: CachedResolver,
     newSelf
   }
 
-  def visitComp(f: List[CompSpec], scopes: Array[ValScope]): Array[ValScope] = f match{
+  @inline
+  private final def visitComp(f: List[CompSpec], scopes: Array[ValScope]): Array[ValScope] = f match{
     case (spec @ ForSpec(_, name, expr)) :: rest =>
       visitComp(
         rest,

--- a/sjsonnet/src/sjsonnet/Expr.scala
+++ b/sjsonnet/src/sjsonnet/Expr.scala
@@ -128,11 +128,11 @@ object Expr{
   case class ImportStr(pos: Position, value: String) extends Expr
   case class ImportBin(pos: Position, value: String) extends Expr
   case class Error(pos: Position, value: Expr) extends Expr
-  case class Apply(pos: Position, value: Expr, args: Array[Expr], namedNames: Array[String]) extends Expr
-  case class Apply0(pos: Position, value: Expr) extends Expr
-  case class Apply1(pos: Position, value: Expr, a1: Expr) extends Expr
-  case class Apply2(pos: Position, value: Expr, a1: Expr, a2: Expr) extends Expr
-  case class Apply3(pos: Position, value: Expr, a1: Expr, a2: Expr, a3: Expr) extends Expr
+  case class Apply(pos: Position, value: Expr, args: Array[Expr], namedNames: Array[String], tailstrict: Boolean) extends Expr
+  case class Apply0(pos: Position, value: Expr, tailstrict: Boolean) extends Expr
+  case class Apply1(pos: Position, value: Expr, a1: Expr, tailstrict: Boolean) extends Expr
+  case class Apply2(pos: Position, value: Expr, a1: Expr, a2: Expr, tailstrict: Boolean) extends Expr
+  case class Apply3(pos: Position, value: Expr, a1: Expr, a2: Expr, a3: Expr, tailstrict: Boolean) extends Expr
   case class ApplyBuiltin(pos: Position, func: Val.Builtin, argExprs: Array[Expr]) extends Expr {
     override def exprErrorString: String = s"std.${func.functionName}"
   }

--- a/sjsonnet/src/sjsonnet/ExprTransform.scala
+++ b/sjsonnet/src/sjsonnet/ExprTransform.scala
@@ -14,37 +14,37 @@ abstract class ExprTransform {
         if(x2 eq x) expr
         else Select(pos, x2, name)
 
-      case Apply(pos, x, y, namedNames) =>
+      case Apply(pos, x, y, namedNames, tailstrict) =>
         val x2 = transform(x)
         val y2 = transformArr(y)
         if((x2 eq x) && (y2 eq y)) expr
-        else Apply(pos, x2, y2, namedNames)
+        else Apply(pos, x2, y2, namedNames, tailstrict)
 
-      case Apply0(pos, x) =>
+      case Apply0(pos, x, tailstrict) =>
         val x2 = transform(x)
         if((x2 eq x)) expr
-        else Apply0(pos, x2)
+        else Apply0(pos, x2, tailstrict)
 
-      case Apply1(pos, x, y) =>
+      case Apply1(pos, x, y, tailstrict) =>
         val x2 = transform(x)
         val y2 = transform(y)
         if((x2 eq x) && (y2 eq y)) expr
-        else Apply1(pos, x2, y2)
+        else Apply1(pos, x2, y2, tailstrict)
 
-      case Apply2(pos, x, y, z) =>
+      case Apply2(pos, x, y, z, tailstrict) =>
         val x2 = transform(x)
         val y2 = transform(y)
         val z2 = transform(z)
         if((x2 eq x) && (y2 eq y) && (z2 eq z)) expr
-        else Apply2(pos, x2, y2, z2)
+        else Apply2(pos, x2, y2, z2, tailstrict)
 
-      case Apply3(pos, x, y, z, a) =>
+      case Apply3(pos, x, y, z, a, tailstrict) =>
         val x2 = transform(x)
         val y2 = transform(y)
         val z2 = transform(z)
         val a2 = transform(a)
         if((x2 eq x) && (y2 eq y) && (z2 eq z) && (a2 eq a)) expr
-        else Apply3(pos, x2, y2, z2, a2)
+        else Apply3(pos, x2, y2, z2, a2, tailstrict)
 
       case ApplyBuiltin(pos, func, x) =>
         val x2 = transformArr(x)

--- a/sjsonnet/src/sjsonnet/Interpreter.scala
+++ b/sjsonnet/src/sjsonnet/Interpreter.scala
@@ -107,7 +107,7 @@ class Interpreter(extVars: Map[String, String],
             override def evalDefault(expr: Expr, vs: ValScope, es: EvalScope) = {
               evaluator.visitExpr(expr)(if (tlaExpressions.exists(_ eq expr)) ValScope.empty else vs)
             }
-          }.apply0(f.pos)(evaluator, f.defSiteValScope)
+          }.apply0(f.pos)(evaluator)
         case x => x
       }
     } yield res

--- a/sjsonnet/src/sjsonnet/Interpreter.scala
+++ b/sjsonnet/src/sjsonnet/Interpreter.scala
@@ -107,7 +107,7 @@ class Interpreter(extVars: Map[String, String],
             override def evalDefault(expr: Expr, vs: ValScope, es: EvalScope) = {
               evaluator.visitExpr(expr)(if (tlaExpressions.exists(_ eq expr)) ValScope.empty else vs)
             }
-          }.apply0(f.pos)(evaluator)
+          }.apply0(f.pos)(evaluator, f.defSiteValScope)
         case x => x
       }
     } yield res

--- a/sjsonnet/src/sjsonnet/Parser.scala
+++ b/sjsonnet/src/sjsonnet/Parser.scala
@@ -227,7 +227,7 @@ class Parser(val currentFile: Path,
             case (Some(tree), Seq()) => Expr.Lookup(i, _: Expr, tree)
             case (start, ins) => Expr.Slice(i, _: Expr, start, ins.lift(0).flatten, ins.lift(1).flatten)
           }
-          case '(' => Pass ~ (args ~ ")" ~ "tailstrict".?.!).map {
+          case '(' => Pass ~ (args ~ ")" ~ "tailstrict".!.?).map {
             case (args, namedNames, tailstrict) => Expr.Apply(i, _: Expr, args, if(namedNames.length == 0) null else namedNames, tailstrict.nonEmpty)
           }
           case '{' => Pass ~ (objinside ~ "}").map(x => Expr.ObjExtend(i, _: Expr, x))

--- a/sjsonnet/src/sjsonnet/Parser.scala
+++ b/sjsonnet/src/sjsonnet/Parser.scala
@@ -227,8 +227,8 @@ class Parser(val currentFile: Path,
             case (Some(tree), Seq()) => Expr.Lookup(i, _: Expr, tree)
             case (start, ins) => Expr.Slice(i, _: Expr, start, ins.lift(0).flatten, ins.lift(1).flatten)
           }
-          case '(' => Pass ~ (args ~ ")").map { case (args, namedNames) =>
-            Expr.Apply(i, _: Expr, args, if(namedNames.length == 0) null else namedNames)
+          case '(' => Pass ~ (args ~ ")" ~ "tailstrict".?.!).map {
+            case (args, namedNames, tailstrict) => Expr.Apply(i, _: Expr, args, if(namedNames.length == 0) null else namedNames, tailstrict.nonEmpty)
           }
           case '{' => Pass ~ (objinside ~ "}").map(x => Expr.ObjExtend(i, _: Expr, x))
           case _ => Fail

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -650,6 +650,7 @@ class Std(private val additionalNativeFunctions: Map[String, Val.Builtin] = Map.
         q.removeFirst().force match {
           case v: Val.Arr => v.asLazyArray.reverseIterator.foreach(q.push)
           case s: Val.Str => out.write(s.value)
+          case _ => Error.fail("Cannot call deepJoin on " + value.prettyName)
         }
       }
       Val.Str(pos, out.toString)

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -582,17 +582,17 @@ object Val{
 
     def evalRhs(args: Array[_ <: Lazy], ev: EvalScope, pos: Position): Val
 
-    override def apply(argsL: Array[_ <: Lazy], namedNames: Array[String], outerPos: Position)(implicit ev: EvalScope): Val =
-      evalRhs(argsL, ev, outerPos)
-
     override def apply1(argVal: Lazy, outerPos: Position)(implicit ev: EvalScope): Val =
-      evalRhs(Array(argVal), ev, outerPos)
+      if(params.names.length != 1) apply(Array(argVal), null, outerPos)
+      else evalRhs(Array(argVal), ev, outerPos)
 
     override def apply2(argVal1: Lazy, argVal2: Lazy, outerPos: Position)(implicit ev: EvalScope): Val =
-      evalRhs(Array(argVal1, argVal2), ev, outerPos)
+      if(params.names.length != 2) apply(Array(argVal1, argVal2), null, outerPos)
+      else evalRhs(Array(argVal1, argVal2), ev, outerPos)
 
     override def apply3(argVal1: Lazy, argVal2: Lazy, argVal3: Lazy, outerPos: Position)(implicit ev: EvalScope): Val =
-      evalRhs(Array(argVal1, argVal2, argVal3), ev, outerPos)
+      if(params.names.length != 3) apply(Array(argVal1, argVal2, argVal3), null, outerPos)
+      else evalRhs(Array(argVal1, argVal2, argVal3), ev, outerPos)
 
     /** Specialize a call to this function in the optimizer. Must return either `null` to leave the
      * call-site as it is or a pair of a (possibly different) `Builtin` and the arguments to pass

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -461,14 +461,14 @@ object Val{
 
     override def asFunc: Func = this
 
-    def apply(argsL: Array[_ <: Lazy], namedNames: Array[String], outerPos: Position)(implicit ev: EvalScope, vs: ValScope = defSiteValScope): Val = {
+    def apply(argsL: Array[_ <: Lazy], namedNames: Array[String], outerPos: Position)(implicit ev: EvalScope): Val = {
       val simple = namedNames == null && params.names.length == argsL.length
       val funDefFileScope: FileScope = pos match { case null => outerPos.fileScope case p => p.fileScope }
       //println(s"apply: argsL: ${argsL.length}, namedNames: $namedNames, paramNames: ${params.names.mkString(",")}")
-      if (ev.tailstrict) {
-        System.arraycopy(argsL, 0, vs.bindings, defSiteValScope.length, argsL.length)
-        evalRhs(vs, ev, funDefFileScope, outerPos)
-      } else if(simple) {
+      if (simple || ev.tailstrict) {
+        if (ev.tailstrict) {
+          argsL.foreach(_.force)
+        }
         val newScope = defSiteValScope.extendSimple(argsL)
         evalRhs(newScope, ev, funDefFileScope, outerPos)
       } else {
@@ -521,7 +521,7 @@ object Val{
       }
     }
 
-    def apply0(outerPos: Position)(implicit ev: EvalScope, vs: ValScope = defSiteValScope): Val = {
+    def apply0(outerPos: Position)(implicit ev: EvalScope): Val = {
       if(params.names.length != 0) apply(Evaluator.emptyLazyArray, null, outerPos)
       else {
         val funDefFileScope: FileScope = pos match { case null => outerPos.fileScope case p => p.fileScope }
@@ -529,48 +529,42 @@ object Val{
       }
     }
 
-    def apply1(argVal: Lazy, outerPos: Position)(implicit ev: EvalScope, vs: ValScope = defSiteValScope): Val = {
+    def apply1(argVal: Lazy, outerPos: Position)(implicit ev: EvalScope): Val = {
       if(params.names.length != 1) apply(Array(argVal), null, outerPos)
       else {
         val funDefFileScope: FileScope = pos match { case null => outerPos.fileScope case p => p.fileScope }
         if (ev.tailstrict) {
-          vs.bindings(defSiteValScope.length) = argVal
-          evalRhs(vs, ev, funDefFileScope, outerPos)
-        } else {
-          val newScope: ValScope = defSiteValScope.extendSimple(argVal)
-          evalRhs(newScope, ev, funDefFileScope, outerPos)
+          argVal.force
         }
+        val newScope: ValScope = defSiteValScope.extendSimple(argVal)
+        evalRhs(newScope, ev, funDefFileScope, outerPos)
       }
     }
 
-    def apply2(argVal1: Lazy, argVal2: Lazy, outerPos: Position)(implicit ev: EvalScope, vs: ValScope = defSiteValScope): Val = {
+    def apply2(argVal1: Lazy, argVal2: Lazy, outerPos: Position)(implicit ev: EvalScope): Val = {
       if(params.names.length != 2) apply(Array(argVal1, argVal2), null, outerPos)
       else {
         val funDefFileScope: FileScope = pos match { case null => outerPos.fileScope case p => p.fileScope }
         if (ev.tailstrict) {
-          vs.bindings(defSiteValScope.length) = argVal1
-          vs.bindings(defSiteValScope.length+1) = argVal2
-          evalRhs(vs, ev, funDefFileScope, outerPos)
-        } else {
-          val newScope: ValScope = defSiteValScope.extendSimple(argVal1, argVal2)
-          evalRhs(newScope, ev, funDefFileScope, outerPos)
+          argVal1.force
+          argVal2.force
         }
+        val newScope: ValScope = defSiteValScope.extendSimple(argVal1, argVal2)
+        evalRhs(newScope, ev, funDefFileScope, outerPos)
       }
     }
 
-    def apply3(argVal1: Lazy, argVal2: Lazy, argVal3: Lazy, outerPos: Position)(implicit ev: EvalScope, vs: ValScope = defSiteValScope): Val = {
+    def apply3(argVal1: Lazy, argVal2: Lazy, argVal3: Lazy, outerPos: Position)(implicit ev: EvalScope): Val = {
       if(params.names.length != 3) apply(Array(argVal1, argVal2, argVal3), null, outerPos)
       else {
         val funDefFileScope: FileScope = pos match { case null => outerPos.fileScope case p => p.fileScope }
         if (ev.tailstrict) {
-          vs.bindings(defSiteValScope.length) = argVal1
-          vs.bindings(defSiteValScope.length+1) = argVal2
-          vs.bindings(defSiteValScope.length+2) = argVal3
-          evalRhs(vs, ev, funDefFileScope, outerPos)
-        } else {
-          val newScope: ValScope = defSiteValScope.extendSimple(argVal1, argVal2, argVal3)
-          evalRhs(newScope, ev, funDefFileScope, outerPos)
+          argVal1.force
+          argVal2.force
+          argVal3.force
         }
+        val newScope: ValScope = defSiteValScope.extendSimple(argVal1, argVal2, argVal3)
+        evalRhs(newScope, ev, funDefFileScope, outerPos)
       }
     }
   }
@@ -588,16 +582,16 @@ object Val{
 
     def evalRhs(args: Array[_ <: Lazy], ev: EvalScope, pos: Position): Val
 
-    override def apply(argsL: Array[_ <: Lazy], namedNames: Array[String], outerPos: Position)(implicit ev: EvalScope, vs: ValScope): Val =
+    override def apply(argsL: Array[_ <: Lazy], namedNames: Array[String], outerPos: Position)(implicit ev: EvalScope): Val =
       evalRhs(argsL, ev, outerPos)
 
-    override def apply1(argVal: Lazy, outerPos: Position)(implicit ev: EvalScope, vs: ValScope): Val =
+    override def apply1(argVal: Lazy, outerPos: Position)(implicit ev: EvalScope): Val =
       evalRhs(Array(argVal), ev, outerPos)
 
-    override def apply2(argVal1: Lazy, argVal2: Lazy, outerPos: Position)(implicit ev: EvalScope, vs: ValScope): Val =
+    override def apply2(argVal1: Lazy, argVal2: Lazy, outerPos: Position)(implicit ev: EvalScope): Val =
       evalRhs(Array(argVal1, argVal2), ev, outerPos)
 
-    override def apply3(argVal1: Lazy, argVal2: Lazy, argVal3: Lazy, outerPos: Position)(implicit ev: EvalScope, vs: ValScope): Val =
+    override def apply3(argVal1: Lazy, argVal2: Lazy, argVal3: Lazy, outerPos: Position)(implicit ev: EvalScope): Val =
       evalRhs(Array(argVal1, argVal2, argVal3), ev, outerPos)
 
     /** Specialize a call to this function in the optimizer. Must return either `null` to leave the
@@ -617,11 +611,11 @@ object Val{
 
     def evalRhs(arg1: Val, ev: EvalScope, pos: Position): Val
 
-    override def apply(argVals: Array[_ <: Lazy], namedNames: Array[String], outerPos: Position)(implicit ev: EvalScope, vs: ValScope): Val =
+    override def apply(argVals: Array[_ <: Lazy], namedNames: Array[String], outerPos: Position)(implicit ev: EvalScope): Val =
       if(namedNames == null && argVals.length == 1) evalRhs(argVals(0).force, ev, outerPos)
       else super.apply(argVals, namedNames, outerPos)
 
-    override def apply1(argVal: Lazy, outerPos: Position)(implicit ev: EvalScope, vs: ValScope): Val =
+    override def apply1(argVal: Lazy, outerPos: Position)(implicit ev: EvalScope): Val =
       if(params.names.length == 1) evalRhs(argVal.force, ev, outerPos)
       else super.apply(Array(argVal), null, outerPos)
   }
@@ -632,12 +626,12 @@ object Val{
 
     def evalRhs(arg1: Val, arg2: Val, ev: EvalScope, pos: Position): Val
 
-    override def apply(argVals: Array[_ <: Lazy], namedNames: Array[String], outerPos: Position)(implicit ev: EvalScope, vs: ValScope): Val =
+    override def apply(argVals: Array[_ <: Lazy], namedNames: Array[String], outerPos: Position)(implicit ev: EvalScope): Val =
       if(namedNames == null && argVals.length == 2)
         evalRhs(argVals(0).force, argVals(1).force, ev, outerPos)
       else super.apply(argVals, namedNames, outerPos)
 
-    override def apply2(argVal1: Lazy, argVal2: Lazy, outerPos: Position)(implicit ev: EvalScope, vs: ValScope): Val =
+    override def apply2(argVal1: Lazy, argVal2: Lazy, outerPos: Position)(implicit ev: EvalScope): Val =
       if(params.names.length == 2) evalRhs(argVal1.force, argVal2.force, ev, outerPos)
       else super.apply(Array(argVal1, argVal2), null, outerPos)
   }
@@ -648,7 +642,7 @@ object Val{
 
     def evalRhs(arg1: Val, arg2: Val, arg3: Val, ev: EvalScope, pos: Position): Val
 
-    override def apply(argVals: Array[_ <: Lazy], namedNames: Array[String], outerPos: Position)(implicit ev: EvalScope, vs: ValScope): Val =
+    override def apply(argVals: Array[_ <: Lazy], namedNames: Array[String], outerPos: Position)(implicit ev: EvalScope): Val =
       if(namedNames == null && argVals.length == 3)
         evalRhs(argVals(0).force, argVals(1).force, argVals(2).force, ev, outerPos)
       else super.apply(argVals, namedNames, outerPos)
@@ -660,7 +654,7 @@ object Val{
 
     def evalRhs(arg1: Val, arg2: Val, arg3: Val, arg4: Val, ev: EvalScope, pos: Position): Val
 
-    override def apply(argVals: Array[_ <: Lazy], namedNames: Array[String], outerPos: Position)(implicit ev: EvalScope, vs: ValScope): Val =
+    override def apply(argVals: Array[_ <: Lazy], namedNames: Array[String], outerPos: Position)(implicit ev: EvalScope): Val =
       if(namedNames == null && argVals.length == 4)
         evalRhs(argVals(0).force, argVals(1).force, argVals(2).force, argVals(3).force, ev, outerPos)
       else super.apply(argVals, namedNames, outerPos)

--- a/sjsonnet/test/resources/test_suite/recursive_function_native.jsonnet
+++ b/sjsonnet/test/resources/test_suite/recursive_function_native.jsonnet
@@ -1,0 +1,38 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+local fibonacci(n) =
+  if n <= 1 then
+    1
+  else
+    fibonacci(n - 1) + fibonacci(n - 2);
+
+std.assertEqual(fibonacci(15), 987) &&
+
+// Tail recursive call
+local sum(x, v) =
+  if x <= 0 then
+    v
+  else
+    sum(x - 1, x + v) tailstrict;
+
+// Scala Native is struggling with large stacks.
+local sz = 1000;
+std.assertEqual(sum(sz, 0), sz * (sz + 1) / 2) &&
+
+std.assertEqual(local x() = 3; x() tailstrict, 3) &&
+
+true

--- a/sjsonnet/test/src-jvm/sjsonnet/FileTests.scala
+++ b/sjsonnet/test/src-jvm/sjsonnet/FileTests.scala
@@ -53,7 +53,7 @@ object FileTests extends TestSuite{
     test("oop_extra") - check()
     test("parsing_edge_cases") - check()
     test("precedence") - check()
-//    test("recursive_function") - check()
+    test("recursive_function") - check()
     test("recursive_import_ok") - check()
     test("recursive_object") - check()
     test("regex") - check()

--- a/sjsonnet/test/src-native/sjsonnet/FileTests.scala
+++ b/sjsonnet/test/src-native/sjsonnet/FileTests.scala
@@ -53,7 +53,7 @@ object FileTests extends TestSuite{
     test("oop_extra") - check()
     test("parsing_edge_cases") - check()
     test("precedence") - check()
-//    test("recursive_function") - check()
+    test("recursive_function_native") - check()
     test("recursive_import_ok") - check()
     test("recursive_object") - check()
     test("sanity") - checkGolden()

--- a/sjsonnet/test/src/sjsonnet/FormatTests.scala
+++ b/sjsonnet/test/src/sjsonnet/FormatTests.scala
@@ -10,6 +10,7 @@ object FormatTests extends TestSuite{
     val json = ujson.read(jsonStr)
     val formatted = Format.format(fmt, Materializer.reverse(null, json), dummyPos)(
       new EvalScope{
+        def tailstrict: Boolean = false
         def extVars = _ => None
         def wd: Path = DummyPath()
         def visitExpr(expr: Expr)(implicit scope: ValScope): Val = ???


### PR DESCRIPTION
With this PR, I'm implementing tailstrict in sjsonnet.
I'm following the guidance from https://github.com/google/jsonnet/issues/343#issuecomment-325987638:

Quote:
1. If you call a function with tailstrict annotation on the apply AST, e.g. foo(42) tailstrict then the evaluation of the function body happens in "tail strict mode". The annotated AST need not actually be a tail call. Also, the arguments of this function are forced.
2. When another function call (can be a completely different function to the one that was originally called) is made when we're evaluating in "tail strict mode" and it is a tail call, then the current stack frame is re-used for the next call, rather than being pushed on top of.
3. Note that in order to preserve the tail strict mode into the new function, the new call AST has to be tailstrict as well.

Resolves #189.

