### PR TITLE
Re-enable handling of unicode strings in std.base64

### DIFF
--- a/sjsonnet/test/graalvm/run_test_suites.py
+++ b/sjsonnet/test/graalvm/run_test_suites.py
@@ -137,6 +137,9 @@ class GoTestSuite(BaseGraalVMTestSuite):
       "native7",
       "native_error",
       "native_panic",
+
+      # We support base64 of unicode strings
+      "builtinBase64_string_high_codepoint",
     ]
     
     # Find all .jsonnet files in the test directory

--- a/sjsonnet/test/resources/go_test_suite/builtinBase64_invalid_byte_array.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/builtinBase64_invalid_byte_array.jsonnet.golden
@@ -1,3 +1,3 @@
-sjsonnet.Error: Expected an array of numbers or a string
+sjsonnet.Error: Expected an array of numbers, got a string at position 1
     at [std.base64].(builtinBase64_invalid_byte_array.jsonnet:1:11)
 

--- a/sjsonnet/test/resources/go_test_suite/builtinBase64_invalid_byte_array1.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/builtinBase64_invalid_byte_array1.jsonnet.golden
@@ -1,3 +1,3 @@
-sjsonnet.Error: Found an invalid codepoint value in the array (must be 0 <= X <= 255), got -1
+sjsonnet.Error: Found an invalid codepoint value at position 1 (must be 0 <= X <= 255), got -1
     at [std.base64].(builtinBase64_invalid_byte_array1.jsonnet:1:11)
 

--- a/sjsonnet/test/resources/go_test_suite/builtinBase64_invalid_byte_array2.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/builtinBase64_invalid_byte_array2.jsonnet.golden
@@ -1,3 +1,3 @@
-sjsonnet.Error: Found an invalid codepoint value in the array (must be 0 <= X <= 255), got 256
+sjsonnet.Error: Found an invalid codepoint value at position 1 (must be 0 <= X <= 255), got 256
     at [std.base64].(builtinBase64_invalid_byte_array2.jsonnet:1:11)
 

--- a/sjsonnet/test/src-js/sjsonnet/FileTests.scala
+++ b/sjsonnet/test/src-js/sjsonnet/FileTests.scala
@@ -16,6 +16,8 @@ object FileTests extends BaseFileTests {
   )
 
   val goTestDataSkippedTests: Set[String] = Set(
+    // We support base64 of unicode strings
+    "builtinBase64_string_high_codepoint.jsonnet",
     "builtinSha1.jsonnet",
     "builtinSha256.jsonnet",
     "builtinSha3.jsonnet",

--- a/sjsonnet/test/src-jvm-native/sjsonnet/FileTests.scala
+++ b/sjsonnet/test/src-jvm-native/sjsonnet/FileTests.scala
@@ -16,7 +16,10 @@ object FileTests extends BaseFileTests {
       )
     else Set.empty[String]
 
-  val goTestDataSkippedTests: Set[String] = Set.empty
+  val goTestDataSkippedTests: Set[String] = Set(
+    // We support base64 of unicode strings
+    "builtinBase64_string_high_codepoint.jsonnet"
+  )
 
   val tests: Tests = Tests {
     test("test_suite") - {


### PR DESCRIPTION
This is an artificial limitation in go-jsonnet and we are not bound by it.
We are perfectly capable of encoding and decoding unicode strings.