### PR TITLE
Allow `std.map` to operate on string args as well.

### DIFF
--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -449,12 +449,26 @@ class Std(
   private object Map_ extends Val.Builtin2("map", "func", "arr") {
     def evalRhs(_func: Lazy, arr: Lazy, ev: EvalScope, pos: Position): Val = {
       val func = _func.force.asFunc
+      val arg = arr.force
+      arg match {
+        case Val.Str(_, str) => evalStr(func, str, ev, pos.noOffset)
+        case _               => evalArr(func, arg.asArr.asLazyArray, ev, pos)
+      }
+    }
+
+    private def evalArr(
+                         _func: Val.Func,
+                         arg: Array[Lazy],
+                         ev: EvalScope,
+                         pos: Position): Val.Arr = {
       Val.Arr(
         pos,
-        arr.force.asArr.asLazyArray.map(v =>
-          (() => func.apply1(v, pos.noOffset)(ev, TailstrictModeDisabled)): Lazy
-        )
+        arg.map(v => (() => _func.apply1(v, pos.noOffset)(ev, TailstrictModeDisabled)): Lazy)
       )
+    }
+
+    private def evalStr(_func: Val.Func, arg: String, ev: EvalScope, pos: Position): Val.Arr = {
+      evalArr(_func, stringChars(pos, arg).asLazyArray, ev, pos)
     }
   }
 

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -457,10 +457,10 @@ class Std(
     }
 
     private def evalArr(
-                         _func: Val.Func,
-                         arg: Array[Lazy],
-                         ev: EvalScope,
-                         pos: Position): Val.Arr = {
+        _func: Val.Func,
+        arg: Array[Lazy],
+        ev: EvalScope,
+        pos: Position): Val.Arr = {
       Val.Arr(
         pos,
         arg.map(v => (() => _func.apply1(v, pos.noOffset)(ev, TailstrictModeDisabled)): Lazy)

--- a/sjsonnet/test/src/sjsonnet/StdMapTests.scala
+++ b/sjsonnet/test/src/sjsonnet/StdMapTests.scala
@@ -1,0 +1,22 @@
+package sjsonnet
+
+import utest._
+import TestUtils.eval
+
+object StdMapTests extends TestSuite {
+  def tests: Tests = Tests {
+    test("stdMap") {
+      eval("std.map(function(x) x * x, [])") ==> ujson.Arr()
+      eval("std.map(function(x) x * x, [1, 2, 3, 4])") ==> ujson.Arr(1, 4, 9, 16)
+
+      // Map accepts strings as well, interpreting it as an array of one-character strings
+      eval("std.map(function(x) x + x, 'Hello')") ==> ujson.Arr("HH", "ee", "ll", "ll", "oo")
+
+      // Test lazy evaluation
+      eval("std.map(function(x) assert x != 'A'; x + x, 'AB')[1]") ==> ujson.Str("BB")
+
+      // Test returning arbitrary values from the mapping function
+      eval("std.map(function(x) std.codepoint(x), 'AB')") ==> ujson.Arr(65, 66)
+    }
+  }
+}


### PR DESCRIPTION
In gojsonnet, a few functions of the stdlib accepts strings in addition to arrays. Sometimes this is mentioned in the stdlib documentation, sometimes it isn't - and importantly, this is a special property of a few select functions and it does NOT mean that a string can be treated as an array of single-character strings in every context with implicit type conversion between the two.

Eyeballing the gojsonnet code yields the following list of std functions which should support strings as parameters:

std.slice
std.member
std.map
std.flatMap
std.base64

Out of those, only `map` had missing support for strings, which is being added in this commit.

FTR, in the process, I discovered other quirks of the `map` function, such as the undocumented, `filterMap`-like behavior from this test case:

`std.assertEqual(std.map(function(x) x * x, std.filter(function(x) x > 5, std.range(1, 10))), [36, 49, 64, 81, 100])`