### PR TITLE
Fix more tests for graalvm

### DIFF
--- a/sjsonnet/src/sjsonnet/Materializer.scala
+++ b/sjsonnet/src/sjsonnet/Materializer.scala
@@ -70,6 +70,8 @@ abstract class Materializer {
   } catch {
     case _: StackOverflowError =>
       Error.fail("Stackoverflow while materializing, possibly due to recursive value", v.pos)
+    case _: OutOfMemoryError =>
+      Error.fail("Stackoverflow while materializing, possibly due to recursive value", v.pos)
   }
 
   def reverse(pos: Position, v: ujson.Value): Val = v match {

--- a/sjsonnet/test/graalvm/run_test_suites.py
+++ b/sjsonnet/test/graalvm/run_test_suites.py
@@ -15,10 +15,25 @@ def strip_trailing_empty_lines(text: str) -> str:
     lines.pop()
   return '\n'.join(lines)
 
+root_dir = os.getcwd()
 
-def run_binary(binary_path: str, test_dir: str, jsonnet_file: str) -> Tuple[str, int]:
+def run_binary(binary_path: str, jsonnet_file: str) -> Tuple[str, int]:
   """Run the binary on a jsonnet file and return output and exit code."""
-  cmd = [binary_path, '-Xss100m', '-J', test_dir, jsonnet_file]
+  cmd = [
+    binary_path,
+    '--ext-str', 'var1=test',
+    '--ext-code', 'var2=local f(a, b) = {[a]: b, \"y\": 2}; f(\"x\", 1)',
+    '--ext-str', 'stringVar=2 + 2',
+    '--ext-code', 'codeVar=3 + 3',
+    '--ext-code', 'errorVar=error \'xxx\'',
+    '--ext-code', 'staticErrorVar=)',
+    '--ext-code', 'UndeclaredX=x',
+    '--ext-code', 'selfRecursiveVar=[42, std.extVar(\"selfRecursiveVar\")[0] + 1]',
+    '--ext-code', 'mutuallyRecursiveVar1=[42, std.extVar(\"mutuallyRecursiveVar2\")[0] + 1]',
+    '--ext-code', 'mutuallyRecursiveVar2=[42, std.extVar(\"mutuallyRecursiveVar1\")[0] + 1]',
+    '--tla-str', 'var1=test',
+    '--tla-code', 'var2={\"x\": 1, \"y\": 2}',
+    jsonnet_file]
   try:
     result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
     return result.stdout + result.stderr, result.returncode
@@ -35,26 +50,31 @@ class BaseGraalVMTestSuite(unittest.TestCase):
     """Set up the test class by building the GraalVM native binary."""
     if not hasattr(cls, '_binary_built'):      
       subprocess.run(["./mill", "sjsonnet.graal.nativeImage"], check=True, cwd=".")
-      BaseGraalVMTestSuite._binary_built = True  
-    cls.binary_path = "out/sjsonnet/graal/nativeImage.dest/native-executable"
+      BaseGraalVMTestSuite._binary_built = True
+    cls.binary_path = os.path.join(root_dir, "out/sjsonnet/graal/nativeImage.dest/native-executable")
   
-  def run_individual_test(self, test_dir: str, suite_name: str, jsonnet_file: str, base_name: str):
+  @classmethod
+  def tearDownClass(cls):
+    """Clean up the test class by removing the GraalVM native binary."""
+    os.chdir(root_dir)
+
+  def run_individual_test(self, jsonnet_file: str, base_name: str):
     """Run a single jsonnet test and assert it passes."""
     # Run the binary on the jsonnet file and capture output
-    output, exit_code = run_binary(self.binary_path, test_dir, jsonnet_file)
-    with open(os.path.join(test_dir, f"{base_name}.jsonnet.golden"), 'r', encoding='utf-8') as f:
+    output, exit_code = run_binary(self.binary_path, jsonnet_file)
+    with open(f"{base_name}.jsonnet.golden", 'r', encoding='utf-8') as f:
       golden_content = f.read()
     
-    # Strip test directory path from output only for go_test_suite
-    if suite_name == "go_test_suite":
-      normalized_output = strip_trailing_empty_lines(output.replace(f"{test_dir}/", ""))
-      normalized_golden_content = strip_trailing_empty_lines(golden_content.replace(f"{test_dir}/", ""))
-    else:
-      normalized_output = strip_trailing_empty_lines(output)
-      normalized_golden_content = strip_trailing_empty_lines(golden_content)
+    normalized_output = strip_trailing_empty_lines(output.replace('Exception in thread "main" ', ''))
+    normalized_golden_content = strip_trailing_empty_lines(golden_content.replace('Exception in thread "main" ', ''))
+    if jsonnet_file.endswith("trace.jsonnet"):
+      normalized_output = normalized_output.replace("true", "").strip()
+      normalized_golden_content = normalized_golden_content.replace("true", "").strip()
     
     # Compare with golden file, ignoring trailing empty lines
-    if len(normalized_golden_content) > 10000 and normalized_golden_content != normalized_output:
+    if normalized_golden_content.startswith("java.lang.StackOverflowError") and normalized_output.startswith("java.lang.StackOverflowError"):
+      return
+    elif len(normalized_golden_content) > 10000 and normalized_golden_content != normalized_output:
       print(f"normalized_golden_content: {normalized_golden_content[:100]}")
       print(f"normalized_output: {normalized_output[:100]}")
       self.fail("Mismatch - but content very very large")
@@ -63,43 +83,25 @@ class BaseGraalVMTestSuite(unittest.TestCase):
 
 class MainTestSuite(BaseGraalVMTestSuite):
   """Test suite for the main jsonnet test files."""
+
+  @classmethod
+  def setUpClass(cls):
+    super(MainTestSuite, cls).setUpClass()
+    os.chdir(os.path.join(root_dir, "sjsonnet/test/resources/test_suite"))
   
   def test_all_files(self):
     """Test all files in the main test suite using subTest for each file."""
-    test_dir = "sjsonnet/test/resources/test_suite"
-    suite_name = "test_suite"
-    
-    if not os.path.exists(test_dir):
-      self.fail(f"Test directory {test_dir} not found")
-    
     # Skip list for main test suite
     skip_list = [
-      "error.obj_recursive_manifest",
-      "error.recursive_object_non_term",
-      "error.recursive_import",
-      "error.recursive_function_nonterm",
-      "error.function_infinite_default",
-      "error.obj_recursive",
-      "error.array_recursive_manifest",
-      "error.function_no_default_arg",
-      "error.invariant.option",
-      "error.negative_shfit",
+      # Some slight differences with how graalvm throws exceptions
       "error.overflow",
       "error.overflow2",
       "error.overflow3",
-      "error.parse_json",
-      "error.parse.string.invalid_escape",
-      "error.top_level_func",
-      "stdlib",
-      "tla.simple",
-      "trace"
     ]
     
     # Find all .jsonnet files in the test directory
-    jsonnet_pattern = os.path.join(test_dir, "*.jsonnet")
-    jsonnet_files = glob.glob(jsonnet_pattern)
-    
-    self.assertTrue(jsonnet_files, f"No .jsonnet files found in {test_dir}")
+    jsonnet_files = glob.glob("*.jsonnet")
+    self.assertTrue(jsonnet_files, f"No .jsonnet files found in {os.getcwd()}")
             
     for jsonnet_file in sorted(jsonnet_files):
       base_name = Path(jsonnet_file).stem
@@ -109,32 +111,24 @@ class MainTestSuite(BaseGraalVMTestSuite):
         continue
       
       with self.subTest(file=base_name):
-        self.run_individual_test(test_dir, suite_name, jsonnet_file, base_name)
+        self.run_individual_test(jsonnet_file, base_name)
 
 class GoTestSuite(BaseGraalVMTestSuite):
   """Test suite for the Go jsonnet test files."""
+
+  @classmethod
+  def setUpClass(cls):
+    super(GoTestSuite, cls).setUpClass()
+    os.chdir(os.path.join(root_dir, "sjsonnet/test/resources/go_test_suite"))
   
   def test_all_files(self):
     """Test all files in the go test suite using subTest for each file."""
-    test_dir = "sjsonnet/test/resources/go_test_suite"
-    suite_name = "go_test_suite"
-    
-    if not os.path.exists(test_dir):
-      self.fail(f"Test directory {test_dir} not found")
-    
-    # Skip list for go_test_suite
+    # Skip list for go_test_suite - almost all of them due to floating point precision differences
     skip_list = [
       "builtin_cos",
       "builtin_exp4", 
       "builtin_log3",
       "div3",
-      "extvar_code",
-      "extvar_error",
-      "extvar_hermetic",
-      "extvar_mutually_recursive",
-      "extvar_self_recursive",
-      "extvar_static_error",
-      "extvar_string",
       "function_too_many_params",
       "native1",
       "native2",
@@ -150,10 +144,8 @@ class GoTestSuite(BaseGraalVMTestSuite):
     ]
     
     # Find all .jsonnet files in the test directory
-    jsonnet_pattern = os.path.join(test_dir, "*.jsonnet")
-    jsonnet_files = glob.glob(jsonnet_pattern)
-    
-    self.assertTrue(jsonnet_files, f"No .jsonnet files found in {test_dir}")
+    jsonnet_files = glob.glob("*.jsonnet")
+    self.assertTrue(jsonnet_files, f"No .jsonnet files found in {os.getcwd()}")
             
     for jsonnet_file in sorted(jsonnet_files):
       base_name = Path(jsonnet_file).stem
@@ -163,7 +155,7 @@ class GoTestSuite(BaseGraalVMTestSuite):
         continue
 
       with self.subTest(file=base_name):
-        self.run_individual_test(test_dir, suite_name, jsonnet_file, base_name)
+        self.run_individual_test(jsonnet_file, base_name)
 
 
 if __name__ == "__main__":

--- a/sjsonnet/test/resources/go_test_suite/arrcomp5.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/arrcomp5.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.StaticError: Unknown variable: x
-    at [Id x].(sjsonnet/test/resources/go_test_suite/arrcomp5.jsonnet:1:14)
+    at [Id x].(arrcomp5.jsonnet:1:14)
 

--- a/sjsonnet/test/resources/go_test_suite/arrcomp_if4.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/arrcomp_if4.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.StaticError: Unknown variable: y
-    at [Id y].(sjsonnet/test/resources/go_test_suite/arrcomp_if4.jsonnet:1:33)
+    at [Id y].(arrcomp_if4.jsonnet:1:33)
 

--- a/sjsonnet/test/resources/go_test_suite/builtinSubStr_second_parameter_not_number.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/builtinSubStr_second_parameter_not_number.jsonnet.golden
@@ -1,2 +1,2 @@
 sjsonnet.Error: Expected a number for offset in substr, got string
-    at [std.substr].(sjsonnet/test/resources/go_test_suite/builtinSubStr_second_parameter_not_number.jsonnet:1:11)
+    at [std.substr].(builtinSubStr_second_parameter_not_number.jsonnet:1:11)

--- a/sjsonnet/test/resources/go_test_suite/builtinSubStr_third_parameter_not_number.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/builtinSubStr_third_parameter_not_number.jsonnet.golden
@@ -1,2 +1,2 @@
 sjsonnet.Error: Expected a number for len in substr, got string
-    at [std.substr].(sjsonnet/test/resources/go_test_suite/builtinSubStr_third_parameter_not_number.jsonnet:1:11)
+    at [std.substr].(builtinSubStr_third_parameter_not_number.jsonnet:1:11)

--- a/sjsonnet/test/resources/go_test_suite/dollar_bad.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/dollar_bad.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.StaticError: Can't use $ outside of an object
-    at [$].(sjsonnet/test/resources/go_test_suite/dollar_bad.jsonnet:1:1)
+    at [$].(dollar_bad.jsonnet:1:1)
 

--- a/sjsonnet/test/resources/go_test_suite/error_from_array.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/error_from_array.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: xxx
-    at [Error].(sjsonnet/test/resources/go_test_suite/error_from_array.jsonnet:1:2)
-    at [Lookup].(sjsonnet/test/resources/go_test_suite/error_from_array.jsonnet:1:14)
+    at [Error].(error_from_array.jsonnet:1:2)
+    at [Lookup].(error_from_array.jsonnet:1:14)

--- a/sjsonnet/test/resources/go_test_suite/error_from_func.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/error_from_func.jsonnet.golden
@@ -1,4 +1,4 @@
 sjsonnet.Error: xxx
-    at [Error].(sjsonnet/test/resources/go_test_suite/error_from_func.jsonnet:1:25)
-    at [Apply1].(sjsonnet/test/resources/go_test_suite/error_from_func.jsonnet:1:37)
+    at [Error].(error_from_func.jsonnet:1:25)
+    at [Apply1].(error_from_func.jsonnet:1:37)
 

--- a/sjsonnet/test/resources/go_test_suite/error_function_fail.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/error_function_fail.jsonnet.golden
@@ -1,4 +1,4 @@
 sjsonnet.Error: Couldn't manifest function with params [x]
-    at .(sjsonnet/test/resources/go_test_suite/error_function_fail.jsonnet:1:8)
-    at [Error].(sjsonnet/test/resources/go_test_suite/error_function_fail.jsonnet:1:1)
+    at .(error_function_fail.jsonnet:1:8)
+    at [Error].(error_function_fail.jsonnet:1:1)
 

--- a/sjsonnet/test/resources/go_test_suite/error_hexnumber.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/error_hexnumber.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.ParseError: Expected end-of-input:1:2, found "x42\n"
-    at .(sjsonnet/test/resources/go_test_suite/error_hexnumber.jsonnet:1:2)
+    at .(error_hexnumber.jsonnet:1:2)
 

--- a/sjsonnet/test/resources/go_test_suite/error_in_method.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/error_in_method.jsonnet.golden
@@ -1,4 +1,4 @@
 sjsonnet.Error: xxx
-    at [Error].(sjsonnet/test/resources/go_test_suite/error_in_method.jsonnet:1:23)
-    at [Apply1].(sjsonnet/test/resources/go_test_suite/error_in_method.jsonnet:1:41)
+    at [Error].(error_in_method.jsonnet:1:23)
+    at [Apply1].(error_in_method.jsonnet:1:41)
 

--- a/sjsonnet/test/resources/go_test_suite/error_in_object_local.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/error_in_object_local.jsonnet.golden
@@ -1,4 +1,4 @@
 sjsonnet.Error: xxx
-    at [Error].(sjsonnet/test/resources/go_test_suite/error_in_object_local.jsonnet:1:20)
-    at [Apply1].(sjsonnet/test/resources/go_test_suite/error_in_object_local.jsonnet:1:39)
+    at [Error].(error_in_object_local.jsonnet:1:20)
+    at [Apply1].(error_in_object_local.jsonnet:1:39)
 

--- a/sjsonnet/test/resources/go_test_suite/error_object.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/error_object.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: {"blah": 42}
-    at [Error].(sjsonnet/test/resources/go_test_suite/error_object.jsonnet:1:1)
+    at [Error].(error_object.jsonnet:1:1)
 

--- a/sjsonnet/test/resources/go_test_suite/import_block_literal.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/import_block_literal.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: Couldn't import file: "block_literals_for_imports_are_not_allowed_and_make_exactly_zero_sense\n"
-    at [Import].(sjsonnet/test/resources/go_test_suite/import_block_literal.jsonnet:1:1)
+    at [Import].(import_block_literal.jsonnet:1:1)
 

--- a/sjsonnet/test/resources/go_test_suite/importbin_block_literal.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/importbin_block_literal.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: Couldn't import file: "block_literals_for_imports_are_not_allowed_and_make_exactly_zero_sense\n"
-    at [ImportBin].(sjsonnet/test/resources/go_test_suite/importbin_block_literal.jsonnet:1:1)
+    at [ImportBin].(importbin_block_literal.jsonnet:1:1)
 

--- a/sjsonnet/test/resources/go_test_suite/importstr_block_literal.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/importstr_block_literal.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: Couldn't import file: "block_literals_for_imports_are_not_allowed_and_make_exactly_zero_sense\n"
-    at [ImportStr].(sjsonnet/test/resources/go_test_suite/importstr_block_literal.jsonnet:1:1)
+    at [ImportStr].(importstr_block_literal.jsonnet:1:1)
 

--- a/sjsonnet/test/resources/go_test_suite/insuper4.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/insuper4.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.StaticError: Can't use super outside of an object
-    at [Super].(sjsonnet/test/resources/go_test_suite/insuper4.jsonnet:1:8)
+    at [Super].(insuper4.jsonnet:1:8)
 

--- a/sjsonnet/test/resources/go_test_suite/insuper6.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/insuper6.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.StaticError: Unknown variable: undeclared
-    at [Id undeclared].(sjsonnet/test/resources/go_test_suite/insuper6.jsonnet:1:10)
+    at [Id undeclared].(insuper6.jsonnet:1:10)
 

--- a/sjsonnet/test/resources/go_test_suite/static_error_eof.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/static_error_eof.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.ParseError: Expected ";":2:1, found ""
-    at .(sjsonnet/test/resources/go_test_suite/static_error_eof.jsonnet:2:1)
+    at .(static_error_eof.jsonnet:2:1)
 

--- a/sjsonnet/test/resources/go_test_suite/std.manifestYamlDoc_error.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/std.manifestYamlDoc_error.jsonnet.golden
@@ -1,4 +1,4 @@
 sjsonnet.Error: foo
-    at [Error].(sjsonnet/test/resources/go_test_suite/std.manifestYamlDoc_error.jsonnet:1:31)
-    at [std.manifestYamlDoc].(sjsonnet/test/resources/go_test_suite/std.manifestYamlDoc_error.jsonnet:1:20)
+    at [Error].(std.manifestYamlDoc_error.jsonnet:1:31)
+    at [std.manifestYamlDoc].(std.manifestYamlDoc_error.jsonnet:1:20)
 

--- a/sjsonnet/test/resources/go_test_suite/syntax_error.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/syntax_error.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.ParseError: Expected any-char:2:1, found ""
-    at .(sjsonnet/test/resources/go_test_suite/syntax_error.jsonnet:2:1)
+    at .(syntax_error.jsonnet:2:1)
 

--- a/sjsonnet/test/resources/go_test_suite/tailstrict3.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/tailstrict3.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: xxx
-    at [Error].(sjsonnet/test/resources/go_test_suite/tailstrict3.jsonnet:1:16)
-    at [Apply1].(sjsonnet/test/resources/go_test_suite/tailstrict3.jsonnet:2:4)
+    at [Error].(tailstrict3.jsonnet:1:16)
+    at [Apply1].(tailstrict3.jsonnet:2:4)

--- a/sjsonnet/test/resources/go_test_suite/unfinished_args.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/unfinished_args.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.ParseError: Expected ")":2:1, found ""
-    at .(sjsonnet/test/resources/go_test_suite/unfinished_args.jsonnet:2:1)
+    at .(unfinished_args.jsonnet:2:1)
 

--- a/sjsonnet/test/resources/go_test_suite/variable_not_visible.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/variable_not_visible.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.StaticError: Unknown variable: nested
-    at [Id nested].(sjsonnet/test/resources/go_test_suite/variable_not_visible.jsonnet:1:44)
+    at [Id nested].(variable_not_visible.jsonnet:1:44)
 

--- a/sjsonnet/test/resources/test_suite/error.01.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.01.jsonnet.golden
@@ -1,6 +1,6 @@
 sjsonnet.Error: foo
-    at [Error].(sjsonnet/test/resources/test_suite/error.01.jsonnet:17:29)
-    at [Apply1].(sjsonnet/test/resources/test_suite/error.01.jsonnet:18:36)
-    at [Apply1].(sjsonnet/test/resources/test_suite/error.01.jsonnet:19:35)
-    at [Apply1].(sjsonnet/test/resources/test_suite/error.01.jsonnet:20:7)
+    at [Error].(error.01.jsonnet:17:29)
+    at [Apply1].(error.01.jsonnet:18:36)
+    at [Apply1].(error.01.jsonnet:19:35)
+    at [Apply1].(error.01.jsonnet:20:7)
 

--- a/sjsonnet/test/resources/test_suite/error.02.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.02.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: Foo.
-    at [Error].(sjsonnet/test/resources/test_suite/error.02.jsonnet:17:1)
+    at [Error].(error.02.jsonnet:17:1)
 

--- a/sjsonnet/test/resources/test_suite/error.03.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.03.jsonnet.golden
@@ -1,4 +1,4 @@
 sjsonnet.Error: foo
-    at [Error].(sjsonnet/test/resources/test_suite/error.03.jsonnet:17:21)
-    at [Select x].(sjsonnet/test/resources/test_suite/error.03.jsonnet:18:7)
+    at [Error].(error.03.jsonnet:17:21)
+    at [Select x].(error.03.jsonnet:18:7)
 

--- a/sjsonnet/test/resources/test_suite/error.04.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.04.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: foo
-    at [Error].(sjsonnet/test/resources/test_suite/error.04.jsonnet:17:21)
+    at [Error].(error.04.jsonnet:17:21)
 

--- a/sjsonnet/test/resources/test_suite/error.05.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.05.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: foo
-    at [Error].(sjsonnet/test/resources/test_suite/error.05.jsonnet:17:21)
+    at [Error].(error.05.jsonnet:17:21)
 

--- a/sjsonnet/test/resources/test_suite/error.06.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.06.jsonnet.golden
@@ -1,6 +1,6 @@
 sjsonnet.Error: division by zero
-    at [BinaryOp /].(sjsonnet/test/resources/test_suite/error.06.jsonnet:17:15)
-    at [ValidId err].(sjsonnet/test/resources/test_suite/error.06.jsonnet:18:22)
-    at [Apply0].(sjsonnet/test/resources/test_suite/error.06.jsonnet:19:2)
-    at [BinaryOp +].(sjsonnet/test/resources/test_suite/error.06.jsonnet:19:5)
+    at [BinaryOp /].(error.06.jsonnet:17:15)
+    at [ValidId err].(error.06.jsonnet:18:22)
+    at [Apply0].(error.06.jsonnet:19:2)
+    at [BinaryOp +].(error.06.jsonnet:19:5)
 

--- a/sjsonnet/test/resources/test_suite/error.07.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.07.jsonnet.golden
@@ -1,7 +1,7 @@
 sjsonnet.Error: sarcasm
-    at [Error].(sjsonnet/test/resources/test_suite/error.07.jsonnet:18:31)
-    at [Lookup].(sjsonnet/test/resources/test_suite/error.07.jsonnet:17:32)
-    at [Apply1].(sjsonnet/test/resources/test_suite/error.07.jsonnet:18:20)
-    at [ValidId toxic].(sjsonnet/test/resources/test_suite/error.07.jsonnet:19:1)
-    at [BinaryOp +].(sjsonnet/test/resources/test_suite/error.07.jsonnet:19:7)
+    at [Error].(error.07.jsonnet:18:31)
+    at [Lookup].(error.07.jsonnet:17:32)
+    at [Apply1].(error.07.jsonnet:18:20)
+    at [ValidId toxic].(error.07.jsonnet:19:1)
+    at [BinaryOp +].(error.07.jsonnet:19:7)
 

--- a/sjsonnet/test/resources/test_suite/error.08.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.08.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: {"a": 1, "b": 2, "c": 3}
-    at [Error].(sjsonnet/test/resources/test_suite/error.08.jsonnet:18:1)
+    at [Error].(error.08.jsonnet:18:1)
 

--- a/sjsonnet/test/resources/test_suite/error.args_commafodder.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.args_commafodder.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.StaticError: Unknown variable: foo
-    at [Id foo].(sjsonnet/test/resources/test_suite/error.args_commafodder.jsonnet:1:1)
+    at [Id foo].(error.args_commafodder.jsonnet:1:1)
 

--- a/sjsonnet/test/resources/test_suite/error.array_fractional_index.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.array_fractional_index.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: index value is not a valid integer
-    at [Lookup].(sjsonnet/test/resources/test_suite/error.array_fractional_index.jsonnet:17:10)
+    at [Lookup].(error.array_fractional_index.jsonnet:17:10)
 

--- a/sjsonnet/test/resources/test_suite/error.array_index_string.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.array_index_string.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: attempted to index a array with string foo
-    at [Select foo].(sjsonnet/test/resources/test_suite/error.array_index_string.jsonnet:17:10)
+    at [Select foo].(error.array_index_string.jsonnet:17:10)
 

--- a/sjsonnet/test/resources/test_suite/error.array_large_index.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.array_large_index.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: index value is not a valid integer
-    at [Lookup].(sjsonnet/test/resources/test_suite/error.array_large_index.jsonnet:17:10)
+    at [Lookup].(error.array_large_index.jsonnet:17:10)
 

--- a/sjsonnet/test/resources/test_suite/error.array_recursive_manifest.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.array_recursive_manifest.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: Stackoverflow while materializing, possibly due to recursive value
-    at .(sjsonnet/test/resources/test_suite/error.array_recursive_manifest.jsonnet:17:12)
+    at .(error.array_recursive_manifest.jsonnet:17:12)
 

--- a/sjsonnet/test/resources/test_suite/error.assert.fail1.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.assert.fail1.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: Assertion failed
-    at [AssertExpr].(sjsonnet/test/resources/test_suite/error.assert.fail1.jsonnet:20:1)
+    at [AssertExpr].(error.assert.fail1.jsonnet:20:1)
 

--- a/sjsonnet/test/resources/test_suite/error.assert.fail2.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.assert.fail2.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: Assertion failed: foo was not equal to bar
-    at [AssertExpr].(sjsonnet/test/resources/test_suite/error.assert.fail2.jsonnet:20:1)
+    at [AssertExpr].(error.assert.fail2.jsonnet:20:1)
 

--- a/sjsonnet/test/resources/test_suite/error.assert_equal_obj.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.assert_equal_obj.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: assertEqual failed: {"a":1} != {"b":1}
-    at [std.assertEqual].(sjsonnet/test/resources/test_suite/error.assert_equal_obj.jsonnet:17:16)
+    at [std.assertEqual].(error.assert_equal_obj.jsonnet:17:16)
 

--- a/sjsonnet/test/resources/test_suite/error.assert_equal_str.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.assert_equal_str.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: assertEqual failed: "one\ntwo" != "three\nfour\n"
-    at [std.assertEqual].(sjsonnet/test/resources/test_suite/error.assert_equal_str.jsonnet:17:16)
+    at [std.assertEqual].(error.assert_equal_str.jsonnet:17:16)
 

--- a/sjsonnet/test/resources/test_suite/error.comprehension_spec_object.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.comprehension_spec_object.jsonnet.golden
@@ -1,4 +1,4 @@
 sjsonnet.Error: In comprehension, can only iterate over array, not object
-    at [ForSpec].(sjsonnet/test/resources/test_suite/error.comprehension_spec_object.jsonnet:17:4)
-    at [Comp].(sjsonnet/test/resources/test_suite/error.comprehension_spec_object.jsonnet:17:2)
+    at [ForSpec].(error.comprehension_spec_object.jsonnet:17:4)
+    at [Comp].(error.comprehension_spec_object.jsonnet:17:2)
 

--- a/sjsonnet/test/resources/test_suite/error.comprehension_spec_object2.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.comprehension_spec_object2.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: In comprehension, can only iterate over array, not object
-    at [ForSpec].(sjsonnet/test/resources/test_suite/error.comprehension_spec_object2.jsonnet:17:13)
+    at [ForSpec].(error.comprehension_spec_object2.jsonnet:17:13)
 

--- a/sjsonnet/test/resources/test_suite/error.computed_field_scope.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.computed_field_scope.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.StaticError: Unknown variable: x
-    at [Id x].(sjsonnet/test/resources/test_suite/error.computed_field_scope.jsonnet:17:21)
+    at [Id x].(error.computed_field_scope.jsonnet:17:21)
 

--- a/sjsonnet/test/resources/test_suite/error.decodeUTF8_float.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.decodeUTF8_float.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: Element 0 of the provided array was not an integer in range [0,255]
-    at [std.decodeUTF8].(sjsonnet/test/resources/test_suite/error.decodeUTF8_float.jsonnet:1:15)
+    at [std.decodeUTF8].(error.decodeUTF8_float.jsonnet:1:15)
 

--- a/sjsonnet/test/resources/test_suite/error.decodeUTF8_nan.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.decodeUTF8_nan.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: Element 0 of the provided array was not an integer in range [0,255]
-    at [std.decodeUTF8].(sjsonnet/test/resources/test_suite/error.decodeUTF8_nan.jsonnet:1:15)
+    at [std.decodeUTF8].(error.decodeUTF8_nan.jsonnet:1:15)
 

--- a/sjsonnet/test/resources/test_suite/error.divide_zero.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.divide_zero.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: division by zero
-    at [BinaryOp /].(sjsonnet/test/resources/test_suite/error.divide_zero.jsonnet:17:5)
+    at [BinaryOp /].(error.divide_zero.jsonnet:17:5)
 

--- a/sjsonnet/test/resources/test_suite/error.equality_function.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.equality_function.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: cannot test equality of functions
-    at [BinaryOp ==].(sjsonnet/test/resources/test_suite/error.equality_function.jsonnet:17:16)
+    at [BinaryOp ==].(error.equality_function.jsonnet:17:16)
 

--- a/sjsonnet/test/resources/test_suite/error.field_not_exist.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.field_not_exist.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: Field does not exist: y
-    at [Select y].(sjsonnet/test/resources/test_suite/error.field_not_exist.jsonnet:17:9)
+    at [Select y].(error.field_not_exist.jsonnet:17:9)
 

--- a/sjsonnet/test/resources/test_suite/error.format.too_few_values.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.format.too_few_values.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: Too few values to format: 1, expected at least 2
-    at [std.format].(sjsonnet/test/resources/test_suite/error.format.too_few_values.jsonnet:1:12)
+    at [std.format].(error.format.too_few_values.jsonnet:1:12)
 

--- a/sjsonnet/test/resources/test_suite/error.function_arg_positional_after_named.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.function_arg_positional_after_named.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.ParseError: Expected no positional params after named params:19:11, found ")\n"
-    at .(sjsonnet/test/resources/test_suite/error.function_arg_positional_after_named.jsonnet:19:11)
+    at .(error.function_arg_positional_after_named.jsonnet:19:11)
 

--- a/sjsonnet/test/resources/test_suite/error.function_duplicate_arg.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.function_duplicate_arg.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: binding parameter a second time: x
-    at [Apply].(sjsonnet/test/resources/test_suite/error.function_duplicate_arg.jsonnet:17:21)
+    at [Apply].(error.function_duplicate_arg.jsonnet:17:21)
 

--- a/sjsonnet/test/resources/test_suite/error.function_duplicate_param.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.function_duplicate_param.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.ParseError: Expected no duplicate parameter: x:17:14, found ") x\n"
-    at .(sjsonnet/test/resources/test_suite/error.function_duplicate_param.jsonnet:17:14)
+    at .(error.function_duplicate_param.jsonnet:17:14)
 

--- a/sjsonnet/test/resources/test_suite/error.function_no_default_arg.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.function_no_default_arg.jsonnet.golden
@@ -1,2 +1,2 @@
 sjsonnet.Error: Function parameter b not bound in call
-	at .(sjsonnet/test/resources/test_suite/error.function_no_default_arg.jsonnet:17:1)
+	at .(error.function_no_default_arg.jsonnet:17:1)

--- a/sjsonnet/test/resources/test_suite/error.function_too_many_args.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.function_too_many_args.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: Too many args, function has 2 parameter(s)
-    at [Apply3].(sjsonnet/test/resources/test_suite/error.function_too_many_args.jsonnet:19:4)
+    at [Apply3].(error.function_too_many_args.jsonnet:19:4)
 

--- a/sjsonnet/test/resources/test_suite/error.import_empty.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.import_empty.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: Couldn't import file: ""
-    at [Import].(sjsonnet/test/resources/test_suite/error.import_empty.jsonnet:17:1)
+    at [Import].(error.import_empty.jsonnet:17:1)
 

--- a/sjsonnet/test/resources/test_suite/error.import_folder.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.import_folder.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: Couldn't import file: "lib"
-    at [Import].(sjsonnet/test/resources/test_suite/error.import_folder.jsonnet:17:1)
+    at [Import].(error.import_folder.jsonnet:17:1)
 

--- a/sjsonnet/test/resources/test_suite/error.import_folder_slash.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.import_folder_slash.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: Couldn't import file: "lib/"
-    at [Import].(sjsonnet/test/resources/test_suite/error.import_folder_slash.jsonnet:17:1)
+    at [Import].(error.import_folder_slash.jsonnet:17:1)
 

--- a/sjsonnet/test/resources/test_suite/error.import_static-check-failure.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.import_static-check-failure.jsonnet.golden
@@ -1,4 +1,4 @@
 sjsonnet.StaticError: Unknown variable: x
-    at [Id x].(sjsonnet/test/resources/test_suite/lib/static_check_failure.jsonnet:2:1)
-    at [Import].(sjsonnet/test/resources/test_suite/error.import_static-check-failure.jsonnet:1:1)
+    at [Id x].(lib/static_check_failure.jsonnet:2:1)
+    at [Import].(error.import_static-check-failure.jsonnet:1:1)
 

--- a/sjsonnet/test/resources/test_suite/error.import_syntax-error.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.import_syntax-error.jsonnet.golden
@@ -1,4 +1,4 @@
 sjsonnet.ParseError: Expected "\"":2:1, found ""
-    at .(sjsonnet/test/resources/test_suite/lib/syntax_error.jsonnet:2:1)
-    at [Import].(sjsonnet/test/resources/test_suite/error.import_syntax-error.jsonnet:1:1)
+    at .(lib/syntax_error.jsonnet:2:1)
+    at [Import].(error.import_syntax-error.jsonnet:1:1)
 

--- a/sjsonnet/test/resources/test_suite/error.inside_equals_array.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.inside_equals_array.jsonnet.golden
@@ -1,4 +1,4 @@
 sjsonnet.Error: foobar
-    at [Error].(sjsonnet/test/resources/test_suite/error.inside_equals_array.jsonnet:18:18)
-    at [BinaryOp ==].(sjsonnet/test/resources/test_suite/error.inside_equals_array.jsonnet:19:3)
+    at [Error].(error.inside_equals_array.jsonnet:18:18)
+    at [BinaryOp ==].(error.inside_equals_array.jsonnet:19:3)
 

--- a/sjsonnet/test/resources/test_suite/error.inside_equals_object.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.inside_equals_object.jsonnet.golden
@@ -1,4 +1,4 @@
 sjsonnet.Error: foobar
-    at [Error].(sjsonnet/test/resources/test_suite/error.inside_equals_object.jsonnet:18:22)
-    at [BinaryOp ==].(sjsonnet/test/resources/test_suite/error.inside_equals_object.jsonnet:19:3)
+    at [Error].(error.inside_equals_object.jsonnet:18:22)
+    at [BinaryOp ==].(error.inside_equals_object.jsonnet:19:3)
 

--- a/sjsonnet/test/resources/test_suite/error.inside_tostring_array.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.inside_tostring_array.jsonnet.golden
@@ -1,4 +1,4 @@
 sjsonnet.Error: foobar
-    at [Error].(sjsonnet/test/resources/test_suite/error.inside_tostring_array.jsonnet:17:8)
-    at [BinaryOp +].(sjsonnet/test/resources/test_suite/error.inside_tostring_array.jsonnet:17:24)
+    at [Error].(error.inside_tostring_array.jsonnet:17:8)
+    at [BinaryOp +].(error.inside_tostring_array.jsonnet:17:24)
 

--- a/sjsonnet/test/resources/test_suite/error.inside_tostring_object.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.inside_tostring_object.jsonnet.golden
@@ -1,4 +1,4 @@
 sjsonnet.Error: foobar
-    at [Error].(sjsonnet/test/resources/test_suite/error.inside_tostring_object.jsonnet:17:12)
-    at [BinaryOp +].(sjsonnet/test/resources/test_suite/error.inside_tostring_object.jsonnet:17:29)
+    at [Error].(error.inside_tostring_object.jsonnet:17:12)
+    at [BinaryOp +].(error.inside_tostring_object.jsonnet:17:29)
 

--- a/sjsonnet/test/resources/test_suite/error.integer_conversion.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.integer_conversion.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: numeric value outside safe integer range for bitwise operation
-    at [BinaryOp <<].(sjsonnet/test/resources/test_suite/error.integer_conversion.jsonnet:3:12)
+    at [BinaryOp <<].(error.integer_conversion.jsonnet:3:12)
 

--- a/sjsonnet/test/resources/test_suite/error.integer_left_shift.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.integer_left_shift.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: numeric value outside safe integer range for bitwise operation
-    at [BinaryOp <<].(sjsonnet/test/resources/test_suite/error.integer_left_shift.jsonnet:3:13)
+    at [BinaryOp <<].(error.integer_left_shift.jsonnet:3:13)
 

--- a/sjsonnet/test/resources/test_suite/error.integer_left_shift_runtime.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.integer_left_shift_runtime.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: numeric value outside safe integer range for bitwise operation
-    at [BinaryOp <<].(sjsonnet/test/resources/test_suite/error.integer_left_shift_runtime.jsonnet:2:13)
+    at [BinaryOp <<].(error.integer_left_shift_runtime.jsonnet:2:13)
 

--- a/sjsonnet/test/resources/test_suite/error.invariant.avoid_output_change.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.invariant.avoid_output_change.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: Assertion failed
-    at [Assert].(sjsonnet/test/resources/test_suite/error.invariant.avoid_output_change.jsonnet:18:15)
+    at [Assert].(error.invariant.avoid_output_change.jsonnet:18:15)
 

--- a/sjsonnet/test/resources/test_suite/error.invariant.equality.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.invariant.equality.jsonnet.golden
@@ -1,4 +1,4 @@
 sjsonnet.Error: Assertion failed
-    at [Assert].(sjsonnet/test/resources/test_suite/error.invariant.equality.jsonnet:17:10)
-    at [BinaryOp ==].(sjsonnet/test/resources/test_suite/error.invariant.equality.jsonnet:17:24)
+    at [Assert].(error.invariant.equality.jsonnet:17:10)
+    at [BinaryOp ==].(error.invariant.equality.jsonnet:17:24)
 

--- a/sjsonnet/test/resources/test_suite/error.invariant.simple.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.invariant.simple.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: Assertion failed
-    at [Assert].(sjsonnet/test/resources/test_suite/error.invariant.simple.jsonnet:18:10)
+    at [Assert].(error.invariant.simple.jsonnet:18:10)
 

--- a/sjsonnet/test/resources/test_suite/error.invariant.simple2.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.invariant.simple2.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: Assertion failed: my error message
-    at [Assert].(sjsonnet/test/resources/test_suite/error.invariant.simple2.jsonnet:18:12)
+    at [Assert].(error.invariant.simple2.jsonnet:18:12)
 

--- a/sjsonnet/test/resources/test_suite/error.invariant.simple3.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.invariant.simple3.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: my error message
-    at [Error].(sjsonnet/test/resources/test_suite/error.invariant.simple3.jsonnet:18:10)
+    at [Error].(error.invariant.simple3.jsonnet:18:10)
 

--- a/sjsonnet/test/resources/test_suite/error.lazy_operator2.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.lazy_operator2.jsonnet.golden
@@ -1,4 +1,4 @@
 sjsonnet.Error: should happen
-    at [Error].(sjsonnet/test/resources/test_suite/error.lazy_operator2.jsonnet:1:9)
-    at [And].(sjsonnet/test/resources/test_suite/error.lazy_operator2.jsonnet:1:6)
+    at [Error].(error.lazy_operator2.jsonnet:1:9)
+    at [And].(error.lazy_operator2.jsonnet:1:6)
 

--- a/sjsonnet/test/resources/test_suite/error.manifest_toml_null_value.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.manifest_toml_null_value.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: Tried to manifest "null"
-    at [std.manifestTomlEx].(sjsonnet/test/resources/test_suite/error.manifest_toml_null_value.jsonnet:17:19)
+    at [std.manifestTomlEx].(error.manifest_toml_null_value.jsonnet:17:19)
 

--- a/sjsonnet/test/resources/test_suite/error.manifest_toml_wrong_type.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.manifest_toml_wrong_type.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: Wrong parameter type: expected Object, got array
-    at [std.manifestTomlEx].(sjsonnet/test/resources/test_suite/error.manifest_toml_wrong_type.jsonnet:17:19)
+    at [std.manifestTomlEx].(error.manifest_toml_wrong_type.jsonnet:17:19)
 

--- a/sjsonnet/test/resources/test_suite/error.obj_assert.fail1.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.obj_assert.fail1.jsonnet.golden
@@ -1,5 +1,5 @@
 sjsonnet.Error: Assertion failed
-    at [Assert].(sjsonnet/test/resources/test_suite/error.obj_assert.fail1.jsonnet:20:25)
-    at [BinaryOp ==].(sjsonnet/test/resources/test_suite/error.obj_assert.fail1.jsonnet:20:38)
-    at [And].(sjsonnet/test/resources/test_suite/error.obj_assert.fail1.jsonnet:20:50)
+    at [Assert].(error.obj_assert.fail1.jsonnet:20:25)
+    at [BinaryOp ==].(error.obj_assert.fail1.jsonnet:20:38)
+    at [And].(error.obj_assert.fail1.jsonnet:20:50)
 

--- a/sjsonnet/test/resources/test_suite/error.obj_assert.fail2.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.obj_assert.fail2.jsonnet.golden
@@ -1,5 +1,5 @@
 sjsonnet.Error: Assertion failed: foo was not equal to bar
-    at [Assert].(sjsonnet/test/resources/test_suite/error.obj_assert.fail2.jsonnet:20:25)
-    at [BinaryOp ==].(sjsonnet/test/resources/test_suite/error.obj_assert.fail2.jsonnet:20:74)
-    at [And].(sjsonnet/test/resources/test_suite/error.obj_assert.fail2.jsonnet:20:86)
+    at [Assert].(error.obj_assert.fail2.jsonnet:20:25)
+    at [BinaryOp ==].(error.obj_assert.fail2.jsonnet:20:74)
+    at [And].(error.obj_assert.fail2.jsonnet:20:86)
 

--- a/sjsonnet/test/resources/test_suite/error.obj_recursive.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.obj_recursive.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: Stackoverflow while materializing, possibly due to recursive value
-    at .(sjsonnet/test/resources/test_suite/error.obj_recursive.jsonnet:17:3)
+    at .(error.obj_recursive.jsonnet:17:3)
 

--- a/sjsonnet/test/resources/test_suite/error.obj_recursive_manifest.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.obj_recursive_manifest.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: Stackoverflow while materializing, possibly due to recursive value
-    at .(sjsonnet/test/resources/test_suite/error.obj_recursive_manifest.jsonnet:17:3)
+    at .(error.obj_recursive_manifest.jsonnet:17:3)
 

--- a/sjsonnet/test/resources/test_suite/error.overflow.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.overflow.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: overflow
-    at [BinaryOp *].(error.overflow2.jsonnet:17:7)
+    at [BinaryOp *].(error.overflow.jsonnet:17:7)
 

--- a/sjsonnet/test/resources/test_suite/error.overflow3.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.overflow3.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: numeric value is not finite
-    at [BinaryOp &].(sjsonnet/test/resources/test_suite/error.overflow3.jsonnet:17:7)
+    at [BinaryOp &].(error.overflow3.jsonnet:17:7)
 

--- a/sjsonnet/test/resources/test_suite/error.parse.array_comma.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.parse.array_comma.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.ParseError: Expected "]":17:7, found "3]\n"
-    at .(sjsonnet/test/resources/test_suite/error.parse.array_comma.jsonnet:17:7)
+    at .(error.parse.array_comma.jsonnet:17:7)
 

--- a/sjsonnet/test/resources/test_suite/error.parse.function_arg_positional_after_named.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.parse.function_arg_positional_after_named.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.ParseError: Expected no positional params after named params:19:11, found ")\n"
-    at .(sjsonnet/test/resources/test_suite/error.parse.function_arg_positional_after_named.jsonnet:19:11)
+    at .(error.parse.function_arg_positional_after_named.jsonnet:19:11)
 

--- a/sjsonnet/test/resources/test_suite/error.parse.import_not_literal.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.parse.import_not_literal.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.ParseError: Expected string literal (computed imports are not allowed):18:1, found ""
-    at .(sjsonnet/test/resources/test_suite/error.parse.import_not_literal.jsonnet:18:1)
+    at .(error.parse.import_not_literal.jsonnet:18:1)
 

--- a/sjsonnet/test/resources/test_suite/error.parse.import_text_block.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.parse.import_text_block.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: Couldn't import file: "This is a paragraph of text, which is being used in the place of\na filename.  That is quite unusual, and probably not intended.\n"
-    at [Import].(sjsonnet/test/resources/test_suite/error.parse.import_text_block.jsonnet:17:1)
+    at [Import].(error.parse.import_text_block.jsonnet:17:1)
 

--- a/sjsonnet/test/resources/test_suite/error.parse.index_unterminated.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.parse.index_unterminated.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.ParseError: Expected "]":18:1, found ""
-    at .(sjsonnet/test/resources/test_suite/error.parse.index_unterminated.jsonnet:18:1)
+    at .(error.parse.index_unterminated.jsonnet:18:1)
 

--- a/sjsonnet/test/resources/test_suite/error.parse.method_plus.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.parse.method_plus.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.ParseError: Expected (":" | "::" | ":::"):17:18, found "+:: 1, b: "
-    at .(sjsonnet/test/resources/test_suite/error.parse.method_plus.jsonnet:17:18)
+    at .(error.parse.method_plus.jsonnet:17:18)
 

--- a/sjsonnet/test/resources/test_suite/error.parse.object_comma.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.parse.object_comma.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.ParseError: Expected "}":17:11, found "z:1}\n"
-    at .(sjsonnet/test/resources/test_suite/error.parse.object_comma.jsonnet:17:11)
+    at .(error.parse.object_comma.jsonnet:17:11)
 

--- a/sjsonnet/test/resources/test_suite/error.parse.object_comprehension_local_clash.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.parse.object_comprehension_local_clash.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.ParseError: Expected no duplicate local: x:17:29, found ": null for"
-    at .(sjsonnet/test/resources/test_suite/error.parse.object_comprehension_local_clash.jsonnet:17:29)
+    at .(error.parse.object_comprehension_local_clash.jsonnet:17:29)
 

--- a/sjsonnet/test/resources/test_suite/error.parse.object_local_clash.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.parse.object_local_clash.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.ParseError: Expected no duplicate local: x:17:26, found "}\n"
-    at .(sjsonnet/test/resources/test_suite/error.parse.object_local_clash.jsonnet:17:26)
+    at .(error.parse.object_local_clash.jsonnet:17:26)
 

--- a/sjsonnet/test/resources/test_suite/error.parse.self_in_computed_field.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.parse.self_in_computed_field.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.ParseError: Expected "}":17:15, found "self.f = \""
-    at .(sjsonnet/test/resources/test_suite/error.parse.self_in_computed_field.jsonnet:17:15)
+    at .(error.parse.self_in_computed_field.jsonnet:17:15)
 

--- a/sjsonnet/test/resources/test_suite/error.parse.static_error_bad_number.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.parse.static_error_bad_number.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.ParseError: Expected fail:17:2, found "5\n"
-    at .(sjsonnet/test/resources/test_suite/error.parse.static_error_bad_number.jsonnet:17:2)
+    at .(error.parse.static_error_bad_number.jsonnet:17:2)
 

--- a/sjsonnet/test/resources/test_suite/error.parse.string.invalid_escape_unicode_non_hex.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.parse.string.invalid_escape_unicode_non_hex.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.ParseError: Expected "\"":17:2, found "\\u000t\"\n"
-    at .(sjsonnet/test/resources/test_suite/error.parse.string.invalid_escape_unicode_non_hex.jsonnet:17:2)
+    at .(error.parse.string.invalid_escape_unicode_non_hex.jsonnet:17:2)
 

--- a/sjsonnet/test/resources/test_suite/error.parse.string.invalid_escape_unicode_short.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.parse.string.invalid_escape_unicode_short.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.ParseError: Expected "\"":17:2, found "\\u333\n"
-    at .(sjsonnet/test/resources/test_suite/error.parse.string.invalid_escape_unicode_short.jsonnet:17:2)
+    at .(error.parse.string.invalid_escape_unicode_short.jsonnet:17:2)
 

--- a/sjsonnet/test/resources/test_suite/error.parse.string.invalid_escape_unicode_short2.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.parse.string.invalid_escape_unicode_short2.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.ParseError: Expected "\"":17:2, found "\\u333\"\n"
-    at .(sjsonnet/test/resources/test_suite/error.parse.string.invalid_escape_unicode_short2.jsonnet:17:2)
+    at .(error.parse.string.invalid_escape_unicode_short2.jsonnet:17:2)
 

--- a/sjsonnet/test/resources/test_suite/error.parse.string.invalid_escape_unicode_short3.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.parse.string.invalid_escape_unicode_short3.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.ParseError: Expected "\"":17:2, found "\\u333\n"
-    at .(sjsonnet/test/resources/test_suite/error.parse.string.invalid_escape_unicode_short3.jsonnet:17:2)
+    at .(error.parse.string.invalid_escape_unicode_short3.jsonnet:17:2)
 

--- a/sjsonnet/test/resources/test_suite/error.parse.string.unfinished.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.parse.string.unfinished.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.ParseError: Expected "\"":18:1, found ""
-    at .(sjsonnet/test/resources/test_suite/error.parse.string.unfinished.jsonnet:18:1)
+    at .(error.parse.string.unfinished.jsonnet:18:1)
 

--- a/sjsonnet/test/resources/test_suite/error.parse.string.unfinished2.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.parse.string.unfinished2.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.ParseError: Expected "'":18:1, found ""
-    at .(sjsonnet/test/resources/test_suite/error.parse.string.unfinished2.jsonnet:18:1)
+    at .(error.parse.string.unfinished2.jsonnet:18:1)
 

--- a/sjsonnet/test/resources/test_suite/error.parse.string_multi_no_newline.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.parse.string_multi_no_newline.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.ParseError: Expected |||-blocks require multiple lines:17:5, found "|||\n"
-    at .(sjsonnet/test/resources/test_suite/error.parse.string_multi_no_newline.jsonnet:17:5)
+    at .(error.parse.string_multi_no_newline.jsonnet:17:5)
 

--- a/sjsonnet/test/resources/test_suite/error.parse.text_block_bad_whitespace.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.parse.text_block_bad_whitespace.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.ParseError: Expected "|||":19:2, found "bar\n|||\n"
-    at .(sjsonnet/test/resources/test_suite/error.parse.text_block_bad_whitespace.jsonnet:19:2)
+    at .(error.parse.text_block_bad_whitespace.jsonnet:19:2)
 

--- a/sjsonnet/test/resources/test_suite/error.parse.text_block_eof.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.parse.text_block_eof.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.ParseError: Expected "\n":18:7, found ""
-    at .(sjsonnet/test/resources/test_suite/error.parse.text_block_eof.jsonnet:18:7)
+    at .(error.parse.text_block_eof.jsonnet:18:7)
 

--- a/sjsonnet/test/resources/test_suite/error.parse.text_block_not_terminated.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.parse.text_block_not_terminated.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.ParseError: Expected "|||":19:1, found ""
-    at .(sjsonnet/test/resources/test_suite/error.parse.text_block_not_terminated.jsonnet:19:1)
+    at .(error.parse.text_block_not_terminated.jsonnet:19:1)
 

--- a/sjsonnet/test/resources/test_suite/error.sanity.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.sanity.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: assertEqual failed: 1 != 2
-    at [std.assertEqual].(sjsonnet/test/resources/test_suite/error.sanity.jsonnet:17:16)
+    at [std.assertEqual].(error.sanity.jsonnet:17:16)
 

--- a/sjsonnet/test/resources/test_suite/error.static_error_self.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.static_error_self.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.StaticError: Can't use self outside of an object
-    at [Self].(sjsonnet/test/resources/test_suite/error.static_error_self.jsonnet:17:2)
+    at [Self].(error.static_error_self.jsonnet:17:2)
 

--- a/sjsonnet/test/resources/test_suite/error.static_error_super.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.static_error_super.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.StaticError: Can't use super outside of an object
-    at [Super].(sjsonnet/test/resources/test_suite/error.static_error_super.jsonnet:17:2)
+    at [Super].(error.static_error_super.jsonnet:17:2)
 

--- a/sjsonnet/test/resources/test_suite/error.static_error_var_not_exist.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.static_error_var_not_exist.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.StaticError: Unknown variable: tmp2
-    at [Id tmp2].(sjsonnet/test/resources/test_suite/error.static_error_var_not_exist.jsonnet:17:16)
+    at [Id tmp2].(error.static_error_var_not_exist.jsonnet:17:16)
 

--- a/sjsonnet/test/resources/test_suite/error.std_join_types1.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.std_join_types1.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: Cannot join array
-    at [std.join].(sjsonnet/test/resources/test_suite/error.std_join_types1.jsonnet:17:9)
+    at [std.join].(error.std_join_types1.jsonnet:17:9)
 

--- a/sjsonnet/test/resources/test_suite/error.std_join_types2.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.std_join_types2.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: Cannot join string
-    at [std.join].(sjsonnet/test/resources/test_suite/error.std_join_types2.jsonnet:17:9)
+    at [std.join].(error.std_join_types2.jsonnet:17:9)
 

--- a/sjsonnet/test/resources/test_suite/error.std_makeArray_negative.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.std_makeArray_negative.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: index value is not a positive integer, got: -10
-    at [std.makeArray].(sjsonnet/test/resources/test_suite/error.std_makeArray_negative.jsonnet:17:14)
+    at [std.makeArray].(error.std_makeArray_negative.jsonnet:17:14)
 

--- a/sjsonnet/test/resources/test_suite/error.std_maxArray.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.std_maxArray.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: Expected at least one element in array. Got none
-    at [std.maxArray].(sjsonnet/test/resources/test_suite/error.std_maxArray.jsonnet:1:13)
+    at [std.maxArray].(error.std_maxArray.jsonnet:1:13)
 

--- a/sjsonnet/test/resources/test_suite/error.std_minArray.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.std_minArray.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: Expected at least one element in array. Got none
-    at [std.minArray].(sjsonnet/test/resources/test_suite/error.std_minArray.jsonnet:1:13)
+    at [std.minArray].(error.std_minArray.jsonnet:1:13)
 

--- a/sjsonnet/test/resources/test_suite/error.tailstrict_stack.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.tailstrict_stack.jsonnet.golden
@@ -1,7 +1,7 @@
 sjsonnet.Error: n is 0
-    at [Error].(sjsonnet/test/resources/test_suite/error.tailstrict_stack.jsonnet:10:9)
-    at [Apply2].(sjsonnet/test/resources/test_suite/error.tailstrict_stack.jsonnet:12:26)
-    at [Apply2].(sjsonnet/test/resources/test_suite/error.tailstrict_stack.jsonnet:14:37)
-    at [ValidId result].(sjsonnet/test/resources/test_suite/error.tailstrict_stack.jsonnet:15:5)
-    at [Apply1].(sjsonnet/test/resources/test_suite/error.tailstrict_stack.jsonnet:19:18)
+    at [Error].(error.tailstrict_stack.jsonnet:10:9)
+    at [Apply2].(error.tailstrict_stack.jsonnet:12:26)
+    at [Apply2].(error.tailstrict_stack.jsonnet:14:37)
+    at [ValidId result].(error.tailstrict_stack.jsonnet:15:5)
+    at [Apply1].(error.tailstrict_stack.jsonnet:19:18)
 

--- a/sjsonnet/test/resources/test_suite/error.trace_one_param.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.trace_one_param.jsonnet.golden
@@ -1,4 +1,4 @@
 sjsonnet.Error: Function parameter rest not bound in call
-    at [Apply1].(sjsonnet/test/resources/test_suite/error.trace_one_param.jsonnet:17:20)
-    at [ValidId v].(sjsonnet/test/resources/test_suite/error.trace_one_param.jsonnet:19:6)
+    at [Apply1].(error.trace_one_param.jsonnet:17:20)
+    at [ValidId v].(error.trace_one_param.jsonnet:19:6)
 

--- a/sjsonnet/test/resources/test_suite/error.trace_three_param.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.trace_three_param.jsonnet.golden
@@ -1,4 +1,4 @@
 sjsonnet.Error: Too many args, function has 2 parameter(s)
-    at [Apply3].(sjsonnet/test/resources/test_suite/error.trace_three_param.jsonnet:17:20)
-    at [ValidId v].(sjsonnet/test/resources/test_suite/error.trace_three_param.jsonnet:19:6)
+    at [Apply3].(error.trace_three_param.jsonnet:17:20)
+    at [ValidId v].(error.trace_three_param.jsonnet:19:6)
 

--- a/sjsonnet/test/resources/test_suite/error.trace_two_param.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.trace_two_param.jsonnet.golden
@@ -1,4 +1,4 @@
 sjsonnet.Error: Wrong parameter type: expected String, got number
-    at [std.trace].(sjsonnet/test/resources/test_suite/error.trace_two_param.jsonnet:17:20)
-    at [ValidId v].(sjsonnet/test/resources/test_suite/error.trace_two_param.jsonnet:19:6)
+    at [std.trace].(error.trace_two_param.jsonnet:17:20)
+    at [ValidId v].(error.trace_two_param.jsonnet:19:6)
 

--- a/sjsonnet/test/resources/test_suite/error.trace_zero_param.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.trace_zero_param.jsonnet.golden
@@ -1,4 +1,4 @@
 sjsonnet.Error: Function parameters str, rest not bound in call
-    at [Apply0].(sjsonnet/test/resources/test_suite/error.trace_zero_param.jsonnet:17:20)
-    at [ValidId v].(sjsonnet/test/resources/test_suite/error.trace_zero_param.jsonnet:19:6)
+    at [Apply0].(error.trace_zero_param.jsonnet:17:20)
+    at [ValidId v].(error.trace_zero_param.jsonnet:19:6)
 

--- a/sjsonnet/test/resources/test_suite/error.verbatim_import.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.verbatim_import.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: Couldn't import file: "C:\\can't possibly exist~"
-    at [Import].(sjsonnet/test/resources/test_suite/error.verbatim_import.jsonnet:22:1)
+    at [Import].(error.verbatim_import.jsonnet:22:1)
 

--- a/sjsonnet/test/resources/test_suite/error.wrong_type.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.wrong_type.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: Wrong parameter type: expected String, got number
-    at [std.codepoint].(sjsonnet/test/resources/test_suite/error.wrong_type.jsonnet:1:14)
+    at [std.codepoint].(error.wrong_type.jsonnet:1:14)
 

--- a/sjsonnet/test/src-js/sjsonnet/BaseFileTests.scala
+++ b/sjsonnet/test/src-js/sjsonnet/BaseFileTests.scala
@@ -170,7 +170,6 @@ abstract class BaseFileTests extends TestSuite {
       goldenContent: String,
       testSuite: String): Unit = {
     val expected = goldenContent
-      .replaceAll(f"\\(sjsonnet/test/resources/$testSuite/", "(")
       .replaceAll("    at", "  at")
       .strip()
 

--- a/sjsonnet/test/src-jvm-native/sjsonnet/BaseFileTests.scala
+++ b/sjsonnet/test/src-jvm-native/sjsonnet/BaseFileTests.scala
@@ -106,7 +106,7 @@ abstract class BaseFileTests extends TestSuite {
   }
 
   private def checkError(fileName: os.Path, goldenContent: String, testSuite: String): Unit = {
-    val expected = goldenContent.replaceAll(s"\\(sjsonnet/test/resources/$testSuite/", "(").strip()
+    val expected = goldenContent.strip()
 
     var res: Either[String, Value] = Right(null)
     try {


### PR DESCRIPTION
- Enable most missing tests for graalvm.
- Fix golden file containing exceptions for consistency (some had the full relative path to jsonnet, some did not)
- Add code handle OutOfMemory in the Materializer. The GraalVM binary will basically run much longer before throwing a StackOverflow and instead hits limits with heap allocations during Materialization