### PR TITLE
Make lazy not a protected class

### DIFF
--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -15,7 +15,7 @@ import scala.reflect.ClassTag
  * evaluated dictionary values, array contents, or function parameters
  * are all wrapped in [[Lazy]] and only truly evaluated on-demand
  */
-protected abstract class Lazy {
+abstract class Lazy {
   protected[this] var cached: Val = null
   def compute(): Val
   final def force: Val = {


### PR DESCRIPTION
Otherwise people can't extend `sjsonnet.Val.Builtin2` since they can't implement
```
  def evalRhs(
      arg1: sjsonnet.Lazy,
      arg2: sjsonnet.Lazy,
      ev: sjsonnet.EvalScope,
      pos: sjsonnet.Position): sjsonnet.Val = {
```

See [example](https://github.com/databricks-eng/universe/pull/1015923)