### PR TITLE
chore: Add additional std function support.

### DIFF
--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -14,7 +14,8 @@ import scala.collection.mutable
   * in Scala code. Uses `builtin` and other helpers to handle the common wrapper
   * logic automatically
   */
-class Std(private val additionalNativeFunctions: Map[String, Val.Func] = Map.empty) extends FunctionBuilder {
+class Std(private val additionalNativeFunctions: Map[String, Val.Func] = Map.empty,
+          private val additionalStdFunctions: Map[String, Val.Func] = Map.empty) extends FunctionBuilder {
   private val dummyPos: Position = new Position(null, 0)
   private val emptyLazyArray = new Array[Lazy](0)
   private val leadingWhiteSpacePattern = Platform.getPatternFromCache("^[ \t\n\f\r\u0085\u00A0']+")
@@ -1624,6 +1625,8 @@ class Std(private val additionalNativeFunctions: Map[String, Val.Func] = Map.emp
     },
   ) ++ builtinNativeFunctions
 
+  require(functions.forall(k => !additionalStdFunctions.contains(k._1)), "Conflicting std functions")
+
   private def toSetArrOrString(args: Array[Val], idx: Int, pos: Position, ev: EvalScope) = {
     args(idx) match {
       case arr: Val.Arr => arr.asLazyArray
@@ -1682,7 +1685,7 @@ class Std(private val additionalNativeFunctions: Map[String, Val.Func] = Map.emp
 
   val Std: Val.Obj = Val.Obj.mk(
     null,
-    functions.toSeq
+    (functions ++ additionalStdFunctions).toSeq
       .map{
         case (k, v) =>
           (

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -16,6 +16,9 @@ import scala.collection.mutable
   */
 class Std(private val additionalNativeFunctions: Map[String, Val.Func] = Map.empty,
           private val additionalStdFunctions: Map[String, Val.Func] = Map.empty) extends FunctionBuilder {
+  //keep for binary compatibility
+  def this(additionalNativeFunctions: Map[String, Val.Func]) = this(additionalNativeFunctions, Map.empty)
+
   private val dummyPos: Position = new Position(null, 0)
   private val emptyLazyArray = new Array[Lazy](0)
   private val leadingWhiteSpacePattern = Platform.getPatternFromCache("^[ \t\n\f\r\u0085\u00A0']+")


### PR DESCRIPTION
Motivation:
Support registry addtional `std`* functions, other than `std.native('xxxfunction')(...)`

eg:
```jsonnet
local input = {
                "person1": {
                  "name": "Alice",
                  "welcome": "Hello Alice!"
                },
                "person2": {
                  "name": "Bob",
                  "welcome": "Hello Bob!"
                }
              };

{
  // Extracting the name of person1 using JSONPath
  extractedName: std.jsonpath(input, "$.person1.name")[0],

  // Extracting the welcome message of person2 using JSONPath
  extractedWelcome: std.jsonpath(input, "$.person2.welcome")[0],
}

```