### PR TITLE
fix(jvm): Let the importer read any path that exists and is not a directory.

### DIFF
--- a/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMainBase.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMainBase.scala
@@ -41,7 +41,7 @@ object SjsonnetMainBase {
             }
             allowed
           })
-          .find(os.exists)
+          .find(f => os.exists(f) && !os.isDir(f))
           .orElse({
             if (debugImporter) {
               System.err.println(s"[import $importName] none of the candidates exist")
@@ -50,7 +50,9 @@ object SjsonnetMainBase {
           })
           .flatMap(p => {
             if (debugImporter) {
-              System.err.println(s"[import $importName] $p is selected as it exists")
+              System.err.println(
+                s"[import $importName] $p is selected as it exists and is not a directory"
+              )
             }
             Some(OsPath(p))
           })
@@ -353,7 +355,7 @@ object SjsonnetMainBase {
       binaryData: Boolean,
       debugImporter: Boolean = false): Option[ResolvedFile] = {
     val osPath = path.asInstanceOf[OsPath].p
-    if (os.exists(osPath) && os.isFile(osPath)) {
+    if (os.exists(osPath) && !os.isDir(osPath)) {
       Some(
         new CachedResolvedFile(
           path.asInstanceOf[OsPath],
@@ -363,7 +365,7 @@ object SjsonnetMainBase {
       )
     } else {
       if (debugImporter) {
-        System.err.println(s"[read $path] file does not exist or is not a file")
+        System.err.println(s"[read $path] file does not exist or is a directory")
       }
       None
     }


### PR DESCRIPTION
This makes `/dev/stdin` work again in `--tla-code-file`, at least on the jvm target. See https://github.com/databricks/sjsonnet/issues/448

My https://github.com/databricks/sjsonnet/pull/432 broke it.

```
$ echo '{a:1}' | sjsonnet-0.5.2.jar --tla-code-file f=/dev/stdin -e 'function(f)f'
{
   "a": 1
}

$ echo '{a:1}' | sjsonnet-master-36ecd2a7448d77b729786dd6336029475aba0eae.jar \
  --debug-importer --tla-code-file f=/dev/stdin -e 'function(f)f'
[import /dev/stdin] candidate /dev/stdin
[import /dev/stdin] /dev/stdin is selected as it exists
[read OsPath(/dev/stdin)] file does not exist or is not a file
[read OsPath(/home/r/git/upstream/sjsonnet/<tla-var f>)] file does not exist or is not a file
Exception in thread "main" sjsonnet.Error: Couldn't import file: "/dev/stdin"
	at [Import].(<tla-var f> offset:0)
	at [ValidId f].(<exec>:1:12)

$ echo '{a:1}' | ./out/sjsonnet/jvm/3.3.6/assembly.dest/out.jar --tla-code-file f=/dev/stdin -e 'function(f)f'
{
   "a": 1
}