### PR TITLE
Fix detection of duplicate fields with dynamic field name expressions

### DIFF
--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -768,8 +768,7 @@ class Evaluator(
     for (s <- visitComp(e.first :: e.rest, Array(compScope))) {
       visitExpr(e.key)(s) match {
         case Val.Str(_, k) =>
-          val prev_length = builder.size()
-          builder.put(
+          val previousValue = builder.put(
             k,
             new Val.Obj.Member(e.plus, Visibility.Normal) {
               def invoke(self: Val.Obj, sup: Val.Obj, fs: FileScope, ev: EvalScope): Val = {
@@ -782,7 +781,7 @@ class Evaluator(
               }
             }
           )
-          if (prev_length == builder.size()) {
+          if (previousValue != null) {
             Error.fail(s"Duplicate key $k in evaluated object comprehension.", e.pos)
           }
         case Val.Null(_) => // do nothing

--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -724,7 +724,10 @@ class Evaluator(
               visitExpr(rhs)(makeNewScope(self, sup))
             }
           }
-          builder.put(k, v)
+          val previousValue = builder.put(k, v)
+          if (previousValue != null) {
+            Error.fail(s"Duplicate key $k in evaluated object.", offset)
+          }
         }
       case Member.Field(offset, fieldName, false, argSpec, sep, rhs) =>
         val k = visitFieldName(fieldName, offset)
@@ -734,7 +737,10 @@ class Evaluator(
               visitMethod(rhs, argSpec, offset)(makeNewScope(self, sup))
             }
           }
-          builder.put(k, v)
+          val previousValue = builder.put(k, v)
+          if (previousValue != null) {
+            Error.fail(s"Duplicate key $k in evaluated object.", offset)
+          }
         }
       case _ =>
         Error.fail("This case should never be hit", objPos)


### PR DESCRIPTION
This PR fixes a bug in the detection of duplicate fields:

Official `jsonnet` and `go-jsonnet` both detect and fail on duplicate field names even when the field names are dynamically computed via [field name expression](https://jsonnet.org/ref/language.html#field-name-expressions):

```jsonnet
{ k: 1, ["k"]: 2 }
```

produces

```
Error: RUNTIME ERROR: Duplicate field name: "k"
	example1.jsonnet:1:1-19	$
	During evaluation	
```

However, sjsonnet currently accepts this and outputs 

```
{"k" : 2}
```

with a last-assignment-wins policy.

sjsonnet already correctly detects _literal_ field name duplication [at parse time](https://github.com/databricks/sjsonnet/blob/0.5.4/sjsonnet/src/sjsonnet/Parser.scala#L401-L413) (e.g. `{k: 1, k: 2}`) and detects field name duplication in object comprehensions at both [parse](https://github.com/databricks/sjsonnet/blob/0.5.4/sjsonnet/src/sjsonnet/Parser.scala#L472-L497) and [evaluation](https://github.com/databricks/sjsonnet/blob/0.5.4/sjsonnet/src/sjsonnet/Evaluator.scala#L771-L788) time (see #100 and #156).

This PR adds duplicate field name detection at normal object evaluation time. The core check is simple and cheap: when adding a member to the object's fields hashmap, check the `put()` return value and fail if we detect that a duplicate key has been inserted. 

One subtlety to handle involves sjsonnet's static object optimizations: it's possible that we might detect duplicates during static optimization because a dynamic field expression might be constant-folded / statically optimized into a fixed literal. Even though we can detect this at optimization time, we must defer the throwing of an error until the object is actually evaluated or accessed during program execution: this is necessary in order to faithfully preserve lazy evaluation semantics. I chose to handle this by rendering such objects ineligible for static optimization: they will remain as `MemberList`s.

I added new regression tests in EvaluatorSuite to cover this bug and confirmed that the expected behavior matches the jsonnet and go-jsonnet implementations.