### PR TITLE
Restore old Evaluator switch, and put the new Evaluator behind a flag

### DIFF
--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -30,64 +30,58 @@ class Evaluator(resolver: CachedResolver,
   var tailstrict: Boolean = false
 
   override def visitExpr(e: Expr)(implicit scope: ValScope): Val = try {
-    (e._tag: @switch) match {
-      case ExprTags.ValidId => visitValidId(e.asInstanceOf[ValidId])
-      case ExprTags.BinaryOp => visitBinaryOp(e.asInstanceOf[BinaryOp])
-      case ExprTags.Select => visitSelect(e.asInstanceOf[Select])
-      case ExprTags.`Val.Func` => e.asInstanceOf[Val.Func]
-      case ExprTags.`Val.Literal` => e.asInstanceOf[Val.Literal]
-      case ExprTags.ApplyBuiltin0 => visitApplyBuiltin0(e.asInstanceOf[ApplyBuiltin0])
-      case ExprTags.ApplyBuiltin1 => visitApplyBuiltin1(e.asInstanceOf[ApplyBuiltin1])
-      case ExprTags.ApplyBuiltin2 => visitApplyBuiltin2(e.asInstanceOf[ApplyBuiltin2])
-      case ExprTags.ApplyBuiltin3 => visitApplyBuiltin3(e.asInstanceOf[ApplyBuiltin3])
-      case ExprTags.ApplyBuiltin4 => visitApplyBuiltin4(e.asInstanceOf[ApplyBuiltin4])
-      case ExprTags.And => visitAnd(e.asInstanceOf[And])
-      case ExprTags.Or => visitOr(e.asInstanceOf[Or])
-      case ExprTags.UnaryOp => visitUnaryOp(e.asInstanceOf[UnaryOp])
-      case ExprTags.Apply1 => visitApply1(e.asInstanceOf[Apply1])
-      case ExprTags.Lookup => visitLookup(e.asInstanceOf[Lookup])
-      case ExprTags.Function =>
-        val f = e.asInstanceOf[Function]
-        visitMethod(f.body, f.params, f.pos)
-      case ExprTags.LocalExpr => visitLocalExpr(e.asInstanceOf[LocalExpr])
-      case ExprTags.Apply => visitApply(e.asInstanceOf[Apply])
-      case ExprTags.IfElse => visitIfElse(e.asInstanceOf[IfElse])
-      case ExprTags.Apply3 => visitApply3(e.asInstanceOf[Apply3])
-      case ExprTags.`ObjBody.MemberList` =>
-        val oml = e.asInstanceOf[ObjBody.MemberList]
-        visitMemberList(oml.pos, oml, null)
-      case ExprTags.Apply2 => visitApply2(e.asInstanceOf[Apply2])
-      case ExprTags.AssertExpr => visitAssert(e.asInstanceOf[AssertExpr])
-      case ExprTags.ApplyBuiltin => visitApplyBuiltin(e.asInstanceOf[ApplyBuiltin])
-      case ExprTags.Comp => visitComp(e.asInstanceOf[Comp])
-      case ExprTags.Arr => visitArr(e.asInstanceOf[Arr])
-      case ExprTags.SelectSuper => visitSelectSuper(e.asInstanceOf[SelectSuper])
-      case ExprTags.LookupSuper => visitLookupSuper(e.asInstanceOf[LookupSuper])
-      case ExprTags.InSuper => visitInSuper(e.asInstanceOf[InSuper])
-      case ExprTags.ObjExtend => visitObjExtend(e.asInstanceOf[ObjExtend])
-      case ExprTags.`ObjBody.ObjComp` => visitObjComp(e.asInstanceOf[ObjBody.ObjComp], null)
-      case ExprTags.Slice => visitSlice(e.asInstanceOf[Slice])
-      case ExprTags.Import => visitImport(e.asInstanceOf[Import])
-      case ExprTags.Apply0 => visitApply0(e.asInstanceOf[Apply0])
-      case ExprTags.ImportStr => visitImportStr(e.asInstanceOf[ImportStr])
-      case ExprTags.ImportBin => visitImportBin(e.asInstanceOf[ImportBin])
-      case ExprTags.Error => visitError(e.asInstanceOf[Expr.Error])
-      case _ => visitInvalid(e)
+    e match {
+      case e: ValidId => visitValidId(e)
+      case e: BinaryOp => visitBinaryOp(e)
+      case e: Select => visitSelect(e)
+      case e: Val => e
+      case e: ApplyBuiltin0 => visitApplyBuiltin0(e)
+      case e: ApplyBuiltin1 => visitApplyBuiltin1(e)
+      case e: ApplyBuiltin2 => visitApplyBuiltin2(e)
+      case e: ApplyBuiltin3 => visitApplyBuiltin3(e)
+      case e: ApplyBuiltin4 => visitApplyBuiltin4(e)
+      case e: And => visitAnd(e)
+      case e: Or => visitOr(e)
+      case e: UnaryOp => visitUnaryOp(e)
+      case e: Apply1 => visitApply1(e)
+      case e: Lookup => visitLookup(e)
+      case e: Function => visitMethod(e.body, e.params, e.pos)
+      case e: LocalExpr => visitLocalExpr(e)
+      case e: Apply => visitApply(e)
+      case e: IfElse => visitIfElse(e)
+      case e: Apply3 => visitApply3(e)
+      case e: ObjBody.MemberList => visitMemberList(e.pos, e, null)
+      case e: Apply2 => visitApply2(e)
+      case e: AssertExpr => visitAssert(e)
+      case e: ApplyBuiltin => visitApplyBuiltin(e)
+      case e: Comp => visitComp(e)
+      case e: Arr => visitArr(e)
+      case e: SelectSuper => visitSelectSuper(e)
+      case e: LookupSuper => visitLookupSuper(e)
+      case e: InSuper => visitInSuper(e)
+      case e: ObjExtend => visitObjExtend(e)
+      case e: ObjBody.ObjComp => visitObjComp(e, null)
+      case e: Slice => visitSlice(e)
+      case e: Import => visitImport(e)
+      case e: Apply0 => visitApply0(e)
+      case e: ImportStr => visitImportStr(e)
+      case e: ImportBin => visitImportBin(e)
+      case e: Expr.Error => visitError(e)
+      case e => visitInvalid(e)
     }
   } catch {
     Error.withStackFrame(e)
   }
   // This is only needed for --no-static-errors, otherwise these expression types do not make it past the optimizer
-  private def visitInvalid(e: Expr): Nothing = (e._tag : @switch) match {
-    case ExprTags.Id =>
-      val id = e.asInstanceOf[Id]
-      Error.fail("Unknown variable: " + id.name, id.pos)
-    case ExprTags.Self =>
-      Error.fail("Can't use self outside of an object", e.pos)
-    case ExprTags.`$` =>
-      Error.fail("Can't use $ outside of an object", e.pos)
-    case ExprTags.Super =>
-      Error.fail("Can't use super outside of an object", e.pos)
+  def visitInvalid(e: Expr): Nothing = e match {
+    case Id(pos, name) =>
+      Error.fail("Unknown variable: " + name, pos)
+    case Self(pos) =>
+      Error.fail("Can't use self outside of an object", pos)
+    case $(pos) =>
+      Error.fail("Can't use $ outside of an object", pos)
+    case Super(pos) =>
+      Error.fail("Can't use super outside of an object", pos)
   }
 
   def visitAsLazy(e: Expr)(implicit scope: ValScope): Lazy = e match {
@@ -162,7 +156,7 @@ class Evaluator(resolver: CachedResolver,
     Error.fail(materializeError(visitExpr(e.value)), e.pos)
   }
 
-  private def materializeError(value: Val) = value match {
+  protected def materializeError(value: Val) = value match {
     case Val.Str(_, s) => s
     case r => Materializer.stringify(r)
   }
@@ -193,7 +187,7 @@ class Evaluator(resolver: CachedResolver,
     }
   }
 
-  private def visitApply(e: Apply)(implicit scope: ValScope) = {
+  protected def visitApply(e: Apply)(implicit scope: ValScope) = {
     val lhs = visitExpr(e.value)
 
     if (tailstrict) {
@@ -215,7 +209,7 @@ class Evaluator(resolver: CachedResolver,
     }
   }
 
-  private def visitApply0(e: Apply0)(implicit scope: ValScope): Val = {
+  protected def visitApply0(e: Apply0)(implicit scope: ValScope): Val = {
     val lhs = visitExpr(e.value)
     if (e.tailstrict) {
       tailstrict = true
@@ -227,7 +221,7 @@ class Evaluator(resolver: CachedResolver,
     }
   }
 
-  private def visitApply1(e: Apply1)(implicit scope: ValScope): Val = {
+  protected def visitApply1(e: Apply1)(implicit scope: ValScope): Val = {
     val lhs = visitExpr(e.value)
     if (tailstrict) {
       lhs.cast[Val.Func].apply1(visitExpr(e.a1), e.pos)
@@ -242,7 +236,7 @@ class Evaluator(resolver: CachedResolver,
     }
   }
 
-  private def visitApply2(e: Apply2)(implicit scope: ValScope): Val = {
+  protected def visitApply2(e: Apply2)(implicit scope: ValScope): Val = {
     val lhs = visitExpr(e.value)
     if (tailstrict) {
       lhs.cast[Val.Func].apply2(visitExpr(e.a1), visitExpr(e.a2), e.pos)
@@ -258,7 +252,7 @@ class Evaluator(resolver: CachedResolver,
     }
   }
 
-  private def visitApply3(e: Apply3)(implicit scope: ValScope): Val = {
+  protected def visitApply3(e: Apply3)(implicit scope: ValScope): Val = {
     val lhs = visitExpr(e.value)
     if (tailstrict) {
       lhs.cast[Val.Func].apply3(visitExpr(e.a1), visitExpr(e.a2), visitExpr(e.a3), e.pos)
@@ -275,7 +269,7 @@ class Evaluator(resolver: CachedResolver,
     }
   }
 
-  private def visitApplyBuiltin0(e: ApplyBuiltin0)(implicit scope: ValScope) = {
+  protected def visitApplyBuiltin0(e: ApplyBuiltin0)(implicit scope: ValScope) = {
     if (tailstrict) {
       e.func.evalRhs(this, e.pos)
     } else if (e.tailstrict) {
@@ -288,7 +282,7 @@ class Evaluator(resolver: CachedResolver,
     }
   }
 
-  private def visitApplyBuiltin1(e: ApplyBuiltin1)(implicit scope: ValScope) = {
+  protected def visitApplyBuiltin1(e: ApplyBuiltin1)(implicit scope: ValScope) = {
     if (tailstrict) {
       e.func.evalRhs(visitExpr(e.a1), this, e.pos)
     } else if (e.tailstrict) {
@@ -301,7 +295,7 @@ class Evaluator(resolver: CachedResolver,
     }
   }
 
-  private def visitApplyBuiltin2(e: ApplyBuiltin2)(implicit scope: ValScope) = {
+  protected def visitApplyBuiltin2(e: ApplyBuiltin2)(implicit scope: ValScope) = {
     if (tailstrict) {
       e.func.evalRhs(visitExpr(e.a1), visitExpr(e.a2), this, e.pos)
     } else if (e.tailstrict) {
@@ -314,7 +308,7 @@ class Evaluator(resolver: CachedResolver,
     }
   }
 
-  private def visitApplyBuiltin3(e: ApplyBuiltin3)(implicit scope: ValScope) = {
+  protected def visitApplyBuiltin3(e: ApplyBuiltin3)(implicit scope: ValScope) = {
     if (tailstrict) {
       e.func.evalRhs(visitExpr(e.a1), visitExpr(e.a2), visitExpr(e.a3), this, e.pos)
     } else if (e.tailstrict) {
@@ -327,7 +321,7 @@ class Evaluator(resolver: CachedResolver,
     }
   }
 
-  private def visitApplyBuiltin4(e: ApplyBuiltin4)(implicit scope: ValScope) = {
+  protected def visitApplyBuiltin4(e: ApplyBuiltin4)(implicit scope: ValScope) = {
     if (tailstrict) {
       e.func.evalRhs(visitExpr(e.a1), visitExpr(e.a2), visitExpr(e.a3), visitExpr(e.a4), this, e.pos)
     } else if (e.tailstrict) {
@@ -340,7 +334,7 @@ class Evaluator(resolver: CachedResolver,
     }
   }
 
-  private def visitApplyBuiltin(e: ApplyBuiltin)(implicit scope: ValScope) = {
+  protected def visitApplyBuiltin(e: ApplyBuiltin)(implicit scope: ValScope) = {
     val arr = new Array[Lazy](e.argExprs.length)
     var idx = 0
 
@@ -381,7 +375,7 @@ class Evaluator(resolver: CachedResolver,
     visitExpr(e.returned)
   }
 
-  private def visitSlice(e: Slice)(implicit scope: ValScope): Val = {
+  protected def visitSlice(e: Slice)(implicit scope: ValScope): Val = {
     def extractParam(e: Option[Expr], default:Int): Int = e match {
       case Some(expr) => visitExpr(expr) match {
         case _:Val.Null => default
@@ -803,7 +797,7 @@ class Evaluator(resolver: CachedResolver,
   }
 
   @tailrec
-  private final def visitComp(f: List[CompSpec], scopes: Array[ValScope]): Array[ValScope] = f match{
+  final def visitComp(f: List[CompSpec], scopes: Array[ValScope]): Array[ValScope] = f match{
     case (spec @ ForSpec(_, name, expr)) :: rest =>
       visitComp(
         rest,
@@ -893,6 +887,75 @@ class Evaluator(resolver: CachedResolver,
     }
     case _ => false
   })
+}
+
+class NewEvaluator(
+  resolver: CachedResolver,
+  extVars: String => Option[Expr],
+  wd: Path,
+  settings: Settings,
+  warnLogger: Error => Unit = null) extends Evaluator(resolver, extVars, wd, settings, warnLogger) {
+
+  override def visitExpr(e: Expr)(implicit scope: ValScope): Val = try {
+    (e._tag: @switch) match {
+      case ExprTags.ValidId => visitValidId(e.asInstanceOf[ValidId])
+      case ExprTags.BinaryOp => visitBinaryOp(e.asInstanceOf[BinaryOp])
+      case ExprTags.Select => visitSelect(e.asInstanceOf[Select])
+      case ExprTags.`Val.Func` => e.asInstanceOf[Val.Func]
+      case ExprTags.`Val.Literal` => e.asInstanceOf[Val.Literal]
+      case ExprTags.ApplyBuiltin0 => visitApplyBuiltin0(e.asInstanceOf[ApplyBuiltin0])
+      case ExprTags.ApplyBuiltin1 => visitApplyBuiltin1(e.asInstanceOf[ApplyBuiltin1])
+      case ExprTags.ApplyBuiltin2 => visitApplyBuiltin2(e.asInstanceOf[ApplyBuiltin2])
+      case ExprTags.ApplyBuiltin3 => visitApplyBuiltin3(e.asInstanceOf[ApplyBuiltin3])
+      case ExprTags.ApplyBuiltin4 => visitApplyBuiltin4(e.asInstanceOf[ApplyBuiltin4])
+      case ExprTags.And => visitAnd(e.asInstanceOf[And])
+      case ExprTags.Or => visitOr(e.asInstanceOf[Or])
+      case ExprTags.UnaryOp => visitUnaryOp(e.asInstanceOf[UnaryOp])
+      case ExprTags.Apply1 => visitApply1(e.asInstanceOf[Apply1])
+      case ExprTags.Lookup => visitLookup(e.asInstanceOf[Lookup])
+      case ExprTags.Function =>
+        val f = e.asInstanceOf[Function]
+        visitMethod(f.body, f.params, f.pos)
+      case ExprTags.LocalExpr => visitLocalExpr(e.asInstanceOf[LocalExpr])
+      case ExprTags.Apply => visitApply(e.asInstanceOf[Apply])
+      case ExprTags.IfElse => visitIfElse(e.asInstanceOf[IfElse])
+      case ExprTags.Apply3 => visitApply3(e.asInstanceOf[Apply3])
+      case ExprTags.`ObjBody.MemberList` =>
+        val oml = e.asInstanceOf[ObjBody.MemberList]
+        visitMemberList(oml.pos, oml, null)
+      case ExprTags.Apply2 => visitApply2(e.asInstanceOf[Apply2])
+      case ExprTags.AssertExpr => visitAssert(e.asInstanceOf[AssertExpr])
+      case ExprTags.ApplyBuiltin => visitApplyBuiltin(e.asInstanceOf[ApplyBuiltin])
+      case ExprTags.Comp => visitComp(e.asInstanceOf[Comp])
+      case ExprTags.Arr => visitArr(e.asInstanceOf[Arr])
+      case ExprTags.SelectSuper => visitSelectSuper(e.asInstanceOf[SelectSuper])
+      case ExprTags.LookupSuper => visitLookupSuper(e.asInstanceOf[LookupSuper])
+      case ExprTags.InSuper => visitInSuper(e.asInstanceOf[InSuper])
+      case ExprTags.ObjExtend => visitObjExtend(e.asInstanceOf[ObjExtend])
+      case ExprTags.`ObjBody.ObjComp` => visitObjComp(e.asInstanceOf[ObjBody.ObjComp], null)
+      case ExprTags.Slice => visitSlice(e.asInstanceOf[Slice])
+      case ExprTags.Import => visitImport(e.asInstanceOf[Import])
+      case ExprTags.Apply0 => visitApply0(e.asInstanceOf[Apply0])
+      case ExprTags.ImportStr => visitImportStr(e.asInstanceOf[ImportStr])
+      case ExprTags.ImportBin => visitImportBin(e.asInstanceOf[ImportBin])
+      case ExprTags.Error => visitError(e.asInstanceOf[Expr.Error])
+      case _ => visitInvalid(e)
+    }
+  } catch {
+    Error.withStackFrame(e)
+  }
+  // This is only needed for --no-static-errors, otherwise these expression types do not make it past the optimizer
+  override def visitInvalid(e: Expr): Nothing = (e._tag : @switch) match {
+    case ExprTags.Id =>
+      val id = e.asInstanceOf[Id]
+      Error.fail("Unknown variable: " + id.name, id.pos)
+    case ExprTags.Self =>
+      Error.fail("Can't use self outside of an object", e.pos)
+    case ExprTags.`$` =>
+      Error.fail("Can't use $ outside of an object", e.pos)
+    case ExprTags.Super =>
+      Error.fail("Can't use super outside of an object", e.pos)
+  }
 }
 
 object Evaluator {

--- a/sjsonnet/src/sjsonnet/Interpreter.scala
+++ b/sjsonnet/src/sjsonnet/Interpreter.scala
@@ -69,7 +69,9 @@ class Interpreter(queryExtVar: String => Option[ExternalVariable[_]],
   private def warn(e: Error): Unit = warnLogger("[warning] " + formatError(e))
 
   def createEvaluator(resolver: CachedResolver, extVars: String => Option[Expr], wd: Path,
-                      settings: Settings, warn: Error => Unit): Evaluator =
+                      settings: Settings, warn: Error => Unit): Evaluator = if (settings.useNewEvaluator)
+    new NewEvaluator(resolver, extVars, wd, settings, warn)
+  else
     new Evaluator(resolver, extVars, wd, settings, warn)
 
   /**

--- a/sjsonnet/src/sjsonnet/Settings.scala
+++ b/sjsonnet/src/sjsonnet/Settings.scala
@@ -11,6 +11,7 @@ class Settings(
   val strictInheritedAssertions: Boolean = false,
   val strictSetOperations: Boolean = false,
   val throwErrorForInvalidSets: Boolean = false,
+  val useNewEvaluator: Boolean = false,
 )
 
 object Settings {

--- a/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
+++ b/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
@@ -3,135 +3,133 @@ package sjsonnet
 import utest._
 import TestUtils.{eval, evalErr}
 object EvaluatorTests extends TestSuite{
-
-
-  def tests: Tests = Tests{
+  def allTests(useNewEvaluator: Boolean): Tests = Tests {
     test("arithmetic") {
-      eval("1 + 2 + 3") ==> ujson.Num(6)
-      eval("1 + 2 * 3") ==> ujson.Num(7)
-      eval("-1 + 2 * 3") ==> ujson.Num(5)
-      eval("6 - 3 + 2") ==> ujson.Num(5)
+      eval("1 + 2 + 3", useNewEvaluator = useNewEvaluator) ==> ujson.Num(6)
+      eval("1 + 2 * 3", useNewEvaluator = useNewEvaluator) ==> ujson.Num(7)
+      eval("-1 + 2 * 3", useNewEvaluator = useNewEvaluator) ==> ujson.Num(5)
+      eval("6 - 3 + 2", useNewEvaluator = useNewEvaluator) ==> ujson.Num(5)
     }
     test("objects") {
-      eval("{x: 1}.x") ==> ujson.Num(1)
+      eval("{x: 1}.x", useNewEvaluator = useNewEvaluator) ==> ujson.Num(1)
     }
     test("arrays") {
-      eval("[1, [2, 3], 4][1][0]") ==> ujson.Num(2)
-      eval("([1, 2, 3] + [4, 5, 6])[3]") ==> ujson.Num(4)
-      evalErr("[][0]") ==>
+      eval("[1, [2, 3], 4][1][0]", useNewEvaluator = useNewEvaluator) ==> ujson.Num(2)
+      eval("([1, 2, 3] + [4, 5, 6])[3]", useNewEvaluator = useNewEvaluator) ==> ujson.Num(4)
+      evalErr("[][0]", useNewEvaluator = useNewEvaluator) ==>
       """sjsonnet.Error: array bounds error: array is empty
         |at [Lookup].(:1:3)""".stripMargin
-      eval("std.slice(std.range(1,4), 0, null, 2)") ==> ujson.Arr(1, 3)
-      eval("std.slice(std.range(1,4), null, null, 2)") ==> ujson.Arr(1, 3)
-      eval("std.slice(std.range(1,4), null, null, null)") ==> ujson.Arr(1, 2, 3, 4)
-      eval("std.range(1,4)[0::2]") ==> ujson.Arr(1, 3)
-      eval("std.range(1,4)[0:null:2]") ==> ujson.Arr(1, 3)
-      eval("std.range(1,4)[null:null:2]") ==> ujson.Arr(1, 3)
-      eval("std.range(1,4)[null:null:null]") ==> ujson.Arr(1, 2, 3, 4)
-      eval("std.range(1,4)[::2]") ==> ujson.Arr(1, 3)
+      eval("std.slice(std.range(1,4), 0, null, 2)", useNewEvaluator = useNewEvaluator) ==> ujson.Arr(1, 3)
+      eval("std.slice(std.range(1,4), null, null, 2)", useNewEvaluator = useNewEvaluator) ==> ujson.Arr(1, 3)
+      eval("std.slice(std.range(1,4), null, null, null)", useNewEvaluator = useNewEvaluator) ==> ujson.Arr(1, 2, 3, 4)
+      eval("std.range(1,4)[0::2]", useNewEvaluator = useNewEvaluator) ==> ujson.Arr(1, 3)
+      eval("std.range(1,4)[0:null:2]", useNewEvaluator = useNewEvaluator) ==> ujson.Arr(1, 3)
+      eval("std.range(1,4)[null:null:2]", useNewEvaluator = useNewEvaluator) ==> ujson.Arr(1, 3)
+      eval("std.range(1,4)[null:null:null]", useNewEvaluator = useNewEvaluator) ==> ujson.Arr(1, 2, 3, 4)
+      eval("std.range(1,4)[::2]", useNewEvaluator = useNewEvaluator) ==> ujson.Arr(1, 3)
     }
     test("functions") {
-      eval("(function(x) x)(1)") ==> ujson.Num(1)
-      eval("function() 1") ==> ujson.Num(1)
-      eval("function(a=1) a") ==> ujson.Num(1)
-      eval("(function(x, y = x + 1) y)(x = 10)") ==> ujson.Num(11)
-      eval("local f(x) = function() true; f(42)") ==> ujson.True
-      eval("local f(x) = function() true; f(42) == true") ==> ujson.False
-      eval("local f(x) = function() true; f(42)() == true") ==> ujson.True
-      assert(evalErr("{foo: function() true}").startsWith("sjsonnet.Error: Couldn't manifest function with params"))
-      eval("{foo: (function() true)()}") ==> ujson.Obj{"foo" -> ujson.True}
+      eval("(function(x) x)(1)", useNewEvaluator = useNewEvaluator) ==> ujson.Num(1)
+      eval("function() 1", useNewEvaluator = useNewEvaluator) ==> ujson.Num(1)
+      eval("function(a=1) a", useNewEvaluator = useNewEvaluator) ==> ujson.Num(1)
+      eval("(function(x, y = x + 1) y)(x = 10)", useNewEvaluator = useNewEvaluator) ==> ujson.Num(11)
+      eval("local f(x) = function() true; f(42)", useNewEvaluator = useNewEvaluator) ==> ujson.True
+      eval("local f(x) = function() true; f(42) == true", useNewEvaluator = useNewEvaluator) ==> ujson.False
+      eval("local f(x) = function() true; f(42)() == true", useNewEvaluator = useNewEvaluator) ==> ujson.True
+      assert(evalErr("{foo: function() true}", useNewEvaluator = useNewEvaluator).startsWith("sjsonnet.Error: Couldn't manifest function with params"))
+      eval("{foo: (function() true)()}", useNewEvaluator = useNewEvaluator) ==> ujson.Obj{"foo" -> ujson.True}
     }
     test("members") {
-      eval("{local x = 1, x: x}['x']") ==> ujson.Num(1)
-      eval("{local x(y) = y + '1', x: x('2')}['x']") ==> ujson.Str("21")
-      eval("{local x(y) = y + '1', x: x(y='2')}['x']") ==> ujson.Str("21")
-      eval("{local x(y='2') = y + '1', x: x()}['x']") ==> ujson.Str("21")
-      eval("""{[{local x = $.y + "lol", y: x, z: "1"}.z]: 2}["1"]""") ==> ujson.Num(2)
-      eval("{local x = 1, y: { z: x }}.y.z") ==> ujson.Num(1)
+      eval("{local x = 1, x: x}['x']", useNewEvaluator = useNewEvaluator) ==> ujson.Num(1)
+      eval("{local x(y) = y + '1', x: x('2')}['x']", useNewEvaluator = useNewEvaluator) ==> ujson.Str("21")
+      eval("{local x(y) = y + '1', x: x(y='2')}['x']", useNewEvaluator = useNewEvaluator) ==> ujson.Str("21")
+      eval("{local x(y='2') = y + '1', x: x()}['x']", useNewEvaluator = useNewEvaluator) ==> ujson.Str("21")
+      eval("""{[{local x = $.y + "lol", y: x, z: "1"}.z]: 2}["1"]""", useNewEvaluator = useNewEvaluator) ==> ujson.Num(2)
+      eval("{local x = 1, y: { z: x }}.y.z", useNewEvaluator = useNewEvaluator) ==> ujson.Num(1)
     }
     test("extends") {
-      eval("(function(a) a.x + a.y)({x: 1}{y: 2})") ==> ujson.Num(3)
-      eval("(function(a) a.x + a.y)({x: 1}{x: 2, y: 3})") ==> ujson.Num(5)
-      eval("({x: 1}{x+: 2}).x") ==> ujson.Num(3)
-      eval("({x+: 1}{x: 2}).x") ==> ujson.Num(2)
-      eval("({x+: 1}{x+: 2}).x") ==> ujson.Num(3)
-      eval("({x+: 1} + {x+: 2}).x") ==> ujson.Num(3)
-      eval("(function(a, b) a + b)({x+: 1}, {x+: 2}).x") ==> ujson.Num(3)
-      eval("""({a: [1]} + {a+: "1"}).a""") ==> ujson.Str("[1]1")
-      eval("""({a: 1} + {a+: "1"}).a""") ==> ujson.Str("11")
-      eval("""({a: "1"} + {a+: 1}).a""") ==> ujson.Str("11")
+      eval("(function(a) a.x + a.y)({x: 1}{y: 2})", useNewEvaluator = useNewEvaluator) ==> ujson.Num(3)
+      eval("(function(a) a.x + a.y)({x: 1}{x: 2, y: 3})", useNewEvaluator = useNewEvaluator) ==> ujson.Num(5)
+      eval("({x: 1}{x+: 2}).x", useNewEvaluator = useNewEvaluator) ==> ujson.Num(3)
+      eval("({x+: 1}{x: 2}).x", useNewEvaluator = useNewEvaluator) ==> ujson.Num(2)
+      eval("({x+: 1}{x+: 2}).x", useNewEvaluator = useNewEvaluator) ==> ujson.Num(3)
+      eval("({x+: 1} + {x+: 2}).x", useNewEvaluator = useNewEvaluator) ==> ujson.Num(3)
+      eval("(function(a, b) a + b)({x+: 1}, {x+: 2}).x", useNewEvaluator = useNewEvaluator) ==> ujson.Num(3)
+      eval("""({a: [1]} + {a+: "1"}).a""", useNewEvaluator = useNewEvaluator) ==> ujson.Str("[1]1")
+      eval("""({a: 1} + {a+: "1"}).a""", useNewEvaluator = useNewEvaluator) ==> ujson.Str("11")
+      eval("""({a: "1"} + {a+: 1}).a""", useNewEvaluator = useNewEvaluator) ==> ujson.Str("11")
     }
     test("ifElse") {
-      eval("if true then 1 else 0") ==> ujson.Num(1)
-      eval("if 2 > 1 then 1 else 0") ==> ujson.Num(1)
-      eval("if false then 1 else 0") ==> ujson.Num(0)
-      eval("if 1 > 2 then 1 else 0") ==> ujson.Num(0)
+      eval("if true then 1 else 0", useNewEvaluator = useNewEvaluator) ==> ujson.Num(1)
+      eval("if 2 > 1 then 1 else 0", useNewEvaluator = useNewEvaluator) ==> ujson.Num(1)
+      eval("if false then 1 else 0", useNewEvaluator = useNewEvaluator) ==> ujson.Num(0)
+      eval("if 1 > 2 then 1 else 0", useNewEvaluator = useNewEvaluator) ==> ujson.Num(0)
     }
     test("self") {
-      eval("{x: 1, y: $.x + 10}.y") ==> ujson.Num(11)
-      eval("{x: 1, y: self.x}.y") ==> ujson.Num(1)
-      eval("{x: 1, y: {x: 2, z: $.x + 10}}.y.z") ==> ujson.Num(11)
-      eval("{x: 1, y: {x: 2, z: self.x + 10}}.y.z") ==> ujson.Num(12)
-      eval("{x: 1, y: {x: 0, y: self.x}.y}.y") ==> ujson.Num(0)
-      eval("""{x: 1, y: "x" in self}.y""") ==> ujson.True
-      eval("""{x: 1, y: "z" in self}.y""") ==> ujson.False
-      eval("""{y: "y" in self}.y""") ==> ujson.True
+      eval("{x: 1, y: $.x + 10}.y", useNewEvaluator = useNewEvaluator) ==> ujson.Num(11)
+      eval("{x: 1, y: self.x}.y", useNewEvaluator = useNewEvaluator) ==> ujson.Num(1)
+      eval("{x: 1, y: {x: 2, z: $.x + 10}}.y.z", useNewEvaluator = useNewEvaluator) ==> ujson.Num(11)
+      eval("{x: 1, y: {x: 2, z: self.x + 10}}.y.z", useNewEvaluator = useNewEvaluator) ==> ujson.Num(12)
+      eval("{x: 1, y: {x: 0, y: self.x}.y}.y", useNewEvaluator = useNewEvaluator) ==> ujson.Num(0)
+      eval("""{x: 1, y: "x" in self}.y""", useNewEvaluator = useNewEvaluator) ==> ujson.True
+      eval("""{x: 1, y: "z" in self}.y""", useNewEvaluator = useNewEvaluator) ==> ujson.False
+      eval("""{y: "y" in self}.y""", useNewEvaluator = useNewEvaluator) ==> ujson.True
     }
     test("topLevel") {
-      eval("local p(n='A') = {w: 'H'+n}; {p: p()}.p.w") ==> ujson.Str("HA")
+      eval("local p(n='A') = {w: 'H'+n}; {p: p()}.p.w", useNewEvaluator = useNewEvaluator) ==> ujson.Str("HA")
     }
     test("lazy") {
-      eval("[{x: $.y, y: $.x}.x, 2][1]") ==> ujson.Num(2)
-      eval("{x: $.y, y: $.x, local z(z0) = [3], w: z($.x)}.w[0]") ==> ujson.Num(3)
-      eval("(function(a=[1, b[1]], b=[a[0], 2]) [a, b])()[0][1]") ==> ujson.Num(2)
+      eval("[{x: $.y, y: $.x}.x, 2][1]", useNewEvaluator = useNewEvaluator) ==> ujson.Num(2)
+      eval("{x: $.y, y: $.x, local z(z0) = [3], w: z($.x)}.w[0]", useNewEvaluator = useNewEvaluator) ==> ujson.Num(3)
+      eval("(function(a=[1, b[1]], b=[a[0], 2]) [a, b])()[0][1]", useNewEvaluator = useNewEvaluator) ==> ujson.Num(2)
     }
     test("comprehensions") {
-      eval("[x + 1 for x in [1, 2, 3]][2]") ==> ujson.Num(4)
-      eval("[x + 1, for x in [1, 2, 3]][2]") ==> ujson.Num(4)
-      eval("[x + y for x in [1, 2, 3] for y in [4, 5, 6] if x + y != 7][3]") ==> ujson.Num(8)
-      eval("""{[""+x]: x * x for x in [1, 2, 3]}["3"]""") ==> ujson.Num(9)
-      eval("""{local y = $["2"], [x]: if x == "1" then y else 0, for x in ["1", "2"]}["1"]""") ==> ujson.Num(0)
+      eval("[x + 1 for x in [1, 2, 3]][2]", useNewEvaluator = useNewEvaluator) ==> ujson.Num(4)
+      eval("[x + 1, for x in [1, 2, 3]][2]", useNewEvaluator = useNewEvaluator) ==> ujson.Num(4)
+      eval("[x + y for x in [1, 2, 3] for y in [4, 5, 6] if x + y != 7][3]", useNewEvaluator = useNewEvaluator) ==> ujson.Num(8)
+      eval("""{[""+x]: x * x for x in [1, 2, 3]}["3"]""", useNewEvaluator = useNewEvaluator) ==> ujson.Num(9)
+      eval("""{local y = $["2"], [x]: if x == "1" then y else 0, for x in ["1", "2"]}["1"]""", useNewEvaluator = useNewEvaluator) ==> ujson.Num(0)
     }
     test("super") {
       test("implicit") {
 
-        eval("({ x: 1, y: self.x } + { x: 2 }).y") ==> ujson.Num(2)
-        eval("({ local x = $.y, y: 1, z: x} + { y: 2 }).z") ==> ujson.Num(2)
-        eval("({ local x = self.y, y: 1, z: x} + { y: 2 }).z") ==> ujson.Num(2)
-        eval("local A = {x: 1, local outer = self, y: A{z: outer}}; A.y.z.x") ==> ujson.Num(1)
-        eval("{local x = self, y: 1, z: {a: x, y: 2}}.z.a.y") ==> ujson.Num(1)
-        eval("local A = {x: 1, local outer = self, y: A{x: outer.x}}; A.y.x") ==> ujson.Num(1)
-        eval("local A = {x: 1, local outer = self, y: A{x: outer.x + 1}}; A.y.y.x") ==> ujson.Num(3)
-        eval("""("a" in ({a: 1}{b: 2}))""") ==> ujson.True
+        eval("({ x: 1, y: self.x } + { x: 2 }).y", useNewEvaluator = useNewEvaluator) ==> ujson.Num(2)
+        eval("({ local x = $.y, y: 1, z: x} + { y: 2 }).z", useNewEvaluator = useNewEvaluator) ==> ujson.Num(2)
+        eval("({ local x = self.y, y: 1, z: x} + { y: 2 }).z", useNewEvaluator = useNewEvaluator) ==> ujson.Num(2)
+        eval("local A = {x: 1, local outer = self, y: A{z: outer}}; A.y.z.x", useNewEvaluator = useNewEvaluator) ==> ujson.Num(1)
+        eval("{local x = self, y: 1, z: {a: x, y: 2}}.z.a.y", useNewEvaluator = useNewEvaluator) ==> ujson.Num(1)
+        eval("local A = {x: 1, local outer = self, y: A{x: outer.x}}; A.y.x", useNewEvaluator = useNewEvaluator) ==> ujson.Num(1)
+        eval("local A = {x: 1, local outer = self, y: A{x: outer.x + 1}}; A.y.y.x", useNewEvaluator = useNewEvaluator) ==> ujson.Num(3)
+        eval("""("a" in ({a: 1}{b: 2}))""", useNewEvaluator = useNewEvaluator) ==> ujson.True
       }
       test("explicit") {
 
-        eval("{ x: 1, y: self.x } + { x: 2, y: super.y + 1}") ==>
+        eval("{ x: 1, y: self.x } + { x: 2, y: super.y + 1}", useNewEvaluator = useNewEvaluator) ==>
           ujson.read("""{ "x": 2, "y": 3 }""")
 
-        eval("{ x: 1 } + { x: 2, y: super.x } + { x: 3, z: super.x }") ==>
+        eval("{ x: 1 } + { x: 2, y: super.x } + { x: 3, z: super.x }", useNewEvaluator = useNewEvaluator) ==>
           ujson.read("""{ "x": 3, "y": 1, "z": 2 }""")
 
-        eval("""({a: 1} + {b: 2} + {c: ["a" in super, "b" in super]}).c""") ==>
+        eval("""({a: 1} + {b: 2} + {c: ["a" in super, "b" in super]}).c""", useNewEvaluator = useNewEvaluator) ==>
           ujson.Arr(true, true)
 
-        eval("""{a: ["a" in super, "b" in super]}.a""") ==> ujson.Arr(false, false)
+        eval("""{a: ["a" in super, "b" in super]}.a""", useNewEvaluator = useNewEvaluator) ==> ujson.Arr(false, false)
 
-        eval("""(({a: 1}{b: 2}){c: super.a}).c""") ==> ujson.Num(1)
-        eval("""(({a: 1}{b: 2}){c: super.b}).c""") ==> ujson.Num(2)
+        eval("""(({a: 1}{b: 2}){c: super.a}).c""", useNewEvaluator = useNewEvaluator) ==> ujson.Num(1)
+        eval("""(({a: 1}{b: 2}){c: super.b}).c""", useNewEvaluator = useNewEvaluator) ==> ujson.Num(2)
 
-        eval("""(({a: 1}{b: 2, f: super.a}){c: super.f}).c""") ==> ujson.Num(1)
-        val ex = intercept[Exception]{eval("""(({a: 1}{b: 2, f: super.b}){c: super.f}).c""")}
+        eval("""(({a: 1}{b: 2, f: super.a}){c: super.f}).c""", useNewEvaluator = useNewEvaluator) ==> ujson.Num(1)
+        val ex = intercept[Exception]{eval("""(({a: 1}{b: 2, f: super.b}){c: super.f}).c""", useNewEvaluator = useNewEvaluator)}
         assert(ex.getMessage.contains("Field does not exist: b"))
 
-        eval("""(({a: 1}{b: 2}) + ({c: super.b}{d: super.a})).c""") ==> ujson.Num(2)
-        eval("""(({a: 1}{b: 2}) + ({c: super.b}{d: super.a})).d""") ==> ujson.Num(1)
+        eval("""(({a: 1}{b: 2}) + ({c: super.b}{d: super.a})).c""", useNewEvaluator = useNewEvaluator) ==> ujson.Num(2)
+        eval("""(({a: 1}{b: 2}) + ({c: super.b}{d: super.a})).d""", useNewEvaluator = useNewEvaluator) ==> ujson.Num(1)
 
-        eval("""local x = {a: 1}; local y = {b: super.a}; x + y""") ==> ujson.read("""{"a": 1, "b": 1}""")
+        eval("""local x = {a: 1}; local y = {b: super.a}; x + y""", useNewEvaluator = useNewEvaluator) ==> ujson.read("""{"a": 1, "b": 1}""")
 
-        eval("""local x = { a: 1, b: { c: 2 }}; x { a: super.a * 10, b:: { c: super.b.c * 10 } }""") ==>
+        eval("""local x = { a: 1, b: { c: 2 }}; x { a: super.a * 10, b:: { c: super.b.c * 10 } }""", useNewEvaluator = useNewEvaluator) ==>
           ujson.Obj("a" -> ujson.Num(10))
-        evalErr("""local x = { a: 1, b: { c: 2 }}; x { a: super.a * 10, b:: { c: super.b.c * 10 } }.b""") ==>
+        evalErr("""local x = { a: 1, b: { c: 2 }}; x { a: super.a * 10, b:: { c: super.b.c * 10 } }.b""", useNewEvaluator = useNewEvaluator) ==>
         """sjsonnet.Error: Attempt to use `super` when there is no super class
           |at [SelectSuper b].(:1:68)
           |at [Select c].(:1:70)
@@ -139,71 +137,71 @@ object EvaluatorTests extends TestSuite{
       }
     }
     test("hidden") {
-      eval("{i::1 }") ==>
+      eval("{i::1 }", useNewEvaluator = useNewEvaluator) ==>
         ujson.read("""{}""")
 
-      eval("{i:: 1} + {i: 2}") ==>
+      eval("{i:: 1} + {i: 2}", useNewEvaluator = useNewEvaluator) ==>
         ujson.read("""{}""")
 
-      eval("{i: 1} + {i:: 2}") ==>
+      eval("{i: 1} + {i:: 2}", useNewEvaluator = useNewEvaluator) ==>
         ujson.read("""{}""")
 
-      eval("{i:: 1} + {i:: 2}") ==>
+      eval("{i:: 1} + {i:: 2}", useNewEvaluator = useNewEvaluator) ==>
         ujson.read("""{}""")
 
-      eval("{i:::1} + {i::2}") ==>
+      eval("{i:::1} + {i::2}", useNewEvaluator = useNewEvaluator) ==>
         ujson.read("""{}""")
 
-      eval("{i::1} + {i:::2}") ==>
+      eval("{i::1} + {i:::2}", useNewEvaluator = useNewEvaluator) ==>
         ujson.read("""{"i": 2}""")
 
-      eval("{i:1} + {i:::2}") ==>
+      eval("{i:1} + {i:::2}", useNewEvaluator = useNewEvaluator) ==>
         ujson.read("""{"i": 2}""")
 
-      eval("local M = {x+: self.i, i :: 1}; { x: 1 } + M") ==>
+      eval("local M = {x+: self.i, i :: 1}; { x: 1 } + M", useNewEvaluator = useNewEvaluator) ==>
         ujson.read("""{ "x": 2 }""")
 
-      eval("""("%(hello)s" % {hello::"world"})""") ==> ujson.Str("world")
+      eval("""("%(hello)s" % {hello::"world"})""", useNewEvaluator = useNewEvaluator) ==> ujson.Str("world")
 
-      eval("""("%(hello)s" % {hello::"world", bad:: error "lol"})""") ==> ujson.Str("world")
+      eval("""("%(hello)s" % {hello::"world", bad:: error "lol"})""", useNewEvaluator = useNewEvaluator) ==> ujson.Str("world")
     }
     test("evaluator2") {
-      eval("""{local x = 1, [x]: x, for x in ["foo"]}.foo""") ==> ujson.Num(1)
-      eval("""{[x]: x, local x = 1, for x in ["foo"]}.foo""") ==> ujson.Num(1)
-      eval("""local foo = ["foo"]; {local foo = 1, [x]: x, for x in foo}.foo""") ==> ujson.Str("foo")
-      eval("""local foo = ["foo"]; {[x]: x, local foo = 2, for x in foo}.foo""") ==> ujson.Str("foo")
+      eval("""{local x = 1, [x]: x, for x in ["foo"]}.foo""", useNewEvaluator = useNewEvaluator) ==> ujson.Num(1)
+      eval("""{[x]: x, local x = 1, for x in ["foo"]}.foo""", useNewEvaluator = useNewEvaluator) ==> ujson.Num(1)
+      eval("""local foo = ["foo"]; {local foo = 1, [x]: x, for x in foo}.foo""", useNewEvaluator = useNewEvaluator) ==> ujson.Str("foo")
+      eval("""local foo = ["foo"]; {[x]: x, local foo = 2, for x in foo}.foo""", useNewEvaluator = useNewEvaluator) ==> ujson.Str("foo")
 
-      eval("""{ [x + ""]: if x == 1 then 1 else x + $["1"] for x in [1, 2, 3] }""") ==>
+      eval("""{ [x + ""]: if x == 1 then 1 else x + $["1"] for x in [1, 2, 3] }""", useNewEvaluator = useNewEvaluator) ==>
         ujson.read("""{ "1": 1, "2": 3, "3": 4 }""")
 
-      eval("""local x = "baz"; { local x = "bar", [x]: x for x in ["foo"] }""") ==>
+      eval("""local x = "baz"; { local x = "bar", [x]: x for x in ["foo"] }""", useNewEvaluator = useNewEvaluator) ==>
         ujson.read("""{ "foo": "bar" }""")
 
-      eval("""{ [x + ""]: x + foo, local foo = 3 for x in [1, 2, 3] }""") ==>
+      eval("""{ [x + ""]: x + foo, local foo = 3 for x in [1, 2, 3] }""", useNewEvaluator = useNewEvaluator) ==>
         ujson.read("""{ "1": 4, "2": 5, "3": 6 }""")
-      eval("""{local y = x, ["foo"]: y, for x in ["foo"]}.foo""") ==> ujson.Str("foo")
+      eval("""{local y = x, ["foo"]: y, for x in ["foo"]}.foo""", useNewEvaluator = useNewEvaluator) ==> ujson.Str("foo")
     }
     test("shadowing") {
-      eval("local x = 1; local x = 2; x") ==> ujson.Num(2)
-      eval("local x = 1; x + local x = 2; x") ==> ujson.Num(3)
+      eval("local x = 1; local x = 2; x", useNewEvaluator = useNewEvaluator) ==> ujson.Num(2)
+      eval("local x = 1; x + local x = 2; x", useNewEvaluator = useNewEvaluator) ==> ujson.Num(3)
       eval("""local str1 = |||
-             |        text
-             |    |||;
-             |
-             |local str1 = |||
-             |        \n
-             |    |||;
-             |
-             |(str1 == "\\n\n")
-             |""".stripMargin) ==> ujson.True
+            |        text
+            |    |||;
+            |
+            |local str1 = |||
+            |        \n
+            |    |||;
+            |
+            |(str1 == "\\n\n")
+            |""".stripMargin, useNewEvaluator = useNewEvaluator) ==> ujson.True
     }
     test("stdLib") {
-      eval("std.pow(2, 3)") ==> ujson.Num(8)
-      eval("std.pow(x=2, n=3)") ==> ujson.Num(8)
-      eval("std.pow(n=3, x=2)") ==> ujson.Num(8)
-      eval("({a:: 1} + {a+:::2}).a") ==> ujson.Num(3)
-      eval("(std.prune({a:: 1}) + {a+:::2}).a") ==> ujson.Num(2)
-      eval("std.toString(std.mapWithIndex(function(idx, elem) elem, [2,1,0]))") ==> ujson.Str("[2, 1, 0]")
+      eval("std.pow(2, 3)", useNewEvaluator = useNewEvaluator) ==> ujson.Num(8)
+      eval("std.pow(x=2, n=3)", useNewEvaluator = useNewEvaluator) ==> ujson.Num(8)
+      eval("std.pow(n=3, x=2)", useNewEvaluator = useNewEvaluator) ==> ujson.Num(8)
+      eval("({a:: 1} + {a+:::2}).a", useNewEvaluator = useNewEvaluator) ==> ujson.Num(3)
+      eval("(std.prune({a:: 1}) + {a+:::2}).a", useNewEvaluator = useNewEvaluator) ==> ujson.Num(2)
+      eval("std.toString(std.mapWithIndex(function(idx, elem) elem, [2,1,0]))", useNewEvaluator = useNewEvaluator) ==> ujson.Str("[2, 1, 0]")
     }
     test("unboundParam") {
       val ex = intercept[Exception]{
@@ -217,7 +215,7 @@ object EvaluatorTests extends TestSuite{
             |
             |params.y
             |
-        """.stripMargin
+        """.stripMargin, useNewEvaluator = useNewEvaluator
         )
       }
 
@@ -234,7 +232,7 @@ object EvaluatorTests extends TestSuite{
             |{
             |  person2: Person('Bob', hello=123),
             |}
-        """.stripMargin
+        """.stripMargin, useNewEvaluator = useNewEvaluator
         )
       }
 
@@ -242,16 +240,16 @@ object EvaluatorTests extends TestSuite{
     }
 
     test("unknownVariable") {
-      evalErr("x") ==>
+      evalErr("x", useNewEvaluator = useNewEvaluator) ==>
         """sjsonnet.StaticError: Unknown variable: x
           |at [Id x].(:1:1)""".stripMargin
-      evalErr("self.x") ==>
+      evalErr("self.x", useNewEvaluator = useNewEvaluator) ==>
         """sjsonnet.StaticError: Can't use self outside of an object
           |at [Self].(:1:1)""".stripMargin
-      evalErr("$.x") ==>
+      evalErr("$.x", useNewEvaluator = useNewEvaluator) ==>
         """sjsonnet.StaticError: Can't use $ outside of an object
           |at [$].(:1:1)""".stripMargin
-      evalErr("super.x") ==>
+      evalErr("super.x", useNewEvaluator = useNewEvaluator) ==>
         """sjsonnet.StaticError: Can't use super outside of an object
           |at [Super].(:1:1)""".stripMargin
     }
@@ -265,90 +263,90 @@ object EvaluatorTests extends TestSuite{
             |{
             |  person2: Person(name='Bob'),
             |}.person2.welcome
-        """.stripMargin
+        """.stripMargin, useNewEvaluator = useNewEvaluator
       )
 
       res ==> ujson.Str("Hello Bob!")
     }
 
     test("equalDollar") {
-      eval("local f(x) = x; {hello: 123, world: f(x=$.hello)}") ==>
+      eval("local f(x) = x; {hello: 123, world: f(x=$.hello)}", useNewEvaluator = useNewEvaluator) ==>
         ujson.Obj("hello" -> 123, "world" -> 123)
     }
     test("stdSubstr") {
-      eval("std.substr('cookie', 6, 2)") ==> ujson.Str("")
+      eval("std.substr('cookie', 6, 2)", useNewEvaluator = useNewEvaluator) ==> ujson.Str("")
     }
     test("manifestIni") {
       eval(
         """std.manifestIni({
           |  main: { a: "1", b: 2, c: true, d: null, e: [1, {"2": 2}, [3]], f: {"hello": "world"} },
           |  sections: {}
-          |})""".stripMargin) ==>
+          |})""".stripMargin, useNewEvaluator = useNewEvaluator) ==>
         ujson.Str("a = 1\nb = 2\nc = true\nd = null\ne = 1\ne = {\"2\": 2}\ne = [3]\nf = {\"hello\": \"world\"}\n")
     }
     test("format") {
-      eval("\"%s\" % \"world\"") ==> ujson.Str("world")
-      eval("\"%s\" % [\"world\"]") ==> ujson.Str("world")
-      eval("\"%s %s\" % [\"hello\", \"world\"]") ==> ujson.Str("hello world")
-      eval("\"%(hello)s\" % {hello: \"world\"}") ==> ujson.Str("world")
+      eval("\"%s\" % \"world\"", useNewEvaluator = useNewEvaluator) ==> ujson.Str("world")
+      eval("\"%s\" % [\"world\"]", useNewEvaluator = useNewEvaluator) ==> ujson.Str("world")
+      eval("\"%s %s\" % [\"hello\", \"world\"]", useNewEvaluator = useNewEvaluator) ==> ujson.Str("hello world")
+      eval("\"%(hello)s\" % {hello: \"world\"}", useNewEvaluator = useNewEvaluator) ==> ujson.Str("world")
     }
     test("binaryOps"){
-      val ex = intercept[Exception](eval("1 && 2"))
+      val ex = intercept[Exception](eval("1 && 2", useNewEvaluator = useNewEvaluator))
       assert(ex.getMessage.contains("binary operator && does not operate on numbers."))
 
-      val ex2 = intercept[Exception](eval("1 || 2"))
+      val ex2 = intercept[Exception](eval("1 || 2", useNewEvaluator = useNewEvaluator))
       assert(ex2.getMessage.contains("binary operator || does not operate on numbers."))
     }
     test("stdToString"){
-      eval("""std.toString({k: "v"})""") ==> ujson.Str("""{"k": "v"}""")
+      eval("""std.toString({k: "v"})""", useNewEvaluator = useNewEvaluator) ==> ujson.Str("""{"k": "v"}""")
     }
     test("floatFormatRegression"){
-      eval("'%.4f' % 0.01") ==> ujson.Str("0.0100")
-      eval("'%05d' % 2") ==> ujson.Str("00002")
-      eval("'%000d' % 2") ==> ujson.Str("2")
-      eval("'%000d' % 2.123") ==> ujson.Str("2")
-      eval("'%5d' % 2") ==> ujson.Str("    2")
-      eval("'%5f' % 2") ==> ujson.Str("2.000000")
+      eval("'%.4f' % 0.01", useNewEvaluator = useNewEvaluator) ==> ujson.Str("0.0100")
+      eval("'%05d' % 2", useNewEvaluator = useNewEvaluator) ==> ujson.Str("00002")
+      eval("'%000d' % 2", useNewEvaluator = useNewEvaluator) ==> ujson.Str("2")
+      eval("'%000d' % 2.123", useNewEvaluator = useNewEvaluator) ==> ujson.Str("2")
+      eval("'%5d' % 2", useNewEvaluator = useNewEvaluator) ==> ujson.Str("    2")
+      eval("'%5f' % 2", useNewEvaluator = useNewEvaluator) ==> ujson.Str("2.000000")
 
-      eval("'%10d' % 2.123") ==> ujson.Str("         2")
-      eval("'%+5.5f' % 123.456") ==> ujson.Str("+123.45600")
-      eval("'%+5.5f' % -123.456") ==> ujson.Str("-123.45600")
-      eval("'% 5.5f' % -123.456") ==> ujson.Str("-123.45600")
-      eval("'%--+5.5f' % -123.456") ==> ujson.Str("-123.45600")
-      eval("'%#-0- + 5.5f' % -123.456") ==> ujson.Str("-123.45600")
+      eval("'%10d' % 2.123", useNewEvaluator = useNewEvaluator) ==> ujson.Str("         2")
+      eval("'%+5.5f' % 123.456", useNewEvaluator = useNewEvaluator) ==> ujson.Str("+123.45600")
+      eval("'%+5.5f' % -123.456", useNewEvaluator = useNewEvaluator) ==> ujson.Str("-123.45600")
+      eval("'% 5.5f' % -123.456", useNewEvaluator = useNewEvaluator) ==> ujson.Str("-123.45600")
+      eval("'%--+5.5f' % -123.456", useNewEvaluator = useNewEvaluator) ==> ujson.Str("-123.45600")
+      eval("'%#-0- + 5.5f' % -123.456", useNewEvaluator = useNewEvaluator) ==> ujson.Str("-123.45600")
     }
     test("strict") {
-      eval("({ a: 1 } { b: 2 }).a", strict = false) ==> ujson.Num(1)
-      evalErr("({ a: 1 } { b: 2 }).a", strict = true) ==>
+      eval("({ a: 1 } { b: 2 }).a", strict = false, useNewEvaluator = useNewEvaluator) ==> ujson.Num(1)
+      evalErr("({ a: 1 } { b: 2 }).a", strict = true, useNewEvaluator = useNewEvaluator) ==>
         """sjsonnet.StaticError: Adjacent object literals not allowed in strict mode - Use '+' to concatenate objects
           |at [ObjExtend].(:1:11)""".stripMargin
-      eval("local x = { c: 3 }; (x { a: 1 } { b: 2 }).a", strict = false) ==> ujson.Num(1)
-      eval("local x = { c: 3 }; (x { a: 1 }).a", strict = true) ==> ujson.Num(1)
-      evalErr("local x = { c: 3 }; ({ a: 1 } { b: 2 }).a", strict = true) ==>
+      eval("local x = { c: 3 }; (x { a: 1 } { b: 2 }).a", strict = false, useNewEvaluator = useNewEvaluator) ==> ujson.Num(1)
+      eval("local x = { c: 3 }; (x { a: 1 }).a", strict = true, useNewEvaluator = useNewEvaluator) ==> ujson.Num(1)
+      evalErr("local x = { c: 3 }; ({ a: 1 } { b: 2 }).a", strict = true, useNewEvaluator = useNewEvaluator) ==>
         """sjsonnet.StaticError: Adjacent object literals not allowed in strict mode - Use '+' to concatenate objects
           |at [ObjExtend].(:1:31)""".stripMargin
     }
     test("objectDeclaration") {
-      eval("{ ['foo']: x for x in  []}", false) ==> ujson.Obj()
-      eval("{ ['foo']: x for x in  [1]}", false) ==> ujson.Obj("foo" -> 1)
+      eval("{ ['foo']: x for x in  []}", false, useNewEvaluator = useNewEvaluator) ==> ujson.Obj()
+      eval("{ ['foo']: x for x in  [1]}", false, useNewEvaluator = useNewEvaluator) ==> ujson.Obj("foo" -> 1)
 
-      eval("{ ['foo']+: x for x in  []}", false) ==> ujson.Obj()
-      eval("{ ['foo']+: x for x in  [1]}", false) ==> ujson.Obj("foo" -> 1)
-      eval("{ ['foo']+: [x] for x in [1]} + { ['foo']+: [x] for x in [2]}", false) ==> ujson.Obj("foo" -> ujson.Arr(1,2))
+      eval("{ ['foo']+: x for x in  []}", false, useNewEvaluator = useNewEvaluator) ==> ujson.Obj()
+      eval("{ ['foo']+: x for x in  [1]}", false, useNewEvaluator = useNewEvaluator) ==> ujson.Obj("foo" -> 1)
+      eval("{ ['foo']+: [x] for x in [1]} + { ['foo']+: [x] for x in [2]}", false, useNewEvaluator = useNewEvaluator) ==> ujson.Obj("foo" -> ujson.Arr(1,2))
     }
     test("givenNoDuplicateFieldsInListComprehension1_expectSuccess") {
-      eval("""{ ["bar"]: x for x in [-876.89]}""") ==> ujson.Obj("bar" -> -876.89)
+      eval("""{ ["bar"]: x for x in [-876.89]}""", useNewEvaluator = useNewEvaluator) ==> ujson.Obj("bar" -> -876.89)
     }
     test("givenNoDuplicateFieldsInListComprehension2_expectSuccess") {
-      eval("""{ ["bar_" + x]: x for x in [5,12]}""") ==> ujson.Obj("bar_5" -> 5, "bar_12" -> 12)
+      eval("""{ ["bar_" + x]: x for x in [5,12]}""", useNewEvaluator = useNewEvaluator) ==> ujson.Obj("bar_5" -> 5, "bar_12" -> 12)
     }
     test("givenDuplicateFieldsInListComprehension_expectFailure") {
-      evalErr("""{ [x]: x for x in ["A", "A"]}""", noDuplicateKeysInComprehension = true) ==>
+      evalErr("""{ [x]: x for x in ["A", "A"]}""", noDuplicateKeysInComprehension = true, useNewEvaluator = useNewEvaluator) ==>
         """sjsonnet.Error: Duplicate key A in evaluated object comprehension.
           |at .(:1:3)""".stripMargin
     }
     test("givenDuplicateFieldsInListComprehension_noflag_expectSuccess") {
-      eval("""{ [x]: x for x in ["A", "A"]}""", noDuplicateKeysInComprehension = false) ==>
+      eval("""{ [x]: x for x in ["A", "A"]}""", noDuplicateKeysInComprehension = false, useNewEvaluator = useNewEvaluator) ==>
         ujson.Obj("A" -> "A")
     }
     test("givenDuplicateFieldsInIndirectListComprehension_expectFailure") {
@@ -356,7 +354,7 @@ object EvaluatorTests extends TestSuite{
         """local y = { a: "A" };
           |local z = { a: "A" };
           |{ [x.a]: x for x in [y, z]}""".stripMargin,
-         noDuplicateKeysInComprehension = true
+        noDuplicateKeysInComprehension = true, useNewEvaluator = useNewEvaluator
       ) ==>
         """sjsonnet.Error: Duplicate key A in evaluated object comprehension.
           |at .(:3:3)""".stripMargin
@@ -366,33 +364,33 @@ object EvaluatorTests extends TestSuite{
         """local y = { a: "A" };
           |local z = { a: "A", "b": "B" };
           |{ [x.a]: x for x in [y, z]}""".stripMargin,
-         noDuplicateKeysInComprehension = false
+        noDuplicateKeysInComprehension = false, useNewEvaluator = useNewEvaluator
       ) ==>
         ujson.Obj("A" -> ujson.Obj("a" -> "A", "b" -> "B"))
     }
     test("functionEqualsNull") {
-      eval("""local f(x)=null; f == null""") ==> ujson.False
-      eval("""local f=null; f == null""") ==> ujson.True
+      eval("""local f(x)=null; f == null""", useNewEvaluator = useNewEvaluator) ==> ujson.False
+      eval("""local f=null; f == null""", useNewEvaluator = useNewEvaluator) ==> ujson.True
     }
 
     test("identifierStartsWithKeyword") {
       for(keyword <- Parser.keywords){
-        eval(s"""local ${keyword}Foo = 123; ${keyword}Foo""") ==> ujson.Num(123)
-        eval(s"""{${keyword}Foo: 123}""") ==> ujson.Obj(s"${keyword}Foo" -> ujson.Num(123))
+        eval(s"""local ${keyword}Foo = 123; ${keyword}Foo""", useNewEvaluator = useNewEvaluator) ==> ujson.Num(123)
+        eval(s"""{${keyword}Foo: 123}""", useNewEvaluator = useNewEvaluator) ==> ujson.Obj(s"${keyword}Foo" -> ujson.Num(123))
       }
     }
 
     test("errorNonString") {
-      assert(evalErr("""error {a: "b"}""").contains("""{"a": "b"}"""))
-      assert(evalErr("""assert 1 == 2 : { a: "b"}; 1""").contains("""{"a": "b"}"""))
+      assert(evalErr("""error {a: "b"}""", useNewEvaluator = useNewEvaluator).contains("""{"a": "b"}"""))
+      assert(evalErr("""assert 1 == 2 : { a: "b"}; 1""", useNewEvaluator = useNewEvaluator).contains("""{"a": "b"}"""))
     }
 
     test("assertInheritance"){
-      test - assert(evalErr("""{ } + {assert false}""").contains("sjsonnet.Error: Assertion failed"))
-      test - assert(evalErr("""{assert false} + {}""").contains("sjsonnet.Error: Assertion failed"))
-      test - assert(evalErr("""{assert false} + {} + {}""").contains("sjsonnet.Error: Assertion failed"))
-      test - assert(evalErr("""{} + {assert false} + {}""").contains("sjsonnet.Error: Assertion failed"))
-      test - assert(evalErr("""{} + {} + {assert false}""").contains("sjsonnet.Error: Assertion failed"))
+      test - assert(evalErr("""{ } + {assert false}""", useNewEvaluator = useNewEvaluator).contains("sjsonnet.Error: Assertion failed"))
+      test - assert(evalErr("""{assert false} + {}""", useNewEvaluator = useNewEvaluator).contains("sjsonnet.Error: Assertion failed"))
+      test - assert(evalErr("""{assert false} + {} + {}""", useNewEvaluator = useNewEvaluator).contains("sjsonnet.Error: Assertion failed"))
+      test - assert(evalErr("""{} + {assert false} + {}""", useNewEvaluator = useNewEvaluator).contains("sjsonnet.Error: Assertion failed"))
+      test - assert(evalErr("""{} + {} + {assert false}""", useNewEvaluator = useNewEvaluator).contains("sjsonnet.Error: Assertion failed"))
       test - {
         val problematicStrictInheritedAssertionsSnippet =
           """local template = { assert self.flag };
@@ -401,15 +399,16 @@ object EvaluatorTests extends TestSuite{
         assert(
           evalErr(
             problematicStrictInheritedAssertionsSnippet,
-            strictInheritedAssertions = true
+            strictInheritedAssertions = true, useNewEvaluator = useNewEvaluator
           ).contains("sjsonnet.Error: Assertion failed")
         )
 
         assert(
-          eval(problematicStrictInheritedAssertionsSnippet, strictInheritedAssertions = false) ==
+          eval(problematicStrictInheritedAssertionsSnippet, strictInheritedAssertions = false, useNewEvaluator = useNewEvaluator) ==
           ujson.Obj("a" -> ujson.Obj("flag" -> true), "b" -> ujson.Obj("flag" -> false))
         )
       }
     }
   }
+  def tests = allTests(false).prefix("Evaluator") ++ allTests(true).prefix("NewEvaluator")
 }

--- a/sjsonnet/test/src/sjsonnet/TestUtils.scala
+++ b/sjsonnet/test/src/sjsonnet/TestUtils.scala
@@ -8,7 +8,8 @@ object TestUtils {
             strict: Boolean = false,
             noDuplicateKeysInComprehension: Boolean = false,
             strictInheritedAssertions: Boolean = false,
-            strictSetOperations: Boolean = true): Either[String, Value] = {
+            strictSetOperations: Boolean = true,
+            useNewEvaluator: Boolean = false): Either[String, Value] = {
     new Interpreter(
       Map(),
       Map(),
@@ -21,7 +22,8 @@ object TestUtils {
         noDuplicateKeysInComprehension = noDuplicateKeysInComprehension,
         strictInheritedAssertions = strictInheritedAssertions,
         strictSetOperations = strictSetOperations,
-        throwErrorForInvalidSets = true
+        throwErrorForInvalidSets = true,
+        useNewEvaluator = useNewEvaluator
       )
     ).interpret(s, DummyPath("(memory)"))
   }
@@ -31,8 +33,9 @@ object TestUtils {
            strict: Boolean = false,
            noDuplicateKeysInComprehension: Boolean = false,
            strictInheritedAssertions: Boolean = false,
-           strictSetOperations: Boolean = true): Value = {
-    eval0(s, preserveOrder, strict, noDuplicateKeysInComprehension, strictInheritedAssertions, strictSetOperations) match {
+           strictSetOperations: Boolean = true,
+           useNewEvaluator: Boolean = false): Value = {
+    eval0(s, preserveOrder, strict, noDuplicateKeysInComprehension, strictInheritedAssertions, strictSetOperations, useNewEvaluator) match {
       case Right(x) => x
       case Left(e) => throw new Exception(e)
     }
@@ -43,8 +46,9 @@ object TestUtils {
               strict: Boolean = false,
               noDuplicateKeysInComprehension: Boolean = false,
               strictInheritedAssertions: Boolean = false,
-              strictSetOperations: Boolean = true): String = {
-    eval0(s, preserveOrder, strict, noDuplicateKeysInComprehension, strictInheritedAssertions, strictSetOperations) match{
+              strictSetOperations: Boolean = true,
+              useNewEvaluator: Boolean = false): String = {
+    eval0(s, preserveOrder, strict, noDuplicateKeysInComprehension, strictInheritedAssertions, strictSetOperations, useNewEvaluator) match{
       case Left(err) => err.split('\n').map(_.trim).mkString("\n")  // normalize inconsistent indenation on JVM vs JS
       case Right(r) => throw new Exception(s"Expected exception, got result: $r")
     }


### PR DESCRIPTION
Before:
```
Result "com.databricks.jsonnet.bundle.test.InternalJsonnetBuilderBenchmark.main":
  239.623 ±(99.9%) 2.487 ms/op [Average]
  (min, avg, max) = (238.165, 239.623, 242.976), stdev = 1.645
  CI (99.9%): [237.136, 242.110] (assumes normal distribution)
```

After:
```
Result "com.databricks.jsonnet.bundle.test.InternalJsonnetBuilderBenchmark.main":
  224.443 ±(99.9%) 1.335 ms/op [Average]
  (min, avg, max) = (223.504, 224.443, 226.269), stdev = 0.883
  CI (99.9%): [223.108, 225.779] (assumes normal distribution)
```

Looks like there's still a small regression somewhere - will continue investigating
Initial 3.3.5 commit
```
Result "com.databricks.jsonnet.bundle.test.InternalJsonnetBuilderBenchmark.main":
  216.718 ±(99.9%) 2.125 ms/op [Average]
  (min, avg, max) = (214.841, 216.718, 218.835), stdev = 1.406
  CI (99.9%): [214.593, 218.843] (assumes normal distribution)
```