### PR TITLE
ProfilingEvaluator: update ExprBox.name to print builtin function and operator names

### DIFF
--- a/bench/src/main/scala/sjsonnet/ProfilingEvaluator.scala
+++ b/bench/src/main/scala/sjsonnet/ProfilingEvaluator.scala
@@ -24,7 +24,18 @@ class ProfilingEvaluator(resolver: CachedResolver,
     var totalTime: Long = 0
     lazy val prettyOffset = prettyIndex(expr.pos).map { case (l,c) => s"$l:$c" }.getOrElse("?:?")
     lazy val prettyPos = s"${expr.pos.currentFile.asInstanceOf[OsPath].p}:$prettyOffset"
-    lazy val name = expr.getClass.getName.split('.').last.split('$').last
+    lazy val name: String = {
+      val exprName = expr.getClass.getName.split('.').last.split('$').last
+      val funcOrOptName: Option[String] = expr match {
+        case a: Expr.ApplyBuiltin => Some(a.func.functionName)
+        case a: Expr.ApplyBuiltin1 => Some(a.func.functionName)
+        case a: Expr.ApplyBuiltin2 => Some(a.func.functionName)
+        case u: Expr.UnaryOp => Some(Expr.UnaryOp.name(u.op))
+        case b: Expr.BinaryOp => Some(Expr.BinaryOp.name(b.op))
+        case _ => None
+      }
+      exprName + funcOrOptName.map(n => s" ($n)").getOrElse("")
+    }
   }
 
   class OpBox(val op: Int, val name: String) extends Box


### PR DESCRIPTION
This PR implements a small quality-of-life improvement in ProfilingEvaluator, updating `ExprBox.name` so that it prints the names of built in functions and operators, making it easier to interpret profiler output.

For example, before we'd print:

```
[info] Profiling...
[info] Top 20 by time:
[info] - 1286ms ApplyBuiltin2 <some-path>/functions.jsonnet.TEMPLATE:162:15
[info] - 470ms ApplyBuiltin2 <some-path>/functions.jsonnet.TEMPLATE:152:15
[info] - 443ms BinaryOp <some-path>/functions.jsonnet.TEMPLATE:158:35
[info] - 307ms Lookup <some-path>/functions.jsonnet.TEMPLATE:158:42
[....]
```

With this PR's small change, that becomes:

```
[info] Top 20 by time:
[info] - 1161ms ApplyBuiltin2 (join) <some-path>/functions.jsonnet.TEMPLATE:162:15
[info] - 459ms ApplyBuiltin2 (join) <some-path>/functions.jsonnet.TEMPLATE:152:15
[info] - 439ms BinaryOp (+) <some-path>/functions.jsonnet.TEMPLATE:158:35
[info] - 311ms Lookup <some-path>/functions.jsonnet.TEMPLATE:158:42
[...]
```

This makes outputs easier to interpret.