### PR TITLE
Fix mill test sources issue that stopped language/platform-specific test suites from running

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -99,11 +99,13 @@ object sjsonnet extends VersionFileModule {
     def moduleDir = super.moduleDir / os.up
     def scalaJSVersion = "1.17.0"
     def moduleKind = Task { ModuleKind.CommonJSModule }
-    def sources = Task.Sources(
-      this.moduleDir / "src",
-      this.moduleDir / "src-js",
-      this.moduleDir / "src-jvm-js"
+    val sourceDirs = Seq(
+      "src",
+      "src-js",
+      "src-jvm-js"
     )
+    def sources = Task.Sources(sourceDirs.map(d => this.moduleDir / d)*)
+
     def mvnDeps = super.mvnDeps() ++
       Seq(
         mvn"org.virtuslab::scala-yaml::0.3.0"
@@ -116,6 +118,7 @@ object sjsonnet extends VersionFileModule {
         this.moduleDir / "resources" / "go_test_suite",
         this.moduleDir / "resources" / "new_test_suite",
       )
+      def sources = Task.Sources(sourceDirs.map(d => this.moduleDir / d)*)
       def generatedSources = Task {
         resources().map(_.path).flatMap { testSuite =>
           val fileNames = os
@@ -185,11 +188,13 @@ object sjsonnet extends VersionFileModule {
       with SjsonnetJvmNative {
     def moduleDir = super.moduleDir / os.up
     def scalaNativeVersion = "0.5.8"
-    def sources = Task.Sources(
-      this.moduleDir / "src",
-      this.moduleDir / "src-native",
-      this.moduleDir / "src-jvm-native"
+    val sourceDirs = Seq(
+      "src",
+      "src-native",
+      "src-jvm-native"
     )
+    def sources = Task.Sources(sourceDirs.map(d => this.moduleDir / d)*)
+
     def mvnDeps = super.mvnDeps() ++
       Seq(
         mvn"com.github.lolgab::scala-native-crypto::0.2.1",
@@ -206,6 +211,7 @@ object sjsonnet extends VersionFileModule {
     object test extends ScalaNativeTests with CrossTests {
       def releaseMode = ReleaseMode.Debug
       def nativeMultithreading = None
+      def sources = Task.Sources(sourceDirs.map(d => this.moduleDir / d)*)
       def forkEnv = super.forkEnv() ++ Map(
         "SCALANATIVE_THREAD_STACK_SIZE" -> stackSize
       )
@@ -221,11 +227,13 @@ object sjsonnet extends VersionFileModule {
       with SjsonnetJvmNative {
     def moduleDir = super.moduleDir / os.up
     def mainClass = Some("sjsonnet.SjsonnetMain")
-    def sources = Task.Sources(
-      this.moduleDir / "src",
-      this.moduleDir / "src-jvm",
-      this.moduleDir / "src-jvm-native"
+    val sourceDirs = Seq(
+      "src",
+      "src-jvm",
+      "src-jvm-native"
     )
+    def sources = Task.Sources(sourceDirs.map(d => this.moduleDir / d)*)
+
     def mvnDeps = super.mvnDeps() ++ Seq(
       mvn"org.tukaani:xz::1.10",
       mvn"org.lz4:lz4-java::1.8.0",
@@ -235,6 +243,7 @@ object sjsonnet extends VersionFileModule {
 
     object test extends ScalaTests with CrossTests {
       def forkArgs = Seq("-Xss" + stackSize)
+      def sources = Task.Sources(sourceDirs.map(d => this.moduleDir / d)*)
     }
 
     object client extends JavaModule with SjsonnetPublishModule {


### PR DESCRIPTION
This PR fixes an issue in the Mill build that was stopped language/platform-specific suites like `FileTests` from being run, leading to a loss of test coverage (notably, the missing tests include the upstream golden file tests). 

I'm not a mill expert and am unsure if this is an _optimal_ fix, but empirically it seems to work based on the testing steps described below.

## The bug

Prior to https://github.com/databricks/sjsonnet/pull/459, the JS and JVM tests both ran test suites that were defined in language-specific source directories (such as `FileTests`, which is defined in `src-js` and `src-jvm-native` directories rather than the shared `src` dir):

```bash
$ ./mill 'sjsonnet.js[2.13.16].test' 2>&1 | grep -E "(FileTests|go_test_suite|test_suite)" | head -3
[141] Checking test_suite/arith_bool.jsonnet
[141] Checking test_suite/arith_float.jsonnet
[141] Checking test_suite/arith_string.jsonnet

$ ./mill 'sjsonnet.jvm[2.13.16].test' 2>&1 | grep -E "(FileTests|go_test_suite|test_suite)" | head -3
[117] + sjsonnet.BufferedRandomAccessFileTests.readChar 4ms  
[117] + sjsonnet.BufferedRandomAccessFileTests.readString 0ms  
[117] + sjsonnet.BufferedRandomAccessFileTests.readChar 0ms  
```

If we looked at these test targets' sources, we see that language-specific source directories are included:

```bash
$ ./mill show 'sjsonnet.jvm[2.13.16].test.sources'
[
  "ref:v0:036fb0dd:/Users/joshrosen/Documents/oss/sjsonnet/sjsonnet/test/src",
  "ref:v0:3f3f627d:/Users/joshrosen/Documents/oss/sjsonnet/sjsonnet/test/src-jvm",
  "ref:v0:9b7be5ed:/Users/joshrosen/Documents/oss/sjsonnet/sjsonnet/test/src-jvm-native"
]

$ ./mill show 'sjsonnet.js[2.13.16].test.sources'
[
  "ref:v0:036fb0dd:/Users/joshrosen/Documents/oss/sjsonnet/sjsonnet/test/src",
  "ref:v0:6ad29257:/Users/joshrosen/Documents/oss/sjsonnet/sjsonnet/test/src-js",
  "ref:v0:c984eca8:/Users/joshrosen/Documents/oss/sjsonnet/sjsonnet/test/src-jvm-js"
]
```

After https://github.com/databricks/sjsonnet/pull/459, which upgraded the Mill version to 1.0.x, a different set of test source paths are used:

```bash
$ ./mill show 'sjsonnet.jvm[2.13.16].test.sources'
[
  "ref:v0:036fb0dd:/Users/joshrosen/Documents/oss/sjsonnet/sjsonnet/test/src",
  "ref:v0:c984eca8:/Users/joshrosen/Documents/oss/sjsonnet/sjsonnet/test/src-2.13.16",
  "ref:v0:c984eca8:/Users/joshrosen/Documents/oss/sjsonnet/sjsonnet/test/src-2.13",
  "ref:v0:c984eca8:/Users/joshrosen/Documents/oss/sjsonnet/sjsonnet/test/src-2"
]

$ ./mill show 'sjsonnet.js[2.13.16].test.sources'
[
  "ref:v0:036fb0dd:/Users/joshrosen/Documents/oss/sjsonnet/sjsonnet/test/src",
  "ref:v0:c984eca8:/Users/joshrosen/Documents/oss/sjsonnet/sjsonnet/test/src-2.13.16",
  "ref:v0:c984eca8:/Users/joshrosen/Documents/oss/sjsonnet/sjsonnet/test/src-2.13",
  "ref:v0:c984eca8:/Users/joshrosen/Documents/oss/sjsonnet/sjsonnet/test/src-2"
]
```

These new paths still include the shared `src` path (so _some_, perhaps _most_, tests continue to run), but the architecture-specific ones are skipped:

```
$ ./mill 'sjsonnet.js[2.13.16].test' 2>&1 | grep -E "(FileTests|go_test_suite|test_suite)" | head -3
# no output
./mill 'sjsonnet.jvm[2.13.16].test' 2>&1 | grep -E "(FileTests|go_test_suite|test_suite)" | head -3
# no output
```

## Fix

I updated each `test` object / module (except for `client` and `server`, which don't do any source directory customization and thus don't need this fix) to explicitly list the source directories. 

Empirically, this restores the old test source paths and the skipped tests are now running.