### PR TITLE
Fix scala native building issues and update mill

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1,4 +1,4 @@
-//| mill-version: 1.0.2
+//| mill-version: 1.0.3-jvm
 //| mvnDeps:
 //| - com.lihaoyi::mill-contrib-jmh:$MILL_VERSION
 //| - com.lihaoyi::mill-contrib-versionfile:$MILL_VERSION
@@ -201,8 +201,9 @@ object sjsonnet extends VersionFileModule {
         mvn"org.virtuslab::scala-yaml::0.3.0"
       )
 
-    def nativeLinkingOptions = super.nativeLinkingOptions() ++
-      Seq("-L/usr/local/opt/openssl@3/lib")
+    val osName = System.getProperty("os.name").toLowerCase
+
+    def nativeLinkingOptions = super.nativeLinkingOptions() ++ (if (osName == "linux") Seq("-static") else Seq())
 
     def releaseMode = ReleaseMode.ReleaseFull
     def nativeLTO = LTO.Full


### PR DESCRIPTION
- Update mill to 1.0.3 and force to use the JVM version instead of the native version (issues in recent ubuntu -  https://github.com/com-lihaoyi/mill/issues/5508)
- compile statically by default in Linux