### PR TITLE
Revert last changes that caused performance regressions

### DIFF
--- a/sjsonnet/src/sjsonnet/Interpreter.scala
+++ b/sjsonnet/src/sjsonnet/Interpreter.scala
@@ -91,7 +91,7 @@ class Interpreter(queryExtVar: String => Option[ExternalVariable[_]],
     varResolver.parse(wd / Util.wrapInLessThanGreaterThan(k), StaticResolvedFile(v))(evaluator).fold(throw _, _._1)
   }
 
-  val evaluator: Evaluator = createEvaluator(
+  lazy val evaluator: Evaluator = createEvaluator(
     resolver,
     // parse extVars lazily, because they can refer to each other and be recursive
     k => queryExtVar(k).map(v => evaluateVar("ext", k, v)),
@@ -99,6 +99,8 @@ class Interpreter(queryExtVar: String => Option[ExternalVariable[_]],
     settings,
     warn
   )
+
+  evaluator // force the lazy val
 
   def formatError(e: Error): String = {
     val s = new StringWriter()

--- a/sjsonnet/src/sjsonnet/StaticOptimizer.scala
+++ b/sjsonnet/src/sjsonnet/StaticOptimizer.scala
@@ -43,15 +43,6 @@ class StaticOptimizer(
     case b2 @ BinaryOp(pos, lhs: Val.Str, BinaryOp.OP_%, rhs) =>
       try ApplyBuiltin1(pos, new Format.PartialApplyFmt(lhs.value), rhs, tailstrict = false)
       catch { case _: Exception => b2 }
-    case Or(_, Val.False(_), rhs) => transform(rhs)
-    case Or(pos, Val.True(_), _) => Val.True(pos)
-    case Or(pos, _, Val.True(_)) => Val.True(pos)
-    case And(_, Val.True(_), rhs) => transform(rhs)
-    case And(pos, Val.False(_), _) => Val.False(pos)
-    case And(pos, _, Val.False(_)) => Val.False(pos)
-    case UnaryOp(pos, UnaryOp.OP_!, Val.True(_)) => Val.False(pos)
-    case UnaryOp(pos, UnaryOp.OP_!, Val.False(_)) => Val.True(pos)
-    case UnaryOp(_, UnaryOp.OP_!, UnaryOp(_, UnaryOp.OP_!, expr)) => expr
 
     case e @ Id(pos, name) =>
       scope.get(name) match {

--- a/sjsonnet/test/src-js/sjsonnet/FileTests.scala
+++ b/sjsonnet/test/src-js/sjsonnet/FileTests.scala
@@ -77,6 +77,7 @@ object FileTests extends TestSuite {
     test("lazy_operator2") - checkFail(
       """sjsonnet.Error: should happen
         |  at [Error].((memory):1:9)
+        |  at [And].((memory):1:6)
         |""".stripMargin)
     test("merge") - check()
     test("null") - check()

--- a/sjsonnet/test/src-jvm/sjsonnet/FileTests.scala
+++ b/sjsonnet/test/src-jvm/sjsonnet/FileTests.scala
@@ -51,7 +51,11 @@ object FileTests extends TestSuite{
     test("local") - check()
     test("lazy") - checkGolden()
     test("lazy_operator1") - checkGolden()
-    test("lazy_operator2") - checkFail("sjsonnet.Error: should happen\n    at [Error].(lazy_operator2.jsonnet:1:9)\n")
+    test("lazy_operator2") - checkFail(
+      """sjsonnet.Error: should happen
+        |    at [Error].(lazy_operator2.jsonnet:1:9)
+        |    at [And].(lazy_operator2.jsonnet:1:6)
+        |""".stripMargin)
     test("merge") - check()
     test("null") - check()
     test("object") - check()

--- a/sjsonnet/test/src-native/sjsonnet/FileTests.scala
+++ b/sjsonnet/test/src-native/sjsonnet/FileTests.scala
@@ -50,7 +50,11 @@ object FileTests extends TestSuite{
     test("local") - check()
     test("lazy") - checkGolden()
     test("lazy_operator1") - checkGolden()
-    test("lazy_operator2") - checkFail("sjsonnet.Error: should happen\n    at [Error].(lazy_operator2.jsonnet:1:9)\n")
+    test("lazy_operator2") - checkFail(
+      """sjsonnet.Error: should happen
+        |    at [Error].(lazy_operator2.jsonnet:1:9)
+        |    at [And].(lazy_operator2.jsonnet:1:6)
+        |""".stripMargin)
     test("merge") - check()
     test("null") - check()
     test("object") - check()


### PR DESCRIPTION
I don't know why the `Make evalutator a simple val` made a difference, but it did.

We are back to the performance level of the scala3 migration (which is better than the 0.4 series)


```
# Run progress: 0.00% complete, ETA 00:02:00
# Fork: 1 of 1
Java HotSpot(TM) 64-Bit Server VM warning: -XX:ThreadPriorityPolicy=1 may require system level permission, e.g., being the root user. If the necessary permission is not possessed, changes to priority will be silently ignored.
# Warmup Iteration   1: 318.899 ms/op
# Warmup Iteration   2: 219.683 ms/op
Iteration   1: 218.122 ms/op
Iteration   2: 217.369 ms/op
Iteration   3: 216.576 ms/op
Iteration   4: 216.465 ms/op
Iteration   5: 215.468 ms/op
Iteration   6: 215.459 ms/op
Iteration   7: 215.341 ms/op
Iteration   8: 214.828 ms/op
Iteration   9: 215.898 ms/op
Iteration  10: 215.108 ms/op


Result "com.databricks.jsonnet.bundle.test.InternalJsonnetBuilderBenchmark.main":
  216.063 ±(99.9%) 1.600 ms/op [Average]
  (min, avg, max) = (214.828, 216.063, 218.122), stdev = 1.058
  CI (99.9%): [214.464, 217.663] (assumes normal distribution)


# Run complete. Total time: 00:02:02

REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
experiments, perform baseline and negative tests that provide experimental control, make sure
the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
Do not assume the numbers tell you what you want them to tell.

Benchmark                             Mode  Cnt    Score   Error  Units
InternalJsonnetBuilderBenchmark.main  avgt   10  216.063 ± 1.600  ms/op

```