### PR TITLE
fix: Support std.sort() on arrays of arrays.

### DIFF
--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -2133,6 +2133,8 @@ class Std(
             indices.sortBy(i => keys(i).cast[Val.Str].asString)
           } else if (keyType == classOf[Val.Num]) {
             indices.sortBy(i => keys(i).cast[Val.Num].asDouble)
+          } else if (keyType == classOf[Val.Arr]) {
+            indices.sortBy(i => keys(i).cast[Val.Arr])(ev.compare(_, _))
           } else {
             Error.fail("Cannot sort with key values that are " + keys(0).prettyName + "s")
           }
@@ -2150,6 +2152,8 @@ class Std(
             vs.map(_.force.cast[Val.Str]).sortBy(_.asString)
           } else if (keyType == classOf[Val.Num]) {
             vs.map(_.force.cast[Val.Num]).sortBy(_.asDouble)
+          } else if (keyType == classOf[Val.Arr]) {
+            vs.map(_.force.cast[Val.Arr]).sortBy(identity)(ev.compare(_, _))
           } else if (keyType == classOf[Val.Obj]) {
             Error.fail("Unable to sort array of objects without key function")
           } else {

--- a/sjsonnet/test/src/sjsonnet/StdWithKeyFTests.scala
+++ b/sjsonnet/test/src/sjsonnet/StdWithKeyFTests.scala
@@ -54,6 +54,12 @@ object StdWithKeyFTests extends TestSuite {
       eval("""std.sort([1, 2, 3])""").toString() ==> """[1,2,3]"""
       eval("""std.sort([1,2,3], keyF=function(x) -x)""").toString() ==> """[3,2,1]"""
       eval("""std.sort([1,2,3], function(x) -x)""").toString() ==> """[3,2,1]"""
+      eval(
+        """std.sort([[1,'b'], [2], [1], [], [1,'a']])"""
+      ).toString() ==> """[[],[1],[1,"a"],[1,"b"],[2]]"""
+      eval(
+        """std.sort([{a:[2]},{a:[]},{a:[1]},{a:[1,'b']},{a:[1,'a']}], function(x) x.a)"""
+      ).toString() ==> """[{"a":[]},{"a":[1]},{"a":[1,"a"]},{"a":[1,"b"]},{"a":[2]}]"""
       assert(
         evalErr("""std.sort([1,2,3], keyF=function(x) error "foo")""").startsWith(
           "sjsonnet.Error: foo"


### PR DESCRIPTION
The std lib specifies `std.sort` as sorting by operator <= which does work on arrays. However, sjsonnet didn't implement sorting arrays of arrays using std.sort:
```
$ sjsonnet-0.5.2 -e '[] <= [1]'
true

$ sjsonnet-0.5.2 -e 'std.sort([[1],[]])'
sjsonnet.Error: Cannot sort array of array
    at [std.sort].(<exec>:1:9)

$ sjsonnet-0.5.2 -e 'std.sort([[1],[]], function(a) a)'
sjsonnet.Error: Cannot sort with key values that are arrays
    at [std.sort].(<exec>:1:9)
```

This PR implements std.sort for arrays of arrays and adds some tests.