### PR TITLE
fix(js,native): std.parseYaml() handling of "---".

### DIFF
--- a/sjsonnet/src-js/sjsonnet/Platform.scala
+++ b/sjsonnet/src-js/sjsonnet/Platform.scala
@@ -42,8 +42,10 @@ object Platform {
       Error.fail("Unsupported YAML node type: " + node.getClass.getSimpleName)
   }
 
+  private val docSplitPattern = Pattern.compile("(^|\n)---\\s*(\n|$)")
+
   def yamlToJson(s: String): ujson.Value = {
-    val docs = s.split("---\\s*\n")
+    val docs = docSplitPattern.split(s, -1)
     docs.size match {
       case 0 => ujson.Obj()
       case 1 =>

--- a/sjsonnet/src-native/sjsonnet/Platform.scala
+++ b/sjsonnet/src-native/sjsonnet/Platform.scala
@@ -76,8 +76,10 @@ object Platform {
       Error.fail("Unsupported YAML node type: " + node.getClass.getSimpleName)
   }
 
+  private val docSplitPattern = Pattern.compile("(?m)^---\\s*$")
+
   def yamlToJson(s: String): ujson.Value = {
-    val docs = s.split("---\\s*\n")
+    val docs = docSplitPattern.split(s, -1)
     docs.size match {
       case 0 => ujson.Obj()
       case 1 =>
@@ -93,9 +95,9 @@ object Platform {
         val buf = new mutable.ArrayBuffer[ujson.Value](docs.size)
         for (doc <- docs) {
           doc.asNode match {
-            case Right(n)                          => buf += nodeToJson(n)
-            case Left(e) if docs.head.trim.isEmpty =>
-            case Left(e)                           =>
+            case Right(n)               => buf += nodeToJson(n)
+            case Left(e) if doc.isEmpty =>
+            case Left(e)                =>
               Error.fail("Error converting YAML to JSON: " + e.getMessage)
           }
         }

--- a/sjsonnet/test/src/sjsonnet/ParseYamlTests.scala
+++ b/sjsonnet/test/src/sjsonnet/ParseYamlTests.scala
@@ -19,6 +19,16 @@ object ParseYamlTests extends TestSuite {
       )
     }
     test {
+      eval("std.parseYaml('---  \nfoo: bar\n---\nbar: baz\n')") ==> ujson.Value(
+        """[{"foo": "bar"}, {"bar": "baz"}]"""
+      )
+    }
+    test {
+      eval("std.parseYaml('---a: 1\nb---: 2\nc: 3---\nd: ---4')") ==> ujson.Value(
+        """{"---a": 1, "b---": 2, "c": "3---", "d": "---4"}"""
+      )
+    }
+    test {
       eval(
         """std.parseYaml(@'{"a":"\"\\n\n\r\f\b\t""" + "\\u263A" + "\"}') {l: std.length(self.a)}"
       ) ==> ujson.Value(


### PR DESCRIPTION
Problem: On js and native targets std.parseYaml() mishandles input where "---" is not at the beginning of the line. (The jvm target is fine.)

Fix: Only match "---" at the beginning of the line. Also don't require a newline after it.

Note that there are other corner cases that are still broken, but for those I'll file a bug against the underlying scala-yaml library.