### PR TITLE
fix: Fix foldr for str

### DIFF
--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -327,7 +327,7 @@ class Std(
           current
         case s: Val.Str =>
           var current = init.force
-          for (char <- s.value) {
+          for (char <- s.value.reverse) {
             val c = current
             current = func.apply2(Val.Str(pos, new String(Array(char))), c, pos.noOffset)(ev)
           }

--- a/sjsonnet/test/src/sjsonnet/Std0150FunctionsTests.scala
+++ b/sjsonnet/test/src/sjsonnet/Std0150FunctionsTests.scala
@@ -155,7 +155,9 @@ object Std0150FunctionsTests extends TestSuite {
 
     test("fold") {
       eval("""std.foldr(function (acc, it) acc + " " + it, "jsonnet", "this is")""") ==>
-      ujson.Str("t e n n o s j this is")
+      ujson.Str("j s o n n e t this is")
+      eval("std.foldr(function(v, i) i + v + v, 'bcd', 'a')") ==> ujson.Str("addccbb")
+
 
       eval("""std.foldl(function (acc, it) acc + " " + it, "jsonnet", "this is")""") ==>
       ujson.Str("this is j s o n n e t")


### PR DESCRIPTION
Motivation:
Fix https://github.com/databricks/sjsonnet/issues/372

It should call `reverse` on the string when folding.