### PR TITLE
Fix overly-eager evaluation of unmerged or removed target fields in std.mergePatch

### DIFF
--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -934,6 +934,8 @@ class Std(private val additionalNativeFunctions: Map[String, Val.Func] = Map.emp
                   // Preserve the LHS/target value:
                   kvs(kvsIdx) = (key, createLazyMember(l.valueRaw(key, l, pos)(ev)))
                 } else {
+                  // Below, lValue is lazy so that we can short circuit and skip its
+                  // evaluation when rValue is not an object:
                   lazy val lValue = l.valueRaw(key, l, pos)(ev)
                   if (rValue.isInstanceOf[Val.Obj] && lValue.isInstanceOf[Val.Obj]) {
                     // Recursively merge objects:

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -934,8 +934,8 @@ class Std(private val additionalNativeFunctions: Map[String, Val.Func] = Map.emp
                   // Preserve the LHS/target value:
                   kvs(kvsIdx) = (key, createLazyMember(l.valueRaw(key, l, pos)(ev)))
                 } else {
-                  val lValue = l.valueRaw(key, l, pos)(ev)
-                  if (lValue.isInstanceOf[Val.Obj] && rValue.isInstanceOf[Val.Obj]) {
+                  lazy val lValue = l.valueRaw(key, l, pos)(ev)
+                  if (rValue.isInstanceOf[Val.Obj] && lValue.isInstanceOf[Val.Obj]) {
                     // Recursively merge objects:
                     kvs(kvsIdx) = (key, createLazyMember(recPair(lValue, rValue)))
                   } else {

--- a/sjsonnet/test/src/sjsonnet/StdMergePatchTests.scala
+++ b/sjsonnet/test/src/sjsonnet/StdMergePatchTests.scala
@@ -108,5 +108,15 @@ object StdMergePatchTests extends TestSuite {
       eval("""{a:: 0} + {[a]: 1 for a in ["a"]}""") ==> ujson.Obj()
       eval("""({a:: 0} + {[a]: 1 for a in ["a"]}).a""") ==> ujson.Num(1)
     }
+
+    test("lazy evaluation of LHS members") {
+      // An erroring target field which doesn't merge with any patch fields.
+      // This shouldn't error because we should avoid eager evaluation of unmerged target fields:
+      eval("(std.mergePatch({ boom: error \"should not error\" }, {}) + { flag: 42 }).flag") ==> ujson.Num(42)
+
+      // An erroring target field which is removed by the patch:
+      // This should not error because we shouldn't evaluate the removed field:
+      eval("(std.mergePatch({ boom: error \"should not error\" }, { boom: null }) + { flag: 42 }).flag") ==> ujson.Num(42)
+    }
   }
 }

--- a/sjsonnet/test/src/sjsonnet/StdMergePatchTests.scala
+++ b/sjsonnet/test/src/sjsonnet/StdMergePatchTests.scala
@@ -112,18 +112,18 @@ object StdMergePatchTests extends TestSuite {
     test("lazy evaluation of LHS members") {
       // An erroring target field which doesn't merge with any patch fields.
       // This shouldn't error because we should avoid eager evaluation of unmerged target fields:
-      eval("(std.mergePatch({ boom: error \"should not error\" }, {}) + { flag: 42 }).flag") ==> ujson.Num(42)
+      eval("""(std.mergePatch({ boom: error "should not error" }, {}) + { flag: 42 }).flag""") ==> ujson.Num(42)
 
       // An erroring target field which is removed by the patch.
       // This should not error because we shouldn't evaluate the removed field:
-      eval("(std.mergePatch({ boom: error \"should not error\" }, { boom: null }) + { flag: 42 }).flag") ==> ujson.Num(42)
+      eval("""(std.mergePatch({ boom: error "should not error" }, { boom: null }) + { flag: 42 }).flag""") ==> ujson.Num(42)
 
       // An overwritten target field which doesn't merge with any patch fields.
       // This should not error because it doesn't require evaluation of the replaced target field:
-      eval("(std.mergePatch({ boom: error \"should error\" }, { boom: 1 }) + { flag: 42 }).flag") ==> ujson.Num(42)
+      eval("""(std.mergePatch({ boom: error "should error" }, { boom: 1 }) + { flag: 42 }).flag""") ==> ujson.Num(42)
 
       // Patch fields are always eagerly evaluated, even if they don't merge with anything:
-      assert(evalErr("(std.mergePatch({a: 1}, {b: error \"should error\"})).a").startsWith("sjsonnet.Error: should error"))
+      assert(evalErr("""(std.mergePatch({a: 1}, {b: error "should error"})).a""").startsWith("sjsonnet.Error: should error"))
     }
   }
 }


### PR DESCRIPTION
This PR fixes #307, an issue where sjsonnet's `std.mergePatch` is overly eager in its evaluation of target object fields in certain circumstances.

## Example reproductions of the bug

```jsonnet
(std.mergePatch({ boom: error "should not error" }, {}) + { flag: 42 }).flag
```

and

```jsonnet
(std.mergePatch({ boom: error "should not error" }, { boom: null }) + { flag: 42 }).flag
```

and

```jsonnet
(std.mergePatch({ boom: error "should error" }, { boom: 1 }) + { flag: 42 }).flag
```

all print `42` in both google/jsonnet and go-jsonnet. In all cases, the target object contains a field, `boom`, which throws an error if evaluated. 

In the first case, the `boom` field doesn't merge with any patch field and isn't required in the final output materialization and thus should not be evaluated.

In the second case, the `boom `field is removed by an explicitly `null` patch field. In this case, the original target value should not be evaluated.

In the third case, the `boom` field is overwritten by a non-erroring field. In this case, the original target value isn't needed and should not be evaluated.

In sjsonnet, all three of these inputs trigger errors.

## Root cause

This behavior difference stems from a difference in the eagerness of value computation: the google/jsonnet reference [implementation](https://github.com/google/jsonnet/blob/5b507462fe4179bbf7acf1808f9502636eac2306/stdlib/std.jsonnet#L1531C2-L1553C13)  avoids the computation of unmerged or removed target fields:

```jsonnet
 mergePatch(target, patch)::
    if std.isObject(patch) then
      local target_object =
        if std.isObject(target) then target else {};

      local target_fields =
        if std.isObject(target_object) then std.objectFields(target_object) else [];

      local null_fields = [k for k in std.objectFields(patch) if patch[k] == null];
      local both_fields = std.setUnion(target_fields, std.objectFields(patch));

      {
        [k]:
          if !std.objectHas(patch, k) then
            target_object[k]
          else if !std.objectHas(target_object, k) then
            std.mergePatch(null, patch[k]) tailstrict
          else
            std.mergePatch(target_object[k], patch[k]) tailstrict
        for k in std.setDiff(both_fields, null_fields)
      }
    else
      patch,
```

In this reference implementation, unmodified target fields are passed through via `target_object[k]` (which is lazy) and removed fields are never retrieved. In contrast, sjsonnet's implementation eagerly evaluates both the target and patch values in all cases.

Note that performing any comparison or type check of an `error` will throw the error. For example, `std.objectFields(error 'err')` errors, as does `(error 'err') == null`. Due to this, the `local null_fields = [k for k in std.objectFields(patch) if patch[k] == null];` means that error patch fields will always throw.

## This PR's fix

In this PR, I have modified sjonnet's implementation to match the reference implementation:

- When a target field is preserved as-is (i.e. without merging with a patch), use `createLazyMember` to preserve laziness.
- When a target field is deleted or is overwritten without merging (e.g. if the patch is supplying a non-Object value), simply skip evaluation of the removed or replaced target field.

I've added new test cases in `sjsonnet/test/src/sjsonnet/StdMergePatchTests.scala`