### PR TITLE
Update ScalaJS entrypoint and documentation

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -86,6 +86,7 @@ object sjsonnet extends VersionFileModule {
   trait SjsonnetJsModule extends SjsonnetCrossModule with ScalaJSModule with SjsonnetPublishModule {
     def millSourcePath = super.millSourcePath / os.up
     def scalaJSVersion = "1.17.0"
+    def moduleKind = T { ModuleKind.CommonJSModule }
     def sources = T.sources(
       this.millSourcePath / "src",
       this.millSourcePath / "src-js",

--- a/readme.md
+++ b/readme.md
@@ -55,15 +55,20 @@ $ ./sjsonnet.jar foo.jsonnet
 
 Or from Javascript:
 
+Since `0.5.3`, the output is a CommonJS module.
+
 ```javascript
-$ node
+const { SjsonnetMain } = require("./sjsonnet.js");
+// or
+import { SjsonnetMain } from "./sjsonnet";
 
-> require("./sjsonnet.js")
+console.log(
+  SjsonnetMain.interpret("local f = function(x) x * x; f(11)", {}, {}, "", (wd, imported) => null)
+);
+// => 121
 
-> SjsonnetMain.interpret("local f = function(x) x * x; f(11)", {}, {}, "", (wd, imported) => null)
-121
-
-> SjsonnetMain.interpret(
+console.log(
+  SjsonnetMain.interpret(
     "local f = import 'foo'; f + 'bar'", // code
     {}, // extVars
     {}, // tlaVars
@@ -74,8 +79,9 @@ $ node
     (wd, imported) => wd + "/" + imported,
     // loader callback: receives the full path and returns the file contents
     (path, binary) => "local bar = 123; bar + bar"
-    )
-'246bar'
+  )
+);
+// => '246bar'
 ```
 
 Note that since Javascript does not necessarily have access to the

--- a/readme.md
+++ b/readme.md
@@ -69,11 +69,11 @@ $ node
     {}, // tlaVars
     "", // initial working directory
 
-    // import callback: receives a base directory and the imported path string,
-    // returns a tuple of the resolved file path and file contents or file contents resolve method
-    (wd, imported) => [wd + "/" + imported, "local bar = 123; bar + bar"],
-    // loader callback: receives the tuple from the import callback and returns the file contents
-    ([path, content]) => content
+    // resolver callback: receives a base directory and the imported path string,
+    // returns the resolved path
+    (wd, imported) => wd + "/" + imported,
+    // loader callback: receives the full path and returns the file contents
+    (path, binary) => "local bar = 123; bar + bar"
     )
 '246bar'
 ```

--- a/sjsonnet/src-js/sjsonnet/SjsonnetMain.scala
+++ b/sjsonnet/src-js/sjsonnet/SjsonnetMain.scala
@@ -13,7 +13,7 @@ object SjsonnetMain {
       tlaVars: js.Any,
       wd0: String,
       importResolver: js.Function2[String, String, String],
-      importLoader: js.Function2[String, Boolean, Either[String, Array[Byte]]],
+      importLoader: js.Function2[String, Boolean, Any],
       preserveOrder: Boolean = false): js.Any = {
     val interp = new Interpreter(
       ujson.WebJson.transform(extVars, ujson.Value).obj.toMap.map {
@@ -33,8 +33,9 @@ object SjsonnetMain {
           }
         def read(path: Path, binaryData: Boolean): Option[ResolvedFile] =
           importLoader(path.asInstanceOf[JsVirtualPath].path, binaryData) match {
-            case Left(s)    => Some(StaticResolvedFile(s))
-            case Right(arr) => Some(StaticBinaryResolvedFile(arr))
+            case s: String        => Some(StaticResolvedFile(s))
+            case arr: Array[Byte] => Some(StaticBinaryResolvedFile(arr))
+            case _                => throw new js.JavaScriptException("Loader result must be string or byte array")
           }
       },
       parseCache = new DefaultParseCache,

--- a/sjsonnet/src-js/sjsonnet/SjsonnetMain.scala
+++ b/sjsonnet/src-js/sjsonnet/SjsonnetMain.scala
@@ -35,7 +35,7 @@ object SjsonnetMain {
           importLoader(path.asInstanceOf[JsVirtualPath].path, binaryData) match {
             case s: String        => Some(StaticResolvedFile(s))
             case arr: Array[Byte] => Some(StaticBinaryResolvedFile(arr))
-            case _                => throw new js.JavaScriptException("Loader result must be string or byte array")
+            case _ => throw new js.JavaScriptException("Loader result must be string or byte array")
           }
       },
       parseCache = new DefaultParseCache,


### PR DESCRIPTION
* Updated the JS entrypoint to allow usage from plain JS/TS, the previous version required an `Either` object which could not be returned from the JS side.
* Updated the documentation to reflect the changes.
* Compile the output as a CommonJS module to make import easier.