### PR TITLE
fix: Handling of special characters in std.parseYaml().

### DIFF
--- a/sjsonnet/src-js/sjsonnet/Platform.scala
+++ b/sjsonnet/src-js/sjsonnet/Platform.scala
@@ -11,7 +11,7 @@ object Platform {
     case _: Node.ScalarNode =>
       YamlDecoder.forAny.construct(node).getOrElse("") match {
         case null          => ujson.Null
-        case v: String     => ujson.Str(v.replaceAll("\\\\n", "\n"))
+        case v: String     => ujson.read(s"\"${v.replace("\"", "\\\"").replace("\n", "\\n")}\"")
         case v: Boolean    => ujson.Bool(v)
         case v: Int        => ujson.Num(v.toDouble)
         case v: Long       => ujson.Num(v.toDouble)

--- a/sjsonnet/src-native/sjsonnet/Platform.scala
+++ b/sjsonnet/src-native/sjsonnet/Platform.scala
@@ -38,7 +38,7 @@ object Platform {
         case Right(v) =>
           v match {
             case null | None   => ujson.Null
-            case v: String     => ujson.Str(v.replaceAll("\\\\n", "\n"))
+            case v: String     => ujson.read(s"\"${v.replace("\"", "\\\"").replace("\n", "\\n")}\"")
             case v: Boolean    => ujson.Bool(v)
             case v: Byte       => ujson.Num(v.toDouble)
             case v: Int        => ujson.Num(v.toDouble)

--- a/sjsonnet/test/src/sjsonnet/ParseYamlTests.scala
+++ b/sjsonnet/test/src/sjsonnet/ParseYamlTests.scala
@@ -18,5 +18,10 @@ object ParseYamlTests extends TestSuite {
         """[{"foo": "bar"}, {"bar": "baz"}]"""
       )
     }
+    test {
+      eval("""std.parseYaml(@'{"a":"\"\\n\n\r\f\b\t""" + "\\u263A" + "\"}') {l: std.length(self.a)}") ==> ujson.Value(
+        """{"a":"\"\\n\n\r\f\b\t""" + "\u263A" + """","l":9}""" // <doublequote> <backslash> <n> <\n> <\r> <\f> <\b> <\t> <smiley>
+      )
+    }
   }
 }


### PR DESCRIPTION
Problem: std.parseYaml() produces incorrect results on the native and js targets when special characters are used; jvm is fine:

```
$ cat x.jsonnet
std.parseYaml(@'{"a":"\"\\n\n\r\f\b\t\u263A"}') { l: std.length(self.a) }

$ sjsonnet-908cc50a0760d42cd6136f07b2029fde97333c9c-jvm x.jsonnet
{
   "a": "\"\\n\n\r\f\b\t☺",
   "l": 9
}

$ sjsonnet-908cc50a0760d42cd6136f07b2029fde97333c9c-native x.jsonnet
{
   "a": "\"\\\n\n\\r\\f\\b\\t\\u263A",
   "l": 18
}
```

This PR fixes the native and js implementations and also adds the equivalent of x.jsonnet from the example above to the tests.