### PR TITLE
feat: Add variableResolver to separate the namespaces.

### DIFF
--- a/bench/src/main/scala/sjsonnet/OptimizerBenchmark.scala
+++ b/bench/src/main/scala/sjsonnet/OptimizerBenchmark.scala
@@ -32,7 +32,7 @@ class OptimizerBenchmark {
     }
     this.ev = ev
     val static = inputs.map {
-      case (expr, fs) => ((new StaticOptimizer(ev, new Std().Std, mutable.HashMap.empty, mutable.HashMap.empty)).optimize(expr), fs)
+      case (expr, fs) => ((new StaticOptimizer(ev,_ => None, new Std().Std, mutable.HashMap.empty, mutable.HashMap.empty)).optimize(expr), fs)
     }
     val countBefore, countStatic = new Counter
     inputs.foreach(t => assert(countBefore.transform(t._1) eq t._1))
@@ -45,7 +45,9 @@ class OptimizerBenchmark {
   @Benchmark
   def main(bh: Blackhole): Unit = {
     bh.consume(inputs.foreach { case (expr, fs) =>
-      bh.consume((new StaticOptimizer(ev, new Std().Std, mutable.HashMap.empty, mutable.HashMap.empty)).optimize(expr))
+      bh.consume((new StaticOptimizer(ev,
+        _ => None,
+        new Std().Std, mutable.HashMap.empty, mutable.HashMap.empty)).optimize(expr))
     })
   }
 

--- a/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMain.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMain.scala
@@ -219,7 +219,8 @@ object SjsonnetMain {
       ),
       storePos = (position: Position) => if (config.yamlDebug.value) currentPos = position else (),
       warnLogger = warnLogger,
-      std = std
+      std = std,
+      variableResolver = _ => None
     )
 
     (config.multi, config.yamlStream.value) match {

--- a/sjsonnet/src/sjsonnet/Interpreter.scala
+++ b/sjsonnet/src/sjsonnet/Interpreter.scala
@@ -20,7 +20,8 @@ class Interpreter(queryExtVar: String => Option[ExternalVariable[_]],
                   settings: Settings,
                   storePos: Position => Unit,
                   warnLogger: String => Unit,
-                  std: Val.Obj
+                  std: Val.Obj,
+                  variableResolver: String => Option[Expr]
                  ) { self =>
 
   def this(extVars: Map[String, String],
@@ -31,10 +32,11 @@ class Interpreter(queryExtVar: String => Option[ExternalVariable[_]],
            settings: Settings = Settings.default,
            storePos: Position => Unit = null,
            warnLogger: (String => Unit) = null,
-           std: Val.Obj = new Std().Std) =
+           std: Val.Obj = new Std().Std,
+           variableResolver: String => Option[Expr] = _ => None) =
     this(key => extVars.get(key).map(ExternalVariable.code(_)),
       key => tlaVars.get(key).map(ExternalVariable.code(_)),
-      wd, importer, parseCache, settings, storePos, warnLogger, std)
+      wd, importer, parseCache, settings, storePos, warnLogger, std, variableResolver)
 
   private val noOffsetPos = new Position(new FileScope(wd), -1)
 
@@ -56,7 +58,7 @@ class Interpreter(queryExtVar: String => Option[ExternalVariable[_]],
                                 std: Val.Obj,
                                 internedStrings: mutable.HashMap[String, String],
                                 internedStaticFieldSets: mutable.HashMap[Val.StaticObjectFieldSet, java.util.LinkedHashMap[String, java.lang.Boolean]]): StaticOptimizer = {
-    new StaticOptimizer(ev, std, internedStrings, internedStaticFieldSets)
+    new StaticOptimizer(ev, variableResolver, std, internedStrings, internedStaticFieldSets)
   }
 
   /**

--- a/sjsonnet/test/src/sjsonnet/ExtFunctionNamespaceTest.scala
+++ b/sjsonnet/test/src/sjsonnet/ExtFunctionNamespaceTest.scala
@@ -1,0 +1,57 @@
+package sjsonnet
+
+import utest._
+import sjsonnet.Expr.Member.Visibility
+
+object ExtFunctionNamespaceTest extends TestSuite with FunctionBuilder {
+  private val extFunctions: Map[String, Val.Func] = Map(
+    builtin("objectReplaceKey", "obj", "key", "newKey") {
+      (pos, ev, o: Val.Obj, key: String, newKey: String) =>
+        val bindings: Array[(String, Val.Obj.Member)] = for {
+          k <- o.visibleKeyNames
+          v = o.value(k, pos.fileScope.noOffsetPos)(ev)
+        } yield {
+          val newKeyName = if (k == key) newKey else k
+          (newKeyName, new Val.Obj.ConstMember(false, Visibility.Normal, v))
+        }
+        Val.Obj.mk(pos, bindings)
+    })
+
+  private val ext = Val.Obj.mk(
+    null,
+    extFunctions.toSeq.map {
+      case (k, v) => (k, new Val.Obj.ConstMember(false, Visibility.Hidden, v))
+    }: _*
+  )
+
+  private def variableResolve(name: String): Option[Expr] = {
+    if (name == "$ext" || name == "ext") {
+      Some(ext)
+    } else {
+      None
+    }
+  }
+
+  private val interpreter = new Interpreter(
+    Map(),
+    Map(),
+    DummyPath(),
+    Importer.empty,
+    parseCache = new DefaultParseCache,
+    variableResolver = variableResolve,
+  )
+
+  def check(s: String, expected: ujson.Value): Unit =
+    interpreter.interpret(s, DummyPath("(memory)")) ==> Right(expected)
+
+  def tests: Tests = Tests {
+    "test objectReplaceKey in ext namespace" - {
+      check(
+        s"""
+           |local obj = {"a": 1, "b": 2};
+           |
+           |ext.objectReplaceKey(obj, "a", "c")
+           |""".stripMargin, ujson.Obj("c" -> 1, "b" -> 2))
+    }
+  }
+}


### PR DESCRIPTION
Motivation:
Instead of adding methods to `std`, adding them to a separate namespace seems better and safer.

```jsonnet
local input = {
                  "name": "Alice",
                  "welcome": "Hello Alice!"
              };

tb.objectReplaceKey(input,"name", "newName")
```
Here we bind the `objectReplaceKey` function to `tb`, and then get the right result.

```json
{"newName":"Alice","welcome":"Hello Alice!"}
```