### PR TITLE
chore: Add missing `final` to case classes.

### DIFF
--- a/sjsonnet/src/sjsonnet/Settings.scala
+++ b/sjsonnet/src/sjsonnet/Settings.scala
@@ -4,7 +4,7 @@ package sjsonnet
  * Settings for the interpreter. This is a subset of Config which is used in the inner layers of the
  * interpreters and shared between all platforms.
  */
-case class Settings(
+final case class Settings(
     val preserveOrder: Boolean = false,
     val strict: Boolean = false,
     val throwErrorForInvalidSets: Boolean = false,

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -148,7 +148,7 @@ object Val {
     }
   }
 
-  case class Arr(pos: Position, private val value: Array[? <: Lazy]) extends Literal {
+  final case class Arr(pos: Position, private val value: Array[? <: Lazy]) extends Literal {
     def prettyName = "array"
 
     override def asArr: Arr = this


### PR DESCRIPTION
Motivation:
It was missing, the `final` keyword.