### PR TITLE
Add a flag to reverse the order of jpath entries.

### DIFF
--- a/bench/src/main/scala/sjsonnet/MainBenchmark.scala
+++ b/bench/src/main/scala/sjsonnet/MainBenchmark.scala
@@ -33,7 +33,7 @@ object MainBenchmark {
       Map.empty[String, String],
       Map.empty[String, String],
       OsPath(wd),
-      importer = SjsonnetMain.resolveImport(config.jpaths.map(os.Path(_, wd)).map(OsPath(_)), None),
+      importer = SjsonnetMain.resolveImport(config.getJpaths.map(os.Path(_, wd)).map(OsPath(_)), None),
       parseCache = parseCache
     )
     val renderer = new Renderer(new StringWriter, indent = 3)

--- a/bench/src/main/scala/sjsonnet/MainBenchmark.scala
+++ b/bench/src/main/scala/sjsonnet/MainBenchmark.scala
@@ -33,7 +33,7 @@ object MainBenchmark {
       Map.empty[String, String],
       Map.empty[String, String],
       OsPath(wd),
-      importer = SjsonnetMain.resolveImport(config.getJpaths.map(os.Path(_, wd)).map(OsPath(_)), None),
+      importer = SjsonnetMain.resolveImport(config.getOrderedJpaths.map(os.Path(_, wd)).map(OsPath(_)), None),
       parseCache = parseCache
     )
     val renderer = new Renderer(new StringWriter, indent = 3)

--- a/bench/src/main/scala/sjsonnet/MaterializerBenchmark.scala
+++ b/bench/src/main/scala/sjsonnet/MaterializerBenchmark.scala
@@ -33,7 +33,7 @@ class MaterializerBenchmark {
       Map.empty[String, String],
       OsPath(wd),
       importer = SjsonnetMain
-        .resolveImport(config.jpaths.map(os.Path(_, wd)).map(OsPath(_)).toIndexedSeq, None),
+        .resolveImport(config.getJpaths.map(os.Path(_, wd)).map(OsPath(_)).toIndexedSeq, None),
       parseCache = new DefaultParseCache
     )
     value = interp.evaluate(os.read(path), OsPath(path)).getOrElse(???)

--- a/bench/src/main/scala/sjsonnet/MaterializerBenchmark.scala
+++ b/bench/src/main/scala/sjsonnet/MaterializerBenchmark.scala
@@ -33,7 +33,7 @@ class MaterializerBenchmark {
       Map.empty[String, String],
       OsPath(wd),
       importer = SjsonnetMain
-        .resolveImport(config.getJpaths.map(os.Path(_, wd)).map(OsPath(_)).toIndexedSeq, None),
+        .resolveImport(config.getOrderedJpaths.map(os.Path(_, wd)).map(OsPath(_)).toIndexedSeq, None),
       parseCache = new DefaultParseCache
     )
     value = interp.evaluate(os.read(path), OsPath(path)).getOrElse(???)

--- a/bench/src/main/scala/sjsonnet/RunProfiler.scala
+++ b/bench/src/main/scala/sjsonnet/RunProfiler.scala
@@ -16,7 +16,7 @@ object RunProfiler extends App {
     Map.empty[String, String],
     OsPath(wd),
     importer = SjsonnetMain
-      .resolveImport(config.jpaths.map(os.Path(_, wd)).map(OsPath(_)).toIndexedSeq, None),
+      .resolveImport(config.getJpaths.map(os.Path(_, wd)).map(OsPath(_)).toIndexedSeq, None),
     parseCache = parseCache
   ) {
     override def createEvaluator(

--- a/bench/src/main/scala/sjsonnet/RunProfiler.scala
+++ b/bench/src/main/scala/sjsonnet/RunProfiler.scala
@@ -16,7 +16,7 @@ object RunProfiler extends App {
     Map.empty[String, String],
     OsPath(wd),
     importer = SjsonnetMain
-      .resolveImport(config.getJpaths.map(os.Path(_, wd)).map(OsPath(_)).toIndexedSeq, None),
+      .resolveImport(config.getOrderedJpaths.map(os.Path(_, wd)).map(OsPath(_)).toIndexedSeq, None),
     parseCache = parseCache
   ) {
     override def createEvaluator(

--- a/sjsonnet/src-jvm-native/sjsonnet/Config.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/Config.scala
@@ -161,14 +161,14 @@ final case class Config(
    * Returns the sequence of jpaths specified on the command line, ordered according to the flags.
    *
    * Historically, sjsonnet evaluated jpaths in left-to-right order, which is also the order of
-   * evaluation in the core. However, in gojsonnet, the arguments are prioritized left to right, and
+   * evaluation in the core. However, in gojsonnet, the arguments are prioritized right to left, and
    * the reverse-jpaths-priority flag was introduced for possible consistency across the two
    * implementations.
+   *
+   * See [[https://jsonnet-libs.github.io/jsonnet-training-course/lesson2.html#jsonnet_path]] for details.
    */
   def getOrderedJpaths: Seq[String] = {
-    if (jpaths == null) {
-      null
-    } else if (reverseJpathsPriority.value) {
+    if (reverseJpathsPriority.value) {
       jpaths.reverse
     } else {
       jpaths

--- a/sjsonnet/src-jvm-native/sjsonnet/Config.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/Config.scala
@@ -156,12 +156,14 @@ final case class Config(
     )
     file: String
 ) {
-  /** Returns the sequence of jpaths specified on the command line, ordered according to the flags.
+
+  /**
+   * Returns the sequence of jpaths specified on the command line, ordered according to the flags.
    *
-   *  Historically, sjsonnet evaluated jpaths in left-to-right order, which is also the order
-   *  of evaluation in the core. However, in gojsonnet, the arguments are prioritized left
-   *  to right, and the reverse-jpaths-priority flag was introduced for possible consistency
-   *  across the two implementations.
+   * Historically, sjsonnet evaluated jpaths in left-to-right order, which is also the order of
+   * evaluation in the core. However, in gojsonnet, the arguments are prioritized left to right, and
+   * the reverse-jpaths-priority flag was introduced for possible consistency across the two
+   * implementations.
    */
   def getOrderedJpaths: Seq[String] = {
     if (jpaths == null) {

--- a/sjsonnet/src-jvm-native/sjsonnet/Config.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/Config.scala
@@ -165,7 +165,8 @@ final case class Config(
    * the reverse-jpaths-priority flag was introduced for possible consistency across the two
    * implementations.
    *
-   * See [[https://jsonnet-libs.github.io/jsonnet-training-course/lesson2.html#jsonnet_path]] for details.
+   * See [[https://jsonnet-libs.github.io/jsonnet-training-course/lesson2.html#jsonnet_path]] for
+   * details.
    */
   def getOrderedJpaths: Seq[String] = {
     if (reverseJpathsPriority.value) {

--- a/sjsonnet/src-jvm-native/sjsonnet/Config.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/Config.scala
@@ -7,7 +7,8 @@ final case class Config(
     @arg(
       name = "jpath",
       short = 'J',
-      doc = "Specify an additional library search dir (left-most wins unless reverse-jpaths-priority is set)"
+      doc =
+        "Specify an additional library search dir (left-most wins unless reverse-jpaths-priority is set)"
     )
     private val jpaths: List[String] = Nil,
     @arg(

--- a/sjsonnet/src-jvm-native/sjsonnet/Config.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/Config.scala
@@ -156,7 +156,14 @@ final case class Config(
     )
     file: String
 ) {
-  def getJpaths: Seq[String] = {
+  /** Returns the sequence of jpaths specified on the command line, ordered according to the flags.
+   *
+   *  Historically, sjsonnet evaluated jpaths in left-to-right order, which is also the order
+   *  of evaluation in the core. However, in gojsonnet, the arguments are prioritized left
+   *  to right, and the reverse-jpaths-priority flag was introduced for possible consistency
+   *  across the two implementations.
+   */
+  def getOrderedJpaths: Seq[String] = {
     if (jpaths == null) {
       null
     } else if (reverseJpathsPriority.value) {

--- a/sjsonnet/src-jvm-native/sjsonnet/Config.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/Config.scala
@@ -7,9 +7,9 @@ final case class Config(
     @arg(
       name = "jpath",
       short = 'J',
-      doc = "Specify an additional library search dir (left-most wins)"
+      doc = "Specify an additional library search dir (left-most wins unless reverse-jpaths-priority is set)"
     )
-    jpaths: List[String] = Nil,
+    private val jpaths: List[String] = Nil,
     @arg(
       name = "debug-importer",
       doc = "Print some additional debugging information about the importer"
@@ -145,8 +145,23 @@ final case class Config(
     )
     throwErrorForInvalidSets: Flag = Flag(),
     @arg(
+      name = "reverse-jpaths-priority",
+      doc = """If set, reverses the import order of specified jpaths (so that the rightmost wins)"""
+    )
+    reverseJpathsPriority: Flag = Flag(),
+    @arg(
       doc = "The jsonnet file you wish to evaluate",
       positional = true
     )
     file: String
-)
+) {
+  def getJpaths: Seq[String] = {
+    if (jpaths == null) {
+      null
+    } else if (reverseJpathsPriority.value) {
+      jpaths.reverse
+    } else {
+      jpaths
+    }
+  }
+}

--- a/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMain.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMain.scala
@@ -15,7 +15,7 @@ import scala.util.Try
 
 object SjsonnetMain {
   def resolveImport(
-      searchRoots0: Seq[Path],
+      searchRoots0: Seq[Path], // Evaluated in order, first occurrence wins
       allowedInputs: Option[Set[os.Path]] = None,
       debugImporter: Boolean = false): Importer =
     new Importer {
@@ -263,7 +263,7 @@ object SjsonnetMain {
           }
         case None =>
           resolveImport(
-            config.getJpaths.map(os.Path(_, wd)).map(OsPath.apply),
+            config.getOrderedJpaths.map(os.Path(_, wd)).map(OsPath.apply),
             allowedInputs,
             config.debugImporter.value
           )

--- a/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMain.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMain.scala
@@ -263,7 +263,7 @@ object SjsonnetMain {
           }
         case None =>
           resolveImport(
-            config.jpaths.map(os.Path(_, wd)).map(OsPath.apply),
+            config.getJpaths.map(os.Path(_, wd)).map(OsPath.apply),
             allowedInputs,
             config.debugImporter.value
           )


### PR DESCRIPTION
In the canonical implementation of jsonnet, the last match presented on -J wins (see
https://jsonnet-libs.github.io/jsonnet-training-course/lesson2.html#jsonnet_path for details). Given the current state is behavior is documented it's undesirable to simply change the implementation as that breaks backwards compatibility so the behavior is hidden behind a feature flag.