### PR TITLE
chore: Add `evaluateVar` to interpreter.

### DIFF
--- a/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMain.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMain.scala
@@ -193,8 +193,8 @@ object SjsonnetMain {
 
     var currentPos: Position = null
     val interp = new Interpreter(
-      queryExtVar = extBinding.get(_),
-      queryTlaVar = tlaBinding.get(_),
+      queryExtVar = key => extBinding.get(key).map(ExternalVariable.code(_)),
+      queryTlaVar = key => extBinding.get(key).map(ExternalVariable.code(_)),
       OsPath(wd),
       importer = importer match{
         case Some(i) => new Importer {

--- a/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMain.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMain.scala
@@ -194,7 +194,7 @@ object SjsonnetMain {
     var currentPos: Position = null
     val interp = new Interpreter(
       queryExtVar = key => extBinding.get(key).map(ExternalVariable.code(_)),
-      queryTlaVar = key => extBinding.get(key).map(ExternalVariable.code(_)),
+      queryTlaVar = key => tlaBinding.get(key).map(ExternalVariable.code(_)),
       OsPath(wd),
       importer = importer match{
         case Some(i) => new Importer {

--- a/sjsonnet/src/sjsonnet/ExternalVariable.scala
+++ b/sjsonnet/src/sjsonnet/ExternalVariable.scala
@@ -6,20 +6,38 @@ package sjsonnet
 sealed trait ExternalVariableKind[T]
 
 object ExternalVariableKind {
+  /**
+   * Get an instance of ExternalVariableKind for a code snippet.
+   * */
   def code: ExternalVariableKind[String] = Code
 
+  /**
+   * Get an instance of ExternalVariableKind for an expr.
+   * */
   def expr: ExternalVariableKind[sjsonnet.Expr] = Expr
 
+  /**
+   * Get an instance of ExternalVariableKind for a variable.
+   * */
   def variable: ExternalVariableKind[String] = Variable
 
+  /**
+   * Indicates that the external variable is a code snippet.
+   * */
   case object Variable extends ExternalVariableKind[String] {
     override def toString: String = "variable"
   }
 
+  /**
+   * Indicates that the external variable is a string literal.
+   * */
   case object Code extends ExternalVariableKind[String] {
     override def toString: String = "code"
   }
 
+  /**
+   * Indicates that the external variable is a parsed jsonnet expression.
+   * */
   case object Expr extends ExternalVariableKind[sjsonnet.Expr] {
     override def toString: String = "expr"
   }

--- a/sjsonnet/src/sjsonnet/ExternalVariableKind.scala
+++ b/sjsonnet/src/sjsonnet/ExternalVariableKind.scala
@@ -1,0 +1,48 @@
+package sjsonnet
+
+/**
+ * An external variable kind indicates the type of external variable.
+ * */
+sealed trait ExternalVariableKind[T]
+
+object ExternalVariableKind {
+  def code: ExternalVariableKind[String] = Code
+
+  def expr: ExternalVariableKind[sjsonnet.Expr] = Expr
+
+  def variable: ExternalVariableKind[String] = Variable
+
+  case object Variable extends ExternalVariableKind[String] {
+    override def toString: String = "variable"
+  }
+
+  case object Code extends ExternalVariableKind[String] {
+    override def toString: String = "code"
+  }
+
+  case object Expr extends ExternalVariableKind[sjsonnet.Expr] {
+    override def toString: String = "expr"
+  }
+}
+
+case class ExternalVariable[T](kind: ExternalVariableKind[T], value: T) {
+  override def toString: String = s"ExternalVariable($kind, $value)"
+}
+
+object ExternalVariable {
+
+  /**
+   * the external variable is a code snippet
+   * */
+  def code(value: String): ExternalVariable[String] = ExternalVariable(ExternalVariableKind.code, value)
+
+  /**
+   * the external variable is a parsed jsonnet expression
+   * */
+  def expr(value: sjsonnet.Expr): ExternalVariable[sjsonnet.Expr] = ExternalVariable(ExternalVariableKind.expr, value)
+
+  /**
+   * the external variable is a variable, string literal
+   * */
+  def variable(value: String): ExternalVariable[String] = ExternalVariable(ExternalVariableKind.variable, value)
+}

--- a/sjsonnet/src/sjsonnet/Interpreter.scala
+++ b/sjsonnet/src/sjsonnet/Interpreter.scala
@@ -73,8 +73,8 @@ class Interpreter(queryExtVar: String => Option[ExternalVariable[_]],
   /**
    * Evaluate a variable to an `Expr`.
    * */
-  def evaluateVar(k: String, externalVariable: ExternalVariable[_]): Expr = externalVariable match {
-    case ExternalVariable(ExternalVariableKind.Code, v: String) => parseVar(k, v)
+  def evaluateVar(ctx: String, k: String, externalVariable: ExternalVariable[_]): Expr = externalVariable match {
+    case ExternalVariable(ExternalVariableKind.Code, v: String) => parseVar(ctx + "-" + k, v)
     case ExternalVariable(ExternalVariableKind.Expr, v: Expr) => v
     case ExternalVariable(ExternalVariableKind.Variable, v: String) => Val.Str(noOffsetPos, v)
   }
@@ -89,7 +89,7 @@ class Interpreter(queryExtVar: String => Option[ExternalVariable[_]],
   val evaluator: Evaluator = createEvaluator(
     resolver,
     // parse extVars lazily, because they can refer to each other and be recursive
-    k => queryExtVar(k).map(v => evaluateVar(s"ext-var $k", v)),
+    k => queryExtVar(k).map(v => evaluateVar("ext", k, v)),
     wd,
     settings,
     warn
@@ -137,7 +137,7 @@ class Interpreter(queryExtVar: String => Option[ExternalVariable[_]],
           while(i < defaults2.length) {
             val k = f.params.names(i)
             for(v <- queryTlaVar(k)){
-              val parsed = evaluateVar(s"tla-var $k", v)
+              val parsed = evaluateVar("tla", k, v)
               defaults2(i) = parsed
               tlaExpressions.add(parsed)
             }

--- a/sjsonnet/src/sjsonnet/Interpreter.scala
+++ b/sjsonnet/src/sjsonnet/Interpreter.scala
@@ -74,7 +74,7 @@ class Interpreter(queryExtVar: String => Option[ExternalVariable[_]],
    * Evaluate a variable to an `Expr`.
    * */
   def evaluateVar(ctx: String, k: String, externalVariable: ExternalVariable[_]): Expr = externalVariable match {
-    case ExternalVariable(ExternalVariableKind.Code, v: String) => parseVar(ctx + "-" + k, v)
+    case ExternalVariable(ExternalVariableKind.Code, v: String) => parseVar(s"$ctx-var $k", v)
     case ExternalVariable(ExternalVariableKind.Expr, v: Expr) => v
     case ExternalVariable(ExternalVariableKind.Variable, v: String) => Val.Str(noOffsetPos, v)
   }


### PR DESCRIPTION
Motivation:
When using Java, I query a Java hashmap, I can then emit the `Expr` directly, instead of converting it to a string and then parsing it.