### PR TITLE
chore: Make Error#formatError accept Throwable.

### DIFF
--- a/sjsonnet/src/sjsonnet/Error.scala
+++ b/sjsonnet/src/sjsonnet/Error.scala
@@ -74,12 +74,15 @@ object Error {
   def fail(msg: String): Nothing =
     throw new Error(msg)
 
-  def formatError(e: Error): String = {
+  def formatError(e: Throwable): String = {
     val s = new StringWriter()
     val p = new PrintWriter(s)
-    e.printStackTrace(p)
-    p.close()
-    s.toString.replace("\t", "    ")
+    try {
+      e.printStackTrace(p)
+      s.toString.replace("\t", "    ")
+    } finally {
+      p.close()
+    }
   }
 }
 


### PR DESCRIPTION
Motivation:
Make Error#formatError accept Throwable, and then I can use it elsewhere.