### PR TITLE
feat: Add FunctionModule helper classes.

### DIFF
--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -5,6 +5,7 @@ import java.nio.charset.StandardCharsets.UTF_8
 import java.util.Base64
 import java.util
 import sjsonnet.Expr.Member.Visibility
+import sjsonnet.functions.FunctionBuilder
 
 import scala.collection.Searching._
 import scala.collection.mutable

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -628,6 +628,18 @@ object Val{
     def staticSafe: Boolean = true
   }
 
+  abstract class Builtin0(functionName: String, def1: Expr = null) extends Builtin(functionName: String, Array.empty, if (def1 == null) null else Array(def1)) {
+    final def evalRhs(args: Array[? <: Lazy], ev: EvalScope, pos: Position): Val =
+      evalRhs(ev, pos)
+
+    def evalRhs(ev: EvalScope, pos: Position): Val
+
+    override def apply(argVals: Array[? <: Lazy], namedNames: Array[String], outerPos: Position)(implicit ev: EvalScope): Val =
+      if (namedNames == null && argVals.length == 0)
+        evalRhs(ev, outerPos)
+      else super.apply(argVals, namedNames, outerPos)
+  }
+
   abstract class Builtin1(functionName: String, pn1: String, def1: Expr = null) extends Builtin(functionName: String, Array(pn1), if(def1 == null) null else Array(def1)) {
     final def evalRhs(args: Array[? <: Lazy], ev: EvalScope, pos: Position): Val =
       evalRhs(args(0).force, ev, pos)

--- a/sjsonnet/src/sjsonnet/functions/AbstractFunctionModule.scala
+++ b/sjsonnet/src/sjsonnet/functions/AbstractFunctionModule.scala
@@ -1,0 +1,18 @@
+package sjsonnet.functions
+
+import sjsonnet.Val
+
+/**
+ * An abstract base class for function modules.
+ */
+abstract class AbstractFunctionModule extends FunctionModule {
+  /**
+   * module's functions
+   * */
+  val functions: Seq[(String, Val.Func)]
+
+  /**
+   * the hodler of the module object
+   * */
+  override final lazy val module: Val.Obj = moduleFromFunctions(functions: _*)
+}

--- a/sjsonnet/src/sjsonnet/functions/FunctionBuilder.scala
+++ b/sjsonnet/src/sjsonnet/functions/FunctionBuilder.scala
@@ -9,6 +9,16 @@ trait FunctionBuilder {
 
   def builtin(obj : Val.Builtin): (String, Val.Builtin) = (obj.functionName, obj)
 
+  def builtin[R: ReadWriter](name: String)
+                            (eval: (Position, EvalScope) => R): (String, Val.Func) = {
+    (name, new Val.Builtin0(name) {
+      def evalRhs(ev: EvalScope, outerPos: Position): Val = {
+        //println("--- calling builtin: "+name)
+        implicitly[ReadWriter[R]].write(outerPos, eval(outerPos, ev))
+      }
+    })
+  }
+
   def builtin[R: ReadWriter, T1: ReadWriter](name: String, p1: String)
                                             (eval: (Position, EvalScope, T1) => R): (String, Val.Func) = {
     (name, new Val.Builtin1(name, p1) {

--- a/sjsonnet/src/sjsonnet/functions/FunctionBuilder.scala
+++ b/sjsonnet/src/sjsonnet/functions/FunctionBuilder.scala
@@ -1,4 +1,6 @@
-package sjsonnet
+package sjsonnet.functions
+
+import sjsonnet._
 
 /**
  * Function building helpers for building functions of the Jsonnet language.

--- a/sjsonnet/src/sjsonnet/functions/FunctionModule.scala
+++ b/sjsonnet/src/sjsonnet/functions/FunctionModule.scala
@@ -1,0 +1,50 @@
+package sjsonnet.functions
+
+import sjsonnet.Expr.Member.Visibility
+import sjsonnet.Val.Obj
+import sjsonnet.{Position, Val}
+
+/**
+ * Function modules are collections of functions that can be used in Jsonnet.
+ */
+trait FunctionModule extends FunctionBuilder {
+  protected val position = new Position(null, 0)
+
+  /**
+   * module name
+   * */
+  def name: String
+
+  /**
+   * function module object
+   * */
+  def module: Val.Obj
+
+  /**
+   * Create a module from a sequence of functions.
+   *
+   * @param functions the functions to include in the module
+   * @return the module object
+   */
+  def moduleFromFunctions(functions: (String, Val.Func)*): Val.Obj = {
+    Val.Obj.mk(position, functions.map { case (k, v) => (k, memberOf(v)) }: _*)
+  }
+
+  /**
+   * Create a module from a sequence of sub-modules.
+   *
+   * @param subModules the sub-modules to include in the module
+   * @return the module object
+   */
+  def moduleFromModules(subModules: FunctionModule*): Val.Obj = {
+    Val.Obj.mk(position, subModules.map { module => (module.name, memberOf(module.module)) }: _*)
+  }
+
+  /**
+   * Create a member of the module.
+   *
+   * @param value the value to include in the module
+   * @return the member object
+   */
+  def memberOf(value: Val): Obj.Member = new Obj.ConstMember(false, Visibility.Normal, value)
+}

--- a/sjsonnet/test/src/sjsonnet/ExtFunction0Test.scala
+++ b/sjsonnet/test/src/sjsonnet/ExtFunction0Test.scala
@@ -1,0 +1,51 @@
+package sjsonnet
+
+import sjsonnet.functions.FunctionModule
+import utest._
+
+object ExtFunction0Test extends TestSuite with FunctionModule {
+  override final val name: String = "ext"
+  override final lazy val module: Val.Obj = moduleFromFunctions(extFunctions: _*)
+
+  private val extFunctions: Seq[(String, Val.Func)] = Seq(
+    builtin("sayHello") {
+      (_, _) => "Hello, world!"
+    })
+
+  private def variableResolve(name: String): Option[Expr] = {
+    if (name == "$ext" || name == "ext") {
+      Some(module)
+    } else {
+      None
+    }
+  }
+
+  private val interpreter = new Interpreter(
+    Map(),
+    Map(),
+    DummyPath(),
+    Importer.empty,
+    parseCache = new DefaultParseCache,
+    variableResolver = variableResolve,
+  )
+
+  def check(s: String)(f: Function[Any, Boolean]): Unit = {
+    val result = interpreter.interpret(s, DummyPath("(memory)"))
+    assertMatch(result) {
+      case Right(v) if f(v) => ()
+      case Left(e) => throw new Exception(s"check failed: $s, $e")
+    }
+  }
+
+  def tests: Tests = Tests {
+    "test uuid function in ext namespace" - {
+      check(
+        s"""
+           |local sayHello = ext.sayHello;
+           |sayHello()
+           |""".stripMargin) {
+        case ujson.Str(v) => v == "Hello, world!"
+      }
+    }
+  }
+}

--- a/sjsonnet/test/src/sjsonnet/ExtFunctionNamespaceTest.scala
+++ b/sjsonnet/test/src/sjsonnet/ExtFunctionNamespaceTest.scala
@@ -1,10 +1,14 @@
 package sjsonnet
 
-import utest._
 import sjsonnet.Expr.Member.Visibility
+import sjsonnet.functions.FunctionModule
+import utest._
 
-object ExtFunctionNamespaceTest extends TestSuite with FunctionBuilder {
-  private val extFunctions: Map[String, Val.Func] = Map(
+object ExtFunctionNamespaceTest extends TestSuite with FunctionModule {
+  override final val name: String = "ext"
+  override final lazy val module: Val.Obj =  moduleFromFunctions(extFunctions :_*)
+
+  private val extFunctions: Seq[(String, Val.Func)] = Seq(
     builtin("objectReplaceKey", "obj", "key", "newKey") {
       (pos, ev, o: Val.Obj, key: String, newKey: String) =>
         val bindings: Array[(String, Val.Obj.Member)] = for {
@@ -17,16 +21,9 @@ object ExtFunctionNamespaceTest extends TestSuite with FunctionBuilder {
         Val.Obj.mk(pos, bindings)
     })
 
-  private val ext = Val.Obj.mk(
-    null,
-    extFunctions.toSeq.map {
-      case (k, v) => (k, new Val.Obj.ConstMember(false, Visibility.Hidden, v))
-    }: _*
-  )
-
   private def variableResolve(name: String): Option[Expr] = {
     if (name == "$ext" || name == "ext") {
-      Some(ext)
+      Some(module)
     } else {
       None
     }

--- a/sjsonnet/test/src/sjsonnet/ValLiteralFunctionTest.scala
+++ b/sjsonnet/test/src/sjsonnet/ValLiteralFunctionTest.scala
@@ -1,6 +1,7 @@
 package sjsonnet
 
 import sjsonnet.Expr.Member.Visibility
+import sjsonnet.functions.FunctionBuilder
 import utest._
 
 object ValLiteralFunctionTest extends TestSuite with FunctionBuilder {


### PR DESCRIPTION
Motivation:
Provide some helper classes.

our current use cases:

```scala
object FunctionRegistry extends FunctionModule {
  override final val name: String = "tb"
  
  override final lazy val module: Val.Obj = moduleFromModules(
    URLFunctions,
    ObjectFunctions,
    JsonPathFunctions)
}
```