### PR TITLE
fix: Indentation of empty lines in YamlRenderer.

### DIFF
--- a/sjsonnet/src/sjsonnet/YamlRenderer.scala
+++ b/sjsonnet/src/sjsonnet/YamlRenderer.scala
@@ -78,10 +78,13 @@ class YamlRenderer(
 
   override def flushBuffer(): Unit = {
     if (newlineBuffered) {
-      // drop space between colon and newline
+      // drop space between colon/dash and newline
       elemBuilder.writeOutToIfLongerThan(_out, 0)
       if (outBuffer.length() > 1 && outBuffer.charAt(outBuffer.length() - 1) == ' ') {
-        outBuffer.setLength(outBuffer.length() - 1)
+        val ch = outBuffer.charAt(outBuffer.length() - 2)
+        if (ch == ':' || ch == '-') {
+          outBuffer.setLength(outBuffer.length() - 1)
+        }
       }
       YamlRenderer.writeIndentation(elemBuilder, indent * depth)
       flushCharBuilder()

--- a/sjsonnet/test/src/sjsonnet/YamlRendererTests.scala
+++ b/sjsonnet/test/src/sjsonnet/YamlRendererTests.scala
@@ -37,6 +37,12 @@ object YamlRendererTests extends TestSuite {
       """k0: "v0"
         |k1: "(\\d+)"""".stripMargin
     }
+    test("emptyLineIndent") {
+      ujson
+        .transform(ujson.Obj("k" -> "a\n\nb\n"), new YamlRenderer(quoteKeys = false))
+        .toString() ==>
+      "k: |\n  a\n  \n  b"
+    }
   }
 
 }


### PR DESCRIPTION
Problem: Empty lines are not indented properly in the YAML output:
```
$ { echo a; echo; echo b; } > file.txt
$ sjsonnet -e 'std.manifestYamlDoc({x:importstr "file.txt"},quote_keys=false)'
"x: |\n  a\n \n  b"
 #          ^
 # The empty line between "a" and "b" only has one space of indentation while
 # the other lines have two...

$ go-jsonnet -e 'std.manifestYamlDoc({x:importstr "file.txt"},quote_keys=false)'
"x: |\n  a\n  \n  b"
```