### PR TITLE
Add new math functions to keep up with go-jsonnet

### DIFF
--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -1102,8 +1102,27 @@ class Std(private val additionalNativeFunctions: Map[String, Val.Builtin] = Map.
     builtin("atan", "x"){ (pos, ev, x: Double) =>
       math.atan(x)
     },
+    builtin("atan2", "x", "y"){ (pos, ev, x: Double, y: Double) =>
+      math.atan2(x, y)
+    },
+    builtin("hypot", "x", "y"){ (pos, ev, x: Double, y: Double) =>
+      math.hypot(x, y)
+    },
+    builtin("deg2rad", "x"){ (pos, ev, x: Double) =>
+      math.toRadians(x)
+    },
+    builtin("rad2deg", "x"){ (pos, ev, x: Double) =>
+      math.toDegrees(x)
+    },
     builtin("log", "x"){ (pos, ev, x: Double) =>
       math.log(x)
+    },
+    builtin("log2", "x"){ (pos, ev, x: Double) =>
+      // no scala log2, do our best without getting fancy with numerics
+      math.log(x) / math.log(2.0)
+    },
+    builtin("log10", "x"){ (pos, ev, x: Double) =>
+      math.log10(x)
     },
     builtin("exp", "x"){ (pos, ev, x: Double) =>
       math.exp(x)
@@ -1667,6 +1686,13 @@ class Std(private val additionalNativeFunctions: Map[String, Val.Builtin] = Map.
         new Val.Obj.Member(false, Visibility.Hidden, cached = false) {
           def invoke(self: Val.Obj, sup: Val.Obj, fs: FileScope, ev: EvalScope): Val =
             Val.Str(self.pos, fs.currentFile.relativeToString(ev.wd))
+        }
+      ),
+      (
+        "pi",
+        new Val.Obj.Member(false, Visibility.Hidden, cached = false) {
+          def invoke(self: Val.Obj, sup: Val.Obj, fs: FileScope, ev:EvalScope): Val = 
+            Val.Num(self.pos, math.Pi)
         }
       )
     ): _*

--- a/sjsonnet/test/resources/test_suite/stdlib.jsonnet
+++ b/sjsonnet/test/resources/test_suite/stdlib.jsonnet
@@ -76,6 +76,20 @@ assertClose(std.acos(1), 0) &&
 assertClose(std.asin(1), 0.5 * pi) &&
 assertClose(std.acos(0), 0.5 * pi) &&
 assertClose(std.atan(0), 0) &&
+assertClose(std.atan2(1.0, 2.0), 0.4636476090008061) &&
+assertClose(std.atan2(2.0, 0.4), 1.373400766945016) &&
+assertClose(std.atan2(1.2, 0.0), 1.5707963267948966) &&
+assertClose(std.hypot(1.0, 2.0), std.sqrt(5.0)) &&
+assertClose(std.hypot(2.0, 0.4), std.sqrt(4.16)) &&
+assertClose(std.hypot(1.2, 0.0), std.sqrt(1.44)) &&
+assertClose(std.deg2rad(180.0), pi) &&
+assertClose(std.deg2rad(45.0), pi / 4.0) &&
+assertClose(std.rad2deg(pi / 2.0), 90.0) &&
+assertClose(std.rad2deg(3.0 * pi), 540.0) &&
+assertClose(std.log2(32.0), 5.0) &&
+assertClose(std.log2(100.0), 6.643856189774724) &&
+assertClose(std.log10(32.0), 1.505149978319906) &&
+assertClose(std.log10(100.0), 2) &&
 assertClose(std.log(std.exp(5)), 5) &&
 assertClose(std.mantissa(1), 0.5) &&
 assertClose(std.exponent(1), 1) &&
@@ -489,6 +503,8 @@ std.assertEqual(std.setMember('a', ['b', 'c']), false) &&
   else
     std.assertEqual(std.thisFile, 'stdlib.jsonnet')
 ) &&
+
+assertClose(std.pi, pi) &&
 
 std.assertEqual(import 'this_file/a.libsonnet', 'this_file/a.libsonnet') &&
 std.assertEqual(import 'this_file/b.libsonnet', 'this_file/a.libsonnet') &&

--- a/sjsonnet/test/resources/test_suite/stdlib_native.jsonnet
+++ b/sjsonnet/test/resources/test_suite/stdlib_native.jsonnet
@@ -76,6 +76,20 @@ assertClose(std.acos(1), 0) &&
 assertClose(std.asin(1), 0.5 * pi) &&
 assertClose(std.acos(0), 0.5 * pi) &&
 assertClose(std.atan(0), 0) &&
+assertClose(std.atan2(1.0, 2.0), 0.4636476090008061) &&
+assertClose(std.atan2(2.0, 0.4), 1.373400766945016) &&
+assertClose(std.atan2(1.2, 0.0), 1.5707963267948966) &&
+assertClose(std.hypot(1.0, 2.0), std.sqrt(5.0)) &&
+assertClose(std.hypot(2.0, 0.4), std.sqrt(4.16)) &&
+assertClose(std.hypot(1.2, 0.0), std.sqrt(1.44)) &&
+assertClose(std.deg2rad(180.0), pi) &&
+assertClose(std.deg2rad(45.0), pi / 4.0) &&
+assertClose(std.rad2deg(pi / 2.0), 90.0) &&
+assertClose(std.rad2deg(3.0 * pi), 540.0) &&
+assertClose(std.log2(32.0), 5.0) &&
+assertClose(std.log2(100.0), 6.643856189774724) &&
+assertClose(std.log10(32.0), 1.505149978319906) &&
+assertClose(std.log10(100.0), 2) &&
 assertClose(std.log(std.exp(5)), 5) &&
 assertClose(std.mantissa(1), 0.5) &&
 assertClose(std.exponent(1), 1) &&
@@ -489,6 +503,8 @@ std.assertEqual(std.setMember('a', ['b', 'c']), false) &&
   else
     std.assertEqual(std.thisFile, 'stdlib_native.jsonnet')
 ) &&
+
+assertClose(std.pi, pi) &&
 
 std.assertEqual(import 'this_file/a.libsonnet', 'this_file/a.libsonnet') &&
 std.assertEqual(import 'this_file/b.libsonnet', 'this_file/a.libsonnet') &&


### PR DESCRIPTION
Adds to the std object some functions:
- trigonometric: std.atan2, std.hypot, std.deg2rad, std.rad2deg
- logarithmic: std.log2, std.log10
And one constant: std.pi