### PR TITLE
chore: Change the additionalNativeFunctions to accept Val.Func

### DIFF
--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -14,7 +14,7 @@ import scala.collection.mutable
   * in Scala code. Uses `builtin` and other helpers to handle the common wrapper
   * logic automatically
   */
-class Std(private val additionalNativeFunctions: Map[String, Val.Builtin] = Map.empty) {
+class Std(private val additionalNativeFunctions: Map[String, Val.Func] = Map.empty) {
   private val dummyPos: Position = new Position(null, 0)
   private val emptyLazyArray = new Array[Lazy](0)
   private val leadingWhiteSpacePattern = Platform.getPatternFromCache("^[ \t\n\f\r\u0085\u00A0']+")


### PR DESCRIPTION
It should be a `Val.Func` to make it works well with `buildin` functions.
otherwise:
```scala
    new Std(JsonnetStdExt.extFunctions.asInstanceOf[Map[String, Val.Builtin]]).Std
```