### PR TITLE
chore: bump scala-native to 0.5.8

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -157,7 +157,7 @@ object sjsonnet extends VersionFileModule {
       with SjsonnetPublishModule
       with SjsonnetJvmNative {
     def millSourcePath = super.millSourcePath / os.up
-    def scalaNativeVersion = "0.5.7"
+    def scalaNativeVersion = "0.5.8"
     def sources = T.sources(
       this.millSourcePath / "src",
       this.millSourcePath / "src-native",


### PR DESCRIPTION
Motivation:

Bump scala native to 0.5.8

https://github.com/scala-native/scala-native/releases/tag/v0.5.8

which may fix : https://github.com/databricks/sjsonnet/issues/374