### PR TITLE
Fix multiple assertion related bugs (inheritance, binding of super in inherited assertions, and timing of evaluation)

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -99,11 +99,13 @@ object sjsonnet extends VersionFileModule {
     def moduleDir = super.moduleDir / os.up
     def scalaJSVersion = "1.17.0"
     def moduleKind = Task { ModuleKind.CommonJSModule }
-    def sources = Task.Sources(
-      this.moduleDir / "src",
-      this.moduleDir / "src-js",
-      this.moduleDir / "src-jvm-js"
+    val sourceDirs = Seq(
+      "src",
+      "src-js",
+      "src-jvm-js"
     )
+    def sources = Task.Sources(sourceDirs.map(d => this.moduleDir / d)*)
+
     def mvnDeps = super.mvnDeps() ++
       Seq(
         mvn"org.virtuslab::scala-yaml::0.3.0"
@@ -116,6 +118,7 @@ object sjsonnet extends VersionFileModule {
         this.moduleDir / "resources" / "go_test_suite",
         this.moduleDir / "resources" / "new_test_suite",
       )
+      def sources = Task.Sources(sourceDirs.map(d => this.moduleDir / d)*)
       def generatedSources = Task {
         resources().map(_.path).flatMap { testSuite =>
           val fileNames = os
@@ -185,11 +188,13 @@ object sjsonnet extends VersionFileModule {
       with SjsonnetJvmNative {
     def moduleDir = super.moduleDir / os.up
     def scalaNativeVersion = "0.5.8"
-    def sources = Task.Sources(
-      this.moduleDir / "src",
-      this.moduleDir / "src-native",
-      this.moduleDir / "src-jvm-native"
+    val sourceDirs = Seq(
+      "src",
+      "src-native",
+      "src-jvm-native"
     )
+    def sources = Task.Sources(sourceDirs.map(d => this.moduleDir / d)*)
+
     def mvnDeps = super.mvnDeps() ++
       Seq(
         mvn"com.github.lolgab::scala-native-crypto::0.2.1",
@@ -206,6 +211,7 @@ object sjsonnet extends VersionFileModule {
     object test extends ScalaNativeTests with CrossTests {
       def releaseMode = ReleaseMode.Debug
       def nativeMultithreading = None
+      def sources = Task.Sources(sourceDirs.map(d => this.moduleDir / d)*)
       def forkEnv = super.forkEnv() ++ Map(
         "SCALANATIVE_THREAD_STACK_SIZE" -> stackSize
       )
@@ -221,11 +227,13 @@ object sjsonnet extends VersionFileModule {
       with SjsonnetJvmNative {
     def moduleDir = super.moduleDir / os.up
     def mainClass = Some("sjsonnet.SjsonnetMain")
-    def sources = Task.Sources(
-      this.moduleDir / "src",
-      this.moduleDir / "src-jvm",
-      this.moduleDir / "src-jvm-native"
+    val sourceDirs = Seq(
+      "src",
+      "src-jvm",
+      "src-jvm-native"
     )
+    def sources = Task.Sources(sourceDirs.map(d => this.moduleDir / d)*)
+
     def mvnDeps = super.mvnDeps() ++ Seq(
       mvn"org.tukaani:xz::1.10",
       mvn"org.lz4:lz4-java::1.8.0",
@@ -235,6 +243,7 @@ object sjsonnet extends VersionFileModule {
 
     object test extends ScalaTests with CrossTests {
       def forkArgs = Seq("-Xss" + stackSize)
+      def sources = Task.Sources(sourceDirs.map(d => this.moduleDir / d)*)
     }
 
     object client extends JavaModule with SjsonnetPublishModule {

--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -726,7 +726,7 @@ class Evaluator(
         if (k != null) {
           val v = new Val.Obj.Member(plus, sep) {
             def invoke(self: Val.Obj, sup: Val.Obj, fs: FileScope, ev: EvalScope): Val = {
-              self.triggerAllAsserts(self)
+              self.triggerAllAsserts()
               visitExpr(rhs)(makeNewScope(self, sup))
             }
           }
@@ -737,7 +737,7 @@ class Evaluator(
         if (k != null) {
           val v = new Val.Obj.Member(false, sep) {
             def invoke(self: Val.Obj, sup: Val.Obj, fs: FileScope, ev: EvalScope): Val = {
-              self.triggerAllAsserts(self)
+              self.triggerAllAsserts()
               visitMethod(rhs, argSpec, offset)(makeNewScope(self, sup))
             }
           }
@@ -882,8 +882,8 @@ class Evaluator(
           val k2 = y.visibleKeyNames
           val k1len = k1.length
           if (k1len != k2.length) return false
-          x.triggerAllAsserts(x)
-          y.triggerAllAsserts(y)
+          x.triggerAllAsserts()
+          y.triggerAllAsserts()
           var i = 0
           while (i < k1len) {
             val k = k1(i)

--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -721,7 +721,6 @@ class Evaluator(
         if (k != null) {
           val v = new Val.Obj.Member(plus, sep) {
             def invoke(self: Val.Obj, sup: Val.Obj, fs: FileScope, ev: EvalScope): Val = {
-              self.triggerAllAsserts()
               visitExpr(rhs)(makeNewScope(self, sup))
             }
           }
@@ -732,7 +731,6 @@ class Evaluator(
         if (k != null) {
           val v = new Val.Obj.Member(false, sep) {
             def invoke(self: Val.Obj, sup: Val.Obj, fs: FileScope, ev: EvalScope): Val = {
-              self.triggerAllAsserts()
               visitMethod(rhs, argSpec, offset)(makeNewScope(self, sup))
             }
           }

--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -666,14 +666,9 @@ class Evaluator(
       } else createNewScope(self, sup)
     }
 
-    // We need to avoid asserting the same object more than once to prevent
-    // infinite recursion, but the previous implementation had the `asserting`
-    // flag kept under the object's *instantiation* rather than under the
-    // object itself. That means that objects that are instantiated once then
-    // extended multiple times would only trigger the assertions once, rather
-    // than once per extension.
-    def assertions(self: Val.Obj): Unit = if (!self.asserting) {
-      self.asserting = true
+    // Trigger an object's own assertions. This defines a closure which is
+    // invoked from within Val.Obj; it should not be called directly.
+    def triggerAsserts(self: Val.Obj): Unit = {
       val newScope: ValScope = makeNewScope(self, self.getSuper)
       var i = 0
       while (i < asserts.length) {
@@ -755,7 +750,7 @@ class Evaluator(
       objPos,
       builder,
       false,
-      if (asserts != null) assertions else null,
+      if (asserts != null) triggerAsserts else null,
       sup,
       valueCache
     )

--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -726,7 +726,7 @@ class Evaluator(
         if (k != null) {
           val v = new Val.Obj.Member(plus, sep) {
             def invoke(self: Val.Obj, sup: Val.Obj, fs: FileScope, ev: EvalScope): Val = {
-              if (asserts != null) assertions(self)
+              self.triggerAllAsserts(self)
               visitExpr(rhs)(makeNewScope(self, sup))
             }
           }
@@ -737,7 +737,7 @@ class Evaluator(
         if (k != null) {
           val v = new Val.Obj.Member(false, sep) {
             def invoke(self: Val.Obj, sup: Val.Obj, fs: FileScope, ev: EvalScope): Val = {
-              if (asserts != null) assertions(self)
+              self.triggerAllAsserts(self)
               visitMethod(rhs, argSpec, offset)(makeNewScope(self, sup))
             }
           }

--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -668,8 +668,8 @@ class Evaluator(
 
     // Trigger an object's own assertions. This defines a closure which is
     // invoked from within Val.Obj; it should not be called directly.
-    def triggerAsserts(self: Val.Obj): Unit = {
-      val newScope: ValScope = makeNewScope(self, self.getSuper)
+    def triggerAsserts(self: Val.Obj, sup: Val.Obj): Unit = {
+      val newScope: ValScope = makeNewScope(self, sup)
       var i = 0
       while (i < asserts.length) {
         val a = asserts(i)

--- a/sjsonnet/src/sjsonnet/Materializer.scala
+++ b/sjsonnet/src/sjsonnet/Materializer.scala
@@ -22,7 +22,7 @@ abstract class Materializer {
       case Val.Str(pos, s) => storePos(pos); visitor.visitString(s, -1)
       case obj: Val.Obj    =>
         storePos(obj.pos)
-        obj.triggerAllAsserts(obj)
+        obj.triggerAllAsserts()
         val objVisitor = visitor.visitObject(obj.visibleKeyNames.length, jsonableKeys = true, -1)
         val sort = !evaluator.settings.preserveOrder
         var prevKey: String = null

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -437,6 +437,7 @@ object Val {
           case null =>
             if (s == null) null else s.valueRaw(k, self, pos, addTo, addKey)
           case m =>
+            self.triggerAllAsserts()
             val vv = m.invoke(self, s, pos.fileScope, evaluator)
             val v = if (s != null && m.add) {
               s.valueRaw(k, self, pos, null, null) match {

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -284,7 +284,11 @@ object Val {
       value0
     }
 
-    @tailrec def triggerAllAsserts(obj: Val.Obj): Unit = {
+    def triggerAllAsserts(): Unit = {
+      triggerAllAsserts(this)
+    }
+
+    @tailrec private def triggerAllAsserts(obj: Val.Obj): Unit = {
       if (triggerAsserts != null) triggerAsserts(obj)
       if (`super` != null) `super`.triggerAllAsserts(obj)
     }

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -265,7 +265,7 @@ object Val {
       private var allKeys: util.LinkedHashMap[String, java.lang.Boolean] = null)
       extends Literal
       with Expr.ObjBody {
-    private[this] var asserting: Boolean = false
+    private var asserting: Boolean = false
 
     def getSuper: Obj = `super`
 

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -265,7 +265,7 @@ object Val {
       private var allKeys: util.LinkedHashMap[String, java.lang.Boolean] = null)
       extends Literal
       with Expr.ObjBody {
-    var asserting: Boolean = false
+    private var asserting: Boolean = false
 
     def getSuper: Obj = `super`
 
@@ -285,7 +285,12 @@ object Val {
     }
 
     def triggerAllAsserts(): Unit = {
-      triggerAllAsserts(this)
+      // We need to avoid asserting the same object more than once to prevent
+      // infinite recursion
+      if (!asserting) {
+        asserting = true
+        triggerAllAsserts(this)
+      }
     }
 
     @tailrec private def triggerAllAsserts(obj: Val.Obj): Unit = {

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -265,7 +265,7 @@ object Val {
       private var allKeys: util.LinkedHashMap[String, java.lang.Boolean] = null)
       extends Literal
       with Expr.ObjBody {
-    private var asserting: Boolean = false
+    private[this] var asserting: Boolean = false
 
     def getSuper: Obj = `super`
 

--- a/sjsonnet/test/resources/go_test_suite/object_invariant_plus.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/object_invariant_plus.jsonnet.golden
@@ -1,13 +1,3 @@
-RUNTIME ERROR: Object assertion failed.
--------------------------------------------------
-	testdata/object_invariant_plus:1:2-14	
-
-{assert false} + {assert true}
-
--------------------------------------------------
-	Checking object assertions	
-
--------------------------------------------------
-	During manifestation	
-
+sjsonnet.Error: Assertion failed
+    at [Assert].(object_invariant_plus.jsonnet:1:9)
 

--- a/sjsonnet/test/src-js/sjsonnet/FileTests.scala
+++ b/sjsonnet/test/src-js/sjsonnet/FileTests.scala
@@ -16,7 +16,6 @@ object FileTests extends BaseFileTests {
   )
 
   val goTestDataSkippedTests: Set[String] = Set(
-    "object_invariant_plus.jsonnet",
     "builtinSha1.jsonnet",
     "builtinSha256.jsonnet",
     "builtinSha3.jsonnet",

--- a/sjsonnet/test/src-jvm-native/sjsonnet/FileTests.scala
+++ b/sjsonnet/test/src-jvm-native/sjsonnet/FileTests.scala
@@ -16,9 +16,7 @@ object FileTests extends BaseFileTests {
       )
     else Set.empty[String]
 
-  val goTestDataSkippedTests: Set[String] = Set(
-    "object_invariant_plus.jsonnet"
-  )
+  val goTestDataSkippedTests: Set[String] = Set.empty
 
   val tests: Tests = Tests {
     test("test_suite") - {

--- a/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
+++ b/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
@@ -692,6 +692,20 @@ object EvaluatorTests extends TestSuite {
           "sjsonnet.Error: Assertion failed"
         )
       )
+      // Both own and inherited assertions are evaluated:
+      test - assert(
+        evalErr("{assert false} + {assert true}", useNewEvaluator = useNewEvaluator).contains(
+          "sjsonnet.Error: Assertion failed"
+        )
+      )
+      // Accessing an object member should trigger computation of that object's own
+      // assertions plus any inherited assertions, even if the accessed member happens
+      // to be a constant.
+      test - assert(
+        evalErr("({assert false} + {x: 2}).x", useNewEvaluator = useNewEvaluator).contains(
+          "sjsonnet.Error: Assertion failed"
+        )
+      )
       test - {
         val problematicStrictInheritedAssertionsSnippet =
           """local template = { assert self.flag };

--- a/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
+++ b/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
@@ -706,6 +706,11 @@ object EvaluatorTests extends TestSuite {
           "sjsonnet.Error: Assertion failed"
         )
       )
+      test - assert(
+        evalErr("({assert false} + {f(x): x}).f(1)", useNewEvaluator = useNewEvaluator).contains(
+          "sjsonnet.Error: Assertion failed"
+        )
+      )
       test - {
         val problematicStrictInheritedAssertionsSnippet =
           """local template = { assert self.flag };


### PR DESCRIPTION
This PR files multiple assertion-related bugs:

- **Inheritance**:
  -  https://github.com/databricks/sjsonnet/issues/439, where inherited object assertions would be skipped if assertions existed lower down in the object inheritance hierarchy (e.g. `{assert false} + {assert true}` would incorrectly pass because the inherited assertions would be skipped, whereas `{assert false} + {x: 2}` would fail because the child lacks its own assertions).
-  **Timing of assertion evaluation**: 
    - Per the `object-index` rule [in the jsonnet spec](https://jsonnet.org/ref/spec.html#execution), accesses of an object member are supposed to require/trigger all object assertions, but `sjsonnet` was skipping this in certain cases. For example, `{assert false} + {x: 2}).x` fails in jsonnet / go-jsonnet but erroneously succeeded in sjsonnet.
- **Binding of `super` in inherited assertions**:
  - The program `{x: 1} + {x: 2, assert super.x == 1 } + {x: 3}` is supposed succeed and print `{x: 3}` but in sjsonnet it fails because the `super.x` was resolving to `2` instead of `1`. 
  - The existing [object_invariant_plus5.jsonnet](https://github.com/databricks/sjsonnet/blob/master/sjsonnet/test/resources/go_test_suite/object_invariant_plus5.jsonnet) test case ought to have caught this issue, but it was "passing by accident" due to the assertion inheritance bug. 

This PR fixes all three issues and I think it's an overall simplification of the assertion handling logic:

- Move more of the assertion logic into `Val.Obj` and consolidate on` Obj.triggerAllAsserts()` as the sole way to trigger object assertions:
  - The old code had a discrepancy where the materializer used `obj.triggerAllAsserts(obj)` whereas some member accesses would directly invoke the `assertions `closure created by the Evaluator (which ignores inherited assertions).
  - Previously, the `asserting` flag was checked at every level of tail recursion and this was responsible for inherited assertions being skipped: once one layer evaluated assertions and set `asserting = true`, subsequent layers would bail out due to a `!asserting` check. Now we check the flag once in the "public" zero-parameter `triggerAllAsserts()` method but don't re-check it at each layer of recursion through superclasses.
  - Move access-time assertion triggering into `Obj.valueRaw`: this ensures that _all_ accesses will trigger assertions. Previously, only members created in `Evaluator` would perform these checks, causing them to be skipped for `ConstMember` and other special cases.
    - Note that this should not affect the performance of static objects: sjsonnet prohibits assertions in static objects and the new code is only invoked in paths guarded by `!static`.
- Pass an explicit `super` scope into `assertions` thunk: previously, the assertions thunk created by the evaluator called `makeNewScope(self, self.getSuper)` but `super` in an assertion refers to the superclass of the _definition_ site. We now explicitly pass in a superclass, ensuring that it resolves correctly as we walk up the inheritance chain and invoke inherited assertions.

I added a few new test cases in `EvaluatorTests`, in addition to enabling the previously-skipped test case from `go-jsonnet`.