### PR TITLE
chore: Change Scala native's release mode to ReleaseFull

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -153,7 +153,7 @@ object sjsonnet extends Module {
       this.millSourcePath / "src-native",
       this.millSourcePath / "src-jvm-native"
     )
-    def releaseMode = ReleaseMode.ReleaseFast
+    def releaseMode = ReleaseMode.ReleaseFull
     def nativeLTO = LTO.Full
     def nativeMultithreading = None
 


### PR DESCRIPTION
Motivation:
Better performance
refs: https://scala-native.org/en/stable/user/sbt.html#compilation-modes

Maybe because of the sjsonnet size is now from `7.2MB` to `12MB`

it's https://github.com/scalameta/scalafmt/blob/main/build.sbt#L342 ReleaseFull in scalafmt