### PR TITLE
chore: Fix matching warning when visit slice.

### DIFF
--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -371,7 +371,8 @@ class Evaluator(resolver: CachedResolver,
     def extractParam(e: Option[Expr], default:Int): Int = e match {
       case Some(expr) => visitExpr(expr) match {
         case _:Val.Null => default
-        case v: Val.Num => v.cast[Val.Num].value.toInt
+        case v: Val.Num => v.value.toInt
+        case v: Val => v.cast[Val.Num].value.toInt
       }
       case None => default
     }


### PR DESCRIPTION
Motivation:
Add missing case in https://github.com/databricks/sjsonnet/pull/338

Otherwise it will fails to a MatchError, where it has a parameter type mismatch error message. 

The current spec will not do any implicit conversion anyway.