### PR TITLE
chore: Extract buildin* to FunctionBuilder

### DIFF
--- a/sjsonnet/src/sjsonnet/FunctionBuilder.scala
+++ b/sjsonnet/src/sjsonnet/FunctionBuilder.scala
@@ -1,0 +1,73 @@
+package sjsonnet
+
+/**
+ * Function building helpers for building functions of the Jsonnet language.
+ * */
+trait FunctionBuilder {
+
+  def builtin(obj : Val.Builtin): (String, Val.Builtin) = (obj.functionName, obj)
+
+  def builtin[R: ReadWriter, T1: ReadWriter](name: String, p1: String)
+                                            (eval: (Position, EvalScope, T1) => R): (String, Val.Func) = {
+    (name, new Val.Builtin1(name, p1) {
+      def evalRhs(arg1: Lazy, ev: EvalScope, outerPos: Position): Val = {
+        //println("--- calling builtin: "+name)
+        val v1: T1 = implicitly[ReadWriter[T1]].apply(arg1.force)
+        implicitly[ReadWriter[R]].write(outerPos, eval(outerPos, ev, v1))
+      }
+    })
+  }
+
+  def builtin[R: ReadWriter, T1: ReadWriter, T2: ReadWriter](name: String, p1: String, p2: String)
+                                                            (eval: (Position, EvalScope, T1, T2) => R): (String, Val.Func) = {
+    (name, new Val.Builtin2(name, p1, p2) {
+      def evalRhs(arg1: Lazy, arg2: Lazy, ev: EvalScope, outerPos: Position): Val = {
+        //println("--- calling builtin: "+name)
+        val v1: T1 = implicitly[ReadWriter[T1]].apply(arg1.force)
+        val v2: T2 = implicitly[ReadWriter[T2]].apply(arg2.force)
+        implicitly[ReadWriter[R]].write(outerPos, eval(outerPos, ev, v1, v2))
+      }
+    })
+  }
+
+  def builtin[R: ReadWriter, T1: ReadWriter, T2: ReadWriter, T3: ReadWriter](name: String, p1: String, p2: String, p3: String)
+                                                                            (eval: (Position, EvalScope, T1, T2, T3) => R): (String, Val.Func) = {
+    (name, new Val.Builtin3(name, p1, p2, p3) {
+      def evalRhs(arg1: Lazy, arg2: Lazy, arg3: Lazy, ev: EvalScope, outerPos: Position): Val = {
+        //println("--- calling builtin: "+name)
+        val v1: T1 = implicitly[ReadWriter[T1]].apply(arg1.force)
+        val v2: T2 = implicitly[ReadWriter[T2]].apply(arg2.force)
+        val v3: T3 = implicitly[ReadWriter[T3]].apply(arg3.force)
+        implicitly[ReadWriter[R]].write(outerPos, eval(outerPos, ev, v1, v2, v3))
+      }
+    })
+  }
+
+  def builtin[R: ReadWriter, T1: ReadWriter, T2: ReadWriter, T3: ReadWriter, T4: ReadWriter]
+  (name: String, p1: String, p2: String, p3: String, p4: String)
+  (eval: (Position, EvalScope, T1, T2, T3, T4) => R): (String, Val.Func) = {
+    (name, new Val.Builtin4(name, p1, p2, p3, p4) {
+      def evalRhs(arg1: Lazy, arg2: Lazy, arg3: Lazy, arg4: Lazy, ev: EvalScope, outerPos: Position): Val = {
+        //println("--- calling builtin: "+name)
+        val v1: T1 = implicitly[ReadWriter[T1]].apply(arg1.force)
+        val v2: T2 = implicitly[ReadWriter[T2]].apply(arg2.force)
+        val v3: T3 = implicitly[ReadWriter[T3]].apply(arg3.force)
+        val v4: T4 = implicitly[ReadWriter[T4]].apply(arg4.force)
+        implicitly[ReadWriter[R]].write(outerPos, eval(outerPos, ev, v1, v2, v3, v4))
+      }
+    })
+  }
+
+  /**
+   * Helper function that can define a built-in function with default parameters
+   *
+   * Arguments of the eval function are (args, ev)
+   */
+  def builtinWithDefaults[R: ReadWriter](name: String, params: (String, Val.Literal)*)
+                                        (eval: (Array[Val], Position, EvalScope) => R): (String, Val.Func) = {
+    name -> new Val.Builtin(name, params.map(_._1).toArray, params.map(_._2).toArray) {
+      def evalRhs(args: Array[? <: Lazy], ev: EvalScope, pos: Position): Val =
+        implicitly[ReadWriter[R]].write(pos, eval(args.map(_.force), pos, ev))
+    }
+  }
+}

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -14,7 +14,7 @@ import scala.collection.mutable
   * in Scala code. Uses `builtin` and other helpers to handle the common wrapper
   * logic automatically
   */
-class Std(private val additionalNativeFunctions: Map[String, Val.Builtin] = Map.empty) {
+class Std(private val additionalNativeFunctions: Map[String, Val.Builtin] = Map.empty) extends FunctionBuilder {
   private val dummyPos: Position = new Position(null, 0)
   private val emptyLazyArray = new Array[Lazy](0)
   private val leadingWhiteSpacePattern = Platform.getPatternFromCache("^[ \t\n\f\r\u0085\u00A0']+")
@@ -1706,72 +1706,6 @@ class Std(private val additionalNativeFunctions: Map[String, Val.Builtin] = Map.
       )
     ): _*
   )
-
-  private def builtin(obj : Val.Builtin) = (obj.functionName, obj)
-
-  def builtin[R: ReadWriter, T1: ReadWriter](name: String, p1: String)
-                                            (eval: (Position, EvalScope, T1) => R): (String, Val.Func) = {
-    (name, new Val.Builtin1(name, p1) {
-      def evalRhs(arg1: Lazy, ev: EvalScope, outerPos: Position): Val = {
-        //println("--- calling builtin: "+name)
-        val v1: T1 = implicitly[ReadWriter[T1]].apply(arg1.force)
-        implicitly[ReadWriter[R]].write(outerPos, eval(outerPos, ev, v1))
-      }
-    })
-  }
-
-  def builtin[R: ReadWriter, T1: ReadWriter, T2: ReadWriter](name: String, p1: String, p2: String)
-                                                            (eval: (Position, EvalScope, T1, T2) => R): (String, Val.Func) = {
-    (name, new Val.Builtin2(name, p1, p2) {
-      def evalRhs(arg1: Lazy, arg2: Lazy, ev: EvalScope, outerPos: Position): Val = {
-        //println("--- calling builtin: "+name)
-        val v1: T1 = implicitly[ReadWriter[T1]].apply(arg1.force)
-        val v2: T2 = implicitly[ReadWriter[T2]].apply(arg2.force)
-        implicitly[ReadWriter[R]].write(outerPos, eval(outerPos, ev, v1, v2))
-      }
-    })
-  }
-
-  def builtin[R: ReadWriter, T1: ReadWriter, T2: ReadWriter, T3: ReadWriter](name: String, p1: String, p2: String, p3: String)
-                                                                            (eval: (Position, EvalScope, T1, T2, T3) => R): (String, Val.Func) = {
-    (name, new Val.Builtin3(name, p1, p2, p3) {
-      def evalRhs(arg1: Lazy, arg2: Lazy, arg3: Lazy, ev: EvalScope, outerPos: Position): Val = {
-        //println("--- calling builtin: "+name)
-        val v1: T1 = implicitly[ReadWriter[T1]].apply(arg1.force)
-        val v2: T2 = implicitly[ReadWriter[T2]].apply(arg2.force)
-        val v3: T3 = implicitly[ReadWriter[T3]].apply(arg3.force)
-        implicitly[ReadWriter[R]].write(outerPos, eval(outerPos, ev, v1, v2, v3))
-      }
-    })
-  }
-
-  def builtin[R: ReadWriter, T1: ReadWriter, T2: ReadWriter, T3: ReadWriter, T4: ReadWriter]
-             (name: String, p1: String, p2: String, p3: String, p4: String)
-             (eval: (Position, EvalScope, T1, T2, T3, T4) => R): (String, Val.Func) = {
-    (name, new Val.Builtin4(name, p1, p2, p3, p4) {
-      def evalRhs(arg1: Lazy, arg2: Lazy, arg3: Lazy, arg4: Lazy, ev: EvalScope, outerPos: Position): Val = {
-        //println("--- calling builtin: "+name)
-        val v1: T1 = implicitly[ReadWriter[T1]].apply(arg1.force)
-        val v2: T2 = implicitly[ReadWriter[T2]].apply(arg2.force)
-        val v3: T3 = implicitly[ReadWriter[T3]].apply(arg3.force)
-        val v4: T4 = implicitly[ReadWriter[T4]].apply(arg4.force)
-        implicitly[ReadWriter[R]].write(outerPos, eval(outerPos, ev, v1, v2, v3, v4))
-      }
-    })
-  }
-
-  /**
-    * Helper function that can define a built-in function with default parameters
-    *
-    * Arguments of the eval function are (args, ev)
-    */
-  def builtinWithDefaults[R: ReadWriter](name: String, params: (String, Val.Literal)*)
-                                        (eval: (Array[Val], Position, EvalScope) => R): (String, Val.Func) = {
-    name -> new Val.Builtin(name, params.map(_._1).toArray, params.map(_._2).toArray) {
-      def evalRhs(args: Array[? <: Lazy], ev: EvalScope, pos: Position): Val =
-        implicitly[ReadWriter[R]].write(pos, eval(args.map(_.force), pos, ev))
-    }
-  }
 
   private def uniqArr(pos: Position, ev: EvalScope, arr: Val, keyF: Val): Val = {
     val arrValue = toArrOrString(arr, pos, ev)


### PR DESCRIPTION
Motivation:

Make the `buildin`* helper function accessible without extending the `Std()` class.

Then I can just extend the `FunctionBuilder`, build the `additionalNativeFunctions`, and then pass it to the `Std()`'s constructor.

otherwise: 
```scala
object JsonnetStdExt extends Std(Map.empty) {
  val extFunctions: Map[String, Val.Func] = Map(
    builtin("objectReplaceKey", "obj", "key", "newKey") {
      (pos, ev, o: Val.Obj, key: String, newKey: String) =>
        val bindings: Array[(String, Val.Obj.Member)] = for {
          k <- o.visibleKeyNames
          v = o.value(k, pos.fileScope.noOffsetPos)(ev)
        } yield {
          val newKeyName = if (k == key) newKey else k
          (newKeyName, new Val.Obj.ConstMember(false, Visibility.Normal, v))
        }
        Val.Obj.mk(pos, bindings)
    }
  )
}
```