### PR TITLE
chore: support query extVar and tlaVar with a function.

### DIFF
--- a/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMain.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMain.scala
@@ -193,8 +193,8 @@ object SjsonnetMain {
 
     var currentPos: Position = null
     val interp = new Interpreter(
-      extBinding,
-      tlaBinding,
+      queryExtVar = extBinding.get(_),
+      queryTlaVar = extBinding.get(_),
       OsPath(wd),
       importer = importer match{
         case Some(i) => new Importer {
@@ -217,7 +217,7 @@ object SjsonnetMain {
         strictSetOperations = config.strictSetOperations.value,
         throwErrorForInvalidSets = config.throwErrorForInvalidSets.value,
       ),
-      storePos = if (config.yamlDebug.value) currentPos = _ else null,
+      storePos = (position: Position) => if (config.yamlDebug.value) currentPos = position else null,
       warnLogger = warnLogger,
       std = std
     )


### PR DESCRIPTION
Motivation:
Currently, I'm using sjsonnet from Java, which will require me to convert to Scala's immutable map.

Modification:
Instead of converting, add a query function to look up the value.

Result:
Less overhead when using in Java