### PR TITLE
Remove last differences between jvm and native in regard to the go testsuite

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -181,7 +181,7 @@ object sjsonnet extends VersionFileModule {
     )
     def ivyDeps = super.ivyDeps() ++
       Agg(
-        ivy"com.github.lolgab::scala-native-crypto::0.2.0",
+        ivy"com.github.lolgab::scala-native-crypto::0.2.1",
         ivy"org.virtuslab::scala-yaml::0.3.0"
       )
 

--- a/sjsonnet/test/resources/go_test_suite/stdlib_smoke_test.jsonnet
+++ b/sjsonnet/test/resources/go_test_suite/stdlib_smoke_test.jsonnet
@@ -5,6 +5,17 @@
 // Functions with optional arguments need two lines - one with none of the optional arguments
 // and the other with all of them.
 
+local assertClose(a, b) =
+  local err =
+    if b == 0 then
+      a - b
+    else
+      if a / b - 1 > 0 then a / b - 1 else 1 - a / b;
+  if err > 0.000005 then
+    error 'Assertion failed (error ' + err + '). ' + a + ' !~ ' + b
+  else
+    true;
+
 {
     // extVar and native are skipped here, because of the special setup required.
     // We also skip undocumented functions used in desugaring and std.trace.
@@ -51,9 +62,9 @@
     floor: std.floor(x=5),
     ceil: std.ceil(x=5),
     sqrt: std.sqrt(x=5),
-    sin: std.sin(x=5),
-    cos: std.cos(x=5),
-    tan: std.tan(x=5),
+    sin: assertClose(std.sin(x=5), -0.9589242746631385),
+    cos: assertClose(std.cos(x=5), 0.28366218546322625),
+    tan: assertClose(std.tan(x=5), -3.380515006246586),
     asin: std.asin(x=0.5),
     acos: std.acos(x=0.5),
     atan: std.atan(x=5),

--- a/sjsonnet/test/resources/go_test_suite/stdlib_smoke_test.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/stdlib_smoke_test.jsonnet.golden
@@ -12,7 +12,7 @@
     "ceil": 5,
     "char": "A",
     "codepoint": 65,
-    "cos": 0.28366218546322625,
+    "cos": true,
     "count": 1,
     "decodeUTF8": "AAA",
     "encodeUTF8": [98, 108, 97, 104],
@@ -94,7 +94,7 @@
         [1, 2, 4]
     ],
     "sign": 1,
-    "sin": -0.9589242746631385,
+    "sin": true,
     "slice": "o",
     "sort": [
         [1, 2, 3],
@@ -109,7 +109,7 @@
     "stringChars": ["b", "l", "a", "h"],
     "stripChars": "bbbb",
     "substr": "s",
-    "tan": -3.380515006246586,
+    "tan": true,
     "thisFile": "stdlib_smoke_test.jsonnet",
     "toString": "42",
     "type": "object",

--- a/sjsonnet/test/src-jvm-native/sjsonnet/FileTests.scala
+++ b/sjsonnet/test/src-jvm-native/sjsonnet/FileTests.scala
@@ -19,12 +19,7 @@ object FileTests extends BaseFileTests {
         })
   val goTestDataSkippedTests: Set[String] = Set(
     "object_invariant_plus.jsonnet"
-  ) ++ (if (isScalaNative)
-          Set(
-            "stdlib_smoke_test.jsonnet",
-            "builtinSha3.jsonnet"
-          )
-        else Set.empty[String])
+  )
 
   val tests: Tests = Tests {
     test("test_suite") - {

--- a/sjsonnet/test/src-jvm-native/sjsonnet/StdShasTests.scala
+++ b/sjsonnet/test/src-jvm-native/sjsonnet/StdShasTests.scala
@@ -4,8 +4,6 @@ import sjsonnet.TestUtils.eval
 import utest._
 
 object StdShasTests extends TestSuite {
-  private val isScalaNative: Boolean = System.getenv("SCALANATIVE_THREAD_STACK_SIZE") != null
-
   def tests: Tests = Tests {
     test {
       eval("std.sha1('')") ==> ujson.Str("da39a3ee5e6b4b0d3255bfef95601890afd80709")
@@ -15,11 +13,9 @@ object StdShasTests extends TestSuite {
       eval("std.sha512('')") ==> ujson.Str(
         "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
       )
-      if (!isScalaNative) {
-        eval("std.sha3('')") ==> ujson.Str(
-          "a69f73cca23a9ac5c8b567dc185a756e97c982164fe25859e0d1dcc1475c80a615b2123af1f5f94c11e3e9402c3ac558f500199d95b6d3e301758586281dcd26"
-        )
-      }
+      eval("std.sha3('')") ==> ujson.Str(
+        "a69f73cca23a9ac5c8b567dc185a756e97c982164fe25859e0d1dcc1475c80a615b2123af1f5f94c11e3e9402c3ac558f500199d95b6d3e301758586281dcd26"
+      )
     }
     test {
       eval("std.sha1('foo')") ==> ujson.Str("0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33")
@@ -29,11 +25,9 @@ object StdShasTests extends TestSuite {
       eval("std.sha512('foo')") ==> ujson.Str(
         "f7fbba6e0636f890e56fbbf3283e524c6fa3204ae298382d624741d0dc6638326e282c41be5e4254d8820772c5518a2c5a8c0c7f7eda19594a7eb539453e1ed7"
       )
-      if (!isScalaNative) {
-        eval("std.sha3('foo')") ==> ujson.Str(
-          "4bca2b137edc580fe50a88983ef860ebaca36c857b1f492839d6d7392452a63c82cbebc68e3b70a2a1480b4bb5d437a7cba6ecf9d89f9ff3ccd14cd6146ea7e7"
-        )
-      }
+      eval("std.sha3('foo')") ==> ujson.Str(
+        "4bca2b137edc580fe50a88983ef860ebaca36c857b1f492839d6d7392452a63c82cbebc68e3b70a2a1480b4bb5d437a7cba6ecf9d89f9ff3ccd14cd6146ea7e7"
+      )
     }
   }
 }


### PR DESCRIPTION
Add support for sha3 in native and fix the golden file for the smoke tests (double rounding error) 