### PR TITLE
Fix handling of non-BMP Unicode strings (jsonnet strings should operate over codepoints, not UTF-16 code units)

### DIFF
--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -374,12 +374,13 @@ class Evaluator(
         v.force(int)
       case (v: Val.Str, i: Val.Num) =>
         val int = i.asPositiveInt
-        if (v.value.isEmpty) Error.fail("string bounds error: string is empty", pos)
-        val unicodeLength = v.value.codePointCount(0, v.value.length)
+        val str = v.value
+        if (str.isEmpty) Error.fail("string bounds error: string is empty", pos)
+        val unicodeLength = str.codePointCount(0, str.length)
         if (int >= unicodeLength)
           Error.fail(s"string bounds error: $int not within [0, $unicodeLength)", pos)
-        val (startUtf16, endUtf16) = Util.codePointOffsetsToStringIndices(v.value, int, int + 1)
-        Val.Str(pos, v.value.substring(startUtf16, endUtf16))
+        val (startUtf16, endUtf16) = Util.codePointOffsetsToStringIndices(str, int, int + 1)
+        Val.Str(pos, str.substring(startUtf16, endUtf16))
       case (v: Val.Obj, i: Val.Str) =>
         v.value(i.value, pos)
       case (lhs, rhs) =>

--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -379,7 +379,8 @@ class Evaluator(
         val unicodeLength = str.codePointCount(0, str.length)
         if (int >= unicodeLength)
           Error.fail(s"string bounds error: $int not within [0, $unicodeLength)", pos)
-        val (startUtf16, endUtf16) = Util.codePointOffsetsToStringIndices(str, int, int + 1)
+        val startUtf16 = if (int == 0) 0 else str.offsetByCodePoints(0, int)
+        val endUtf16 = str.offsetByCodePoints(startUtf16, 1)
         Val.Str(pos, str.substring(startUtf16, endUtf16))
       case (v: Val.Obj, i: Val.Str) =>
         v.value(i.value, pos)

--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -524,7 +524,7 @@ class Evaluator(
 
       case Expr.BinaryOp.OP_< =>
         (l, r) match {
-          case (Val.Str(_, l), Val.Str(_, r)) => Val.bool(pos, l < r)
+          case (Val.Str(_, l), Val.Str(_, r)) => Val.bool(pos, Util.compareStringsByCodepoint(l, r) < 0)
           case (Val.Num(_, l), Val.Num(_, r)) => Val.bool(pos, l < r)
           case (x: Val.Arr, y: Val.Arr)       => Val.bool(pos, compare(x, y) < 0)
           case _                              => fail()
@@ -532,7 +532,7 @@ class Evaluator(
 
       case Expr.BinaryOp.OP_> =>
         (l, r) match {
-          case (Val.Str(_, l), Val.Str(_, r)) => Val.bool(pos, l > r)
+          case (Val.Str(_, l), Val.Str(_, r)) => Val.bool(pos, Util.compareStringsByCodepoint(l, r) > 0)
           case (Val.Num(_, l), Val.Num(_, r)) => Val.bool(pos, l > r)
           case (x: Val.Arr, y: Val.Arr)       => Val.bool(pos, compare(x, y) > 0)
           case _                              => fail()
@@ -540,7 +540,7 @@ class Evaluator(
 
       case Expr.BinaryOp.OP_<= =>
         (l, r) match {
-          case (Val.Str(_, l), Val.Str(_, r)) => Val.bool(pos, l <= r)
+          case (Val.Str(_, l), Val.Str(_, r)) => Val.bool(pos, Util.compareStringsByCodepoint(l, r) <= 0)
           case (Val.Num(_, l), Val.Num(_, r)) => Val.bool(pos, l <= r)
           case (x: Val.Arr, y: Val.Arr)       => Val.bool(pos, compare(x, y) <= 0)
           case _                              => fail()
@@ -548,7 +548,7 @@ class Evaluator(
 
       case Expr.BinaryOp.OP_>= =>
         (l, r) match {
-          case (Val.Str(_, l), Val.Str(_, r)) => Val.bool(pos, l >= r)
+          case (Val.Str(_, l), Val.Str(_, r)) => Val.bool(pos, Util.compareStringsByCodepoint(l, r) >= 0)
           case (Val.Num(_, l), Val.Num(_, r)) => Val.bool(pos, l >= r)
           case (x: Val.Arr, y: Val.Arr)       => Val.bool(pos, compare(x, y) >= 0)
           case _                              => fail()
@@ -834,7 +834,7 @@ class Evaluator(
   def compare(x: Val, y: Val): Int = (x, y) match {
     case (_: Val.Null, _: Val.Null) => 0
     case (x: Val.Num, y: Val.Num)   => x.asDouble.compareTo(y.asDouble)
-    case (x: Val.Str, y: Val.Str)   => x.value.compareTo(y.value)
+    case (x: Val.Str, y: Val.Str)   => Util.compareStringsByCodepoint(x.value, y.value)
     case (x: Val.Bool, y: Val.Bool) => x.asBoolean.compareTo(y.asBoolean)
     case (x: Val.Arr, y: Val.Arr)   =>
       val len = math.min(x.length, y.length)

--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -524,7 +524,8 @@ class Evaluator(
 
       case Expr.BinaryOp.OP_< =>
         (l, r) match {
-          case (Val.Str(_, l), Val.Str(_, r)) => Val.bool(pos, Util.compareStringsByCodepoint(l, r) < 0)
+          case (Val.Str(_, l), Val.Str(_, r)) =>
+            Val.bool(pos, Util.compareStringsByCodepoint(l, r) < 0)
           case (Val.Num(_, l), Val.Num(_, r)) => Val.bool(pos, l < r)
           case (x: Val.Arr, y: Val.Arr)       => Val.bool(pos, compare(x, y) < 0)
           case _                              => fail()
@@ -532,7 +533,8 @@ class Evaluator(
 
       case Expr.BinaryOp.OP_> =>
         (l, r) match {
-          case (Val.Str(_, l), Val.Str(_, r)) => Val.bool(pos, Util.compareStringsByCodepoint(l, r) > 0)
+          case (Val.Str(_, l), Val.Str(_, r)) =>
+            Val.bool(pos, Util.compareStringsByCodepoint(l, r) > 0)
           case (Val.Num(_, l), Val.Num(_, r)) => Val.bool(pos, l > r)
           case (x: Val.Arr, y: Val.Arr)       => Val.bool(pos, compare(x, y) > 0)
           case _                              => fail()
@@ -540,7 +542,8 @@ class Evaluator(
 
       case Expr.BinaryOp.OP_<= =>
         (l, r) match {
-          case (Val.Str(_, l), Val.Str(_, r)) => Val.bool(pos, Util.compareStringsByCodepoint(l, r) <= 0)
+          case (Val.Str(_, l), Val.Str(_, r)) =>
+            Val.bool(pos, Util.compareStringsByCodepoint(l, r) <= 0)
           case (Val.Num(_, l), Val.Num(_, r)) => Val.bool(pos, l <= r)
           case (x: Val.Arr, y: Val.Arr)       => Val.bool(pos, compare(x, y) <= 0)
           case _                              => fail()
@@ -548,7 +551,8 @@ class Evaluator(
 
       case Expr.BinaryOp.OP_>= =>
         (l, r) match {
-          case (Val.Str(_, l), Val.Str(_, r)) => Val.bool(pos, Util.compareStringsByCodepoint(l, r) >= 0)
+          case (Val.Str(_, l), Val.Str(_, r)) =>
+            Val.bool(pos, Util.compareStringsByCodepoint(l, r) >= 0)
           case (Val.Num(_, l), Val.Num(_, r)) => Val.bool(pos, l >= r)
           case (x: Val.Arr, y: Val.Arr)       => Val.bool(pos, compare(x, y) >= 0)
           case _                              => fail()

--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -375,9 +375,11 @@ class Evaluator(
       case (v: Val.Str, i: Val.Num) =>
         val int = i.asPositiveInt
         if (v.value.isEmpty) Error.fail("string bounds error: string is empty", pos)
-        if (int >= v.value.length)
-          Error.fail(s"string bounds error: $int not within [0, ${v.value.length})", pos)
-        Val.Str(pos, new String(Array(v.value(int))))
+        val unicodeLength = v.value.codePointCount(0, v.value.length)
+        if (int >= unicodeLength)
+          Error.fail(s"string bounds error: $int not within [0, $unicodeLength)", pos)
+        val (startUtf16, endUtf16) = Util.codePointOffsetsToStringIndices(v.value, int, int + 1)
+        Val.Str(pos, v.value.substring(startUtf16, endUtf16))
       case (v: Val.Obj, i: Val.Str) =>
         v.value(i.value, pos)
       case (lhs, rhs) =>

--- a/sjsonnet/src/sjsonnet/Materializer.scala
+++ b/sjsonnet/src/sjsonnet/Materializer.scala
@@ -34,7 +34,7 @@ abstract class Materializer {
             -1
           )
           if (sort) {
-            if (prevKey != null && k.compareTo(prevKey) <= 0)
+            if (prevKey != null && Util.compareStringsByCodepoint(k, prevKey) <= 0)
               Error.fail(
                 s"""Internal error: Unexpected key "$k" after "$prevKey" in sorted object materialization""",
                 v.pos

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -2113,13 +2113,16 @@ class Std(
   }
 
   def stringChars(pos: Position, str: String): Val.Arr = {
-    val a = new Array[Lazy](str.length)
+    val chars = new Array[Lazy](str.codePointCount(0, str.length))
+    var charIndex = 0
     var i = 0
-    while (i < a.length) {
-      a(i) = Val.Str(pos, String.valueOf(str.charAt(i)))
-      i += 1
+    while (i < str.length) {
+      val codePoint = str.codePointAt(i)
+      chars(charIndex) = Val.Str(pos, new String(Character.toChars(codePoint)))
+      i += Character.charCount(codePoint)
+      charIndex += 1
     }
-    Val.Arr(pos, a)
+    Val.Arr(pos, chars)
   }
 
   def getVisibleKeys(ev: EvalScope, v1: Val.Obj): Array[String] =

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -97,12 +97,14 @@ class Std(
   }
 
   private object Codepoint extends Val.Builtin1("codepoint", "str") {
-    def evalRhs(str: Lazy, ev: EvalScope, pos: Position): Val = if (
-      str.force.asString.length != 1 || str.force.asString.codePointCount(0, 1) > 1
-    ) {
-      Error.fail("expected a single character string, got " + str.force.asString)
-    } else {
-      Val.Num(pos, str.force.asString.codePointAt(0).toDouble)
+    def evalRhs(str: Lazy, ev: EvalScope, pos: Position): Val = {
+      val s = str.force.asString
+      val codePointCount = s.codePointCount(0, s.length)
+      if (codePointCount != 1) {
+        Error.fail("expected a single character string, got " + s)
+      } else {
+        Val.Num(pos, s.codePointAt(0).toDouble)
+      }
     }
   }
 

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -543,8 +543,8 @@ class Std(
       if (safeLength <= 0) {
         Val.Str(pos, "")
       } else {
-        val (startUtf16, endUtf16) =
-          Util.codePointOffsetsToStringIndices(str, safeOffset, safeOffset + safeLength)
+        val startUtf16 = if (safeOffset == 0) 0 else str.offsetByCodePoints(0, safeOffset)
+        val endUtf16 = str.offsetByCodePoints(startUtf16, safeLength)
         Val.Str(pos, str.substring(startUtf16, endUtf16))
       }
     }

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -1042,7 +1042,7 @@ class Std(
         indexedPath: Seq[String])(implicit ev: EvalScope): StringWriter = {
       val (sections, nonSections) =
         v.visibleKeyNames.partition(k => isSection(v.value(k, v.pos)(ev)))
-      for (k <- nonSections.sorted) {
+      for (k <- nonSections.sorted(Util.CodepointStringOrdering)) {
         out.write(cumulatedIndent)
         out.write(TomlRenderer.escapeKey(k))
         out.write(" = ")
@@ -1052,7 +1052,7 @@ class Std(
       }
       out.write('\n')
 
-      for (k <- sections.sorted) {
+      for (k <- sections.sorted(Util.CodepointStringOrdering)) {
         val v0 = v.value(k, v.pos, v)(ev)
         if (isTableArray(v0)) {
           for (i <- 0 until v0.asArr.length) {
@@ -2078,7 +2078,7 @@ class Std(
           val indices = Array.range(0, vs.length)
 
           val sortedIndices = if (keyType == classOf[Val.Str]) {
-            indices.sortBy(i => keys(i).cast[Val.Str].asString)
+            indices.sortBy(i => keys(i).cast[Val.Str].asString)(Util.CodepointStringOrdering)
           } else if (keyType == classOf[Val.Num]) {
             indices.sortBy(i => keys(i).cast[Val.Num].asDouble)
           } else if (keyType == classOf[Val.Arr]) {
@@ -2097,7 +2097,7 @@ class Std(
             Error.fail("Cannot sort with values that are not all the same type")
 
           if (keyType == classOf[Val.Str]) {
-            vs.map(_.force.cast[Val.Str]).sortBy(_.asString)
+            vs.map(_.force.cast[Val.Str]).sortBy(_.asString)(Util.CodepointStringOrdering)
           } else if (keyType == classOf[Val.Num]) {
             vs.map(_.force.cast[Val.Num]).sortBy(_.asDouble)
           } else if (keyType == classOf[Val.Arr]) {
@@ -2132,7 +2132,7 @@ class Std(
     maybeSortKeys(ev, v1.allKeyNames)
 
   @inline private def maybeSortKeys(ev: EvalScope, keys: Array[String]): Array[String] =
-    if (ev.settings.preserveOrder) keys else keys.sorted
+    if (ev.settings.preserveOrder) keys else keys.sorted(Util.CodepointStringOrdering)
 
   def getObjValuesFromKeys(
       pos: Position,

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -51,7 +51,7 @@ class Std(
       Val.Num(
         pos,
         x.force match {
-          case Val.Str(_, s) => s.length
+          case Val.Str(_, s) => s.codePointCount(0, s.length)
           case a: Val.Arr    => a.length
           case o: Val.Obj    => o.visibleKeyNames.length
           case o: Val.Func   => o.params.names.length

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -2118,7 +2118,7 @@ class Std(
     var i = 0
     while (i < str.length) {
       val codePoint = str.codePointAt(i)
-      chars(charIndex) = Val.Str(pos, new String(Character.toChars(codePoint)))
+      chars(charIndex) = Val.Str(pos, Character.toString(codePoint))
       i += Character.charCount(codePoint)
       charIndex += 1
     }

--- a/sjsonnet/src/sjsonnet/Std.scala
+++ b/sjsonnet/src/sjsonnet/Std.scala
@@ -535,9 +535,18 @@ class Std(
         case v: Val.Num => v.asPositiveInt
         case _ => Error.fail("Expected a number for len in substr, got " + len.force.prettyName)
       }
-      val safeOffset = math.min(offset, str.length)
-      val safeLength = math.min(length, str.length - safeOffset)
-      Val.Str(pos, str.substring(safeOffset, safeOffset + safeLength))
+
+      val unicodeLength = str.codePointCount(0, str.length)
+      val safeOffset = math.min(offset, unicodeLength)
+      val safeLength = math.min(length, unicodeLength - safeOffset)
+
+      if (safeLength <= 0) {
+        Val.Str(pos, "")
+      } else {
+        val (startUtf16, endUtf16) =
+          Util.codePointOffsetsToStringIndices(str, safeOffset, safeOffset + safeLength)
+        Val.Str(pos, str.substring(startUtf16, endUtf16))
+      }
     }
   }
 

--- a/sjsonnet/src/sjsonnet/Util.scala
+++ b/sjsonnet/src/sjsonnet/Util.scala
@@ -143,9 +143,9 @@ object Util {
   }
 
   /**
-   * Compares two strings by Unicode codepoint values rather than UTF-16 code units.
-   * This ensures that strings with characters above U+FFFF (which require surrogate pairs
-   * in UTF-16) are compared correctly according to their Unicode codepoint values.
+   * Compares two strings by Unicode codepoint values rather than UTF-16 code units. This ensures
+   * that strings with characters above U+FFFF (which require surrogate pairs in UTF-16) are
+   * compared correctly according to their Unicode codepoint values.
    */
   def compareStringsByCodepoint(s1: String, s2: String): Int = {
     val n1 = s1.length
@@ -176,8 +176,8 @@ object Util {
   }
 
   /**
-   * A reusable Ordering[String] that compares by Unicode codepoint values.
-   * Use this in place of default `.sorted` when ordering should be codepoint-aware.
+   * A reusable Ordering[String] that compares by Unicode codepoint values. Use this in place of
+   * default `.sorted` when ordering should be codepoint-aware.
    */
   val CodepointStringOrdering: Ordering[String] = new Ordering[String] {
     override def compare(x: String, y: String): Int = compareStringsByCodepoint(x, y)

--- a/sjsonnet/src/sjsonnet/Util.scala
+++ b/sjsonnet/src/sjsonnet/Util.scala
@@ -105,7 +105,8 @@ object Util {
           val (startUtf16, endUtf16) = codePointOffsetsToStringIndices(s, start, end)
           s.substring(startUtf16, endUtf16)
         case _ =>
-          val result = new java.lang.StringBuilder()
+          val result = new java.lang.StringBuilder(
+            math.min(s.length, ((end - start) + step - 1) / step))
           var sIdx = 0
           var codepointIndex = 0
 
@@ -118,19 +119,22 @@ object Util {
 
           // Collect every `step`th codepoint until `end`
           var rel = 0 // relative index from start
+          var nextInclude = 0 // next relative index to include
           while (sIdx < s.length && codepointIndex < end) {
             val c = s.charAt(sIdx)
             if (Character.isSurrogate(c)) {
-              // Handle surrogate pair
+              // Handle surrogate pair (or unpaired surrogates)
               val cp = s.codePointAt(sIdx)
-              if (rel % step == 0) {
+              if (rel == nextInclude) {
                 result.append(Character.toString(cp))
+                nextInclude += step
               }
               sIdx += Character.charCount(cp)
             } else {
               // Single char, non-surrogate
-              if (rel % step == 0) {
+              if (rel == nextInclude) {
                 result.append(c)
+                nextInclude += step
               }
               sIdx += 1
             }

--- a/sjsonnet/src/sjsonnet/Util.scala
+++ b/sjsonnet/src/sjsonnet/Util.scala
@@ -105,8 +105,8 @@ object Util {
           val (startUtf16, endUtf16) = codePointOffsetsToStringIndices(s, start, end)
           s.substring(startUtf16, endUtf16)
         case _ =>
-          val result = new java.lang.StringBuilder(
-            math.min(s.length, ((end - start) + step - 1) / step))
+          val result =
+            new java.lang.StringBuilder(math.min(s.length, ((end - start) + step - 1) / step))
           var sIdx = 0
           var codepointIndex = 0
 

--- a/sjsonnet/src/sjsonnet/Util.scala
+++ b/sjsonnet/src/sjsonnet/Util.scala
@@ -112,7 +112,7 @@ object Util {
           // Skip to start codepoint position
           while (sIdx < s.length && codepointIndex < start) {
             val cp = s.codePointAt(sIdx)
-            sIdx += java.lang.Character.charCount(cp)
+            sIdx += Character.charCount(cp)
             codepointIndex += 1
           }
 
@@ -120,13 +120,13 @@ object Util {
           var rel = 0 // relative index from start
           while (sIdx < s.length && codepointIndex < end) {
             val c = s.charAt(sIdx)
-            if (java.lang.Character.isSurrogate(c)) {
+            if (Character.isSurrogate(c)) {
               // Handle surrogate pair
               val cp = s.codePointAt(sIdx)
               if (rel % step == 0) {
-                result.append(java.lang.Character.toChars(cp))
+                result.append(Character.toString(cp))
               }
-              sIdx += java.lang.Character.charCount(cp)
+              sIdx += Character.charCount(cp)
             } else {
               // Single char, non-surrogate
               if (rel % step == 0) {
@@ -155,21 +155,21 @@ object Util {
     while (i1 < n1 && i2 < n2) {
       val c1 = s1.charAt(i1)
       val c2 = s2.charAt(i2)
-      val c1Sur = java.lang.Character.isSurrogate(c1)
-      val c2Sur = java.lang.Character.isSurrogate(c2)
+      val c1Sur = Character.isSurrogate(c1)
+      val c2Sur = Character.isSurrogate(c2)
 
       if (!c1Sur && !c2Sur) {
         // Both are non-surrogates, compare directly
-        if (c1 != c2) return java.lang.Character.compare(c1, c2)
+        if (c1 != c2) return Character.compare(c1, c2)
         i1 += 1
         i2 += 1
       } else {
         // At least one is a surrogate, use full codepoint logic
         val cp1 = s1.codePointAt(i1)
         val cp2 = s2.codePointAt(i2)
-        if (cp1 != cp2) return java.lang.Integer.compare(cp1, cp2)
-        i1 += java.lang.Character.charCount(cp1)
-        i2 += java.lang.Character.charCount(cp2)
+        if (cp1 != cp2) return Integer.compare(cp1, cp2)
+        i1 += Character.charCount(cp1)
+        i2 += Character.charCount(cp2)
       }
     }
     if (i1 < n1) 1 else if (i2 < n2) -1 else 0

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -455,7 +455,7 @@ object Val {
 
     def foreachElement(sort: Boolean, pos: Position)(f: (String, Val) => Unit)(implicit
         ev: EvalScope): Unit = {
-      val keys = if (sort) visibleKeyNames.sorted else visibleKeyNames
+      val keys = if (sort) visibleKeyNames.sorted(Util.CodepointStringOrdering) else visibleKeyNames
       for (k <- keys) {
         val v = value(k, pos)
         f(k, v)

--- a/sjsonnet/test/src/sjsonnet/UnicodeHandlingTests.scala
+++ b/sjsonnet/test/src/sjsonnet/UnicodeHandlingTests.scala
@@ -1,0 +1,174 @@
+package sjsonnet
+
+import utest._
+import TestUtils.{eval, evalErr}
+
+/**
+ * Tests for correct handling of Unicode strings, especially those that require surrogate pairs in
+ * UTF-16 (i.e., codepoints above U+FFFF).
+ */
+object UnicodeHandlingTests extends TestSuite {
+  def tests: Tests = Tests {
+
+    test("stringLength") {
+      eval("std.length('🌍')") ==> ujson.Num(1)
+      eval("std.length('Hello 🌍')") ==> ujson.Num(7)
+      eval("std.length('👨‍👩‍👧‍👦')") ==> ujson.Num(7) // Family emoji with ZWJ sequences
+    }
+
+    test("stringIndex") {
+      eval("'Hello 🌍 World'[6]") ==> ujson.Str("🌍")
+      eval("'A🌍B'[1]") ==> ujson.Str("🌍")
+      assert(evalErr("'A🌍B'[3]").contains("string bounds error"))
+    }
+
+    test("codepoint") {
+      eval("std.codepoint('🌍')") ==> ujson.Num(127757)
+      assert(evalErr("std.codepoint('')").contains("expected a single character string"))
+      assert(evalErr("std.codepoint('🌍!')").contains("expected a single character string"))
+      assert(evalErr("std.codepoint('abc')").contains("expected a single character string"))
+    }
+
+    test("char") {
+      eval("std.char(127757)") ==> ujson.Str("🌍")
+    }
+
+    test("stringChars") {
+      eval("std.stringChars('🌍')") ==> ujson.Arr("🌍")
+      eval("std.stringChars('Hello 🌍')") ==> ujson.Arr("H", "e", "l", "l", "o", " ", "🌍")
+    }
+
+    test("map") {
+      eval("std.map(function(x) std.codepoint(x), '🌍')") ==> ujson.Arr(127757)
+      eval("std.map(function(x) std.codepoint(x), 'A🌍B')") ==> ujson.Arr(65, 127757, 66)
+    }
+
+    test("substr") {
+      eval("std.substr('A🌍B', 0, 1)") ==> ujson.Str("A")
+      eval("std.substr('A🌍B', 1, 1)") ==> ujson.Str("🌍")
+      eval("std.substr('A🌍B', 2, 1)") ==> ujson.Str("B")
+      eval("std.substr('Hello 🌍 World', 6, 100)") ==> ujson.Str("🌍 World")
+      eval("std.substr('🌍', 1, 5)") ==> ujson.Str("") // Beyond string length
+    }
+
+    test("stringSlice") {
+      eval("'A🌍B'[0:1]") ==> ujson.Str("A")
+      eval("'A🌍B'[1:2]") ==> ujson.Str("🌍")
+      eval("'A🌍B🚀C'[0:5:2]") ==> ujson.Str("ABC")
+      eval("'ABC🚀'[-2:]") ==> ujson.Str("C🚀")
+    }
+
+    test("codepointVsUtf16Ordering") {
+      // This test demonstrates why sjsonnet uses Unicode codepoint ordering instead of UTF-16 code unit ordering.
+      //
+      // The problem: UTF-16 encodes characters above U+FFFF as "surrogate pairs" - two 16-bit code units.
+      // When comparing strings by UTF-16 code units, we only look at the raw 16-bit values, not the
+      // actual Unicode codepoints they represent.
+      //
+      // Critical test case:
+      // - U+FFFF = "\uFFFF" → UTF-16: [0xFFFF] (single code unit)
+      // - U+10000 = "\uD800\uDC00" → UTF-16: [0xD800, 0xDC00] (surrogate pair: high + low surrogate)
+      //
+      // Correct Unicode codepoint order: U+FFFF (65535) < U+10000 (65536) → "\uFFFF" < "\uD800\uDC00"
+      //
+      // Wrong UTF-16 code unit order: When comparing "\uFFFF" vs "\uD800\uDC00", UTF-16 comparison sees:
+      //   0xFFFF (65535) vs 0xD800 (55296) ← only looks at first code unit of surrogate pair!
+      //   Since 65535 > 55296, it incorrectly concludes "\uFFFF" > "\uD800\uDC00"
+      //
+      // This breaks ordering for ALL characters above U+FFFF (emojis, math symbols, etc.)
+
+      val testStrings = Array("\uFFFF", "\uD800\uDC00") // U+FFFF, U+10000
+
+      // Scala's default string ordering uses UTF-16 code units: "\uD800\uDC00" < "\uFFFF"
+      val utf16Sorted = testStrings.sorted.toList
+      utf16Sorted ==> List("\uD800\uDC00", "\uFFFF")
+
+      // Our Unicode codepoint ordering: "\uFFFF" < "\uD800\uDC00"
+      val codepointSorted = testStrings.sorted(sjsonnet.Util.CodepointStringOrdering).toList
+      codepointSorted ==> List("\uFFFF", "\uD800\uDC00")
+
+      // Critical: these produce different results! This test would fail with UTF-16 ordering.
+      assert(utf16Sorted != codepointSorted)
+
+      // Jsonnet string operations should use Unicode codepoint ordering
+      eval("'\\uFFFF' < '\\uD800\\uDC00'") ==> ujson.Bool(true)
+      eval("std.sort(['\\uD800\\uDC00', '\\uFFFF'])") ==> ujson.Arr("\uFFFF", "\uD800\uDC00")
+    }
+
+    // sjsonnet allows unpaired surrogates in Unicode escape sequences,
+    // unlike go-jsonnet and C++ jsonnet which reject them at parse time.
+
+    test("unpairedSurrogatesInEscapes") {
+      // These should parse successfully (go-jsonnet/C++ jsonnet would fail)
+      eval("\"\\uD800\"") ==> ujson.Str("\uD800") // High surrogate
+      eval("\"\\uDC00\"") ==> ujson.Str("\uDC00") // Low surrogate
+      eval("\"\\uD83D\\uDE00\"") ==> ujson.Str("😀") // Valid pair
+    }
+
+    test("stdCharPreservesRawSurrogates") {
+      // std.char() preserves raw surrogate codepoints (go-jsonnet replaces with U+FFFD)
+      eval("std.codepoint(std.char(55296))") ==> ujson.Num(55296) // 0xD800 high surrogate
+      eval("std.codepoint(std.char(56320))") ==> ujson.Num(56320) // 0xDC00 low surrogate
+    }
+
+    test("stringComparisons") {
+      // Comprehensive test of ALL comparison operators with the critical UTF-16 vs Unicode boundary case
+      // This ensures mutation testing catches bugs in any specific comparison implementation
+
+      val maxBmp = "'\\uFFFF'"      // U+FFFF (max Basic Multilingual Plane)
+      val minSupplementary = "'\\uD800\\uDC00'" // U+10000 (min Supplementary Plane)
+
+      // All comparison operators must use Unicode codepoint ordering
+      // With UTF-16 code unit ordering, these would ALL give wrong results
+
+      // Less than: U+FFFF < U+10000
+      eval(s"$maxBmp < $minSupplementary") ==> ujson.Bool(true)
+      eval(s"$minSupplementary < $maxBmp") ==> ujson.Bool(false)
+
+      // Less than or equal: U+FFFF <= U+10000
+      eval(s"$maxBmp <= $minSupplementary") ==> ujson.Bool(true)
+      eval(s"$minSupplementary <= $maxBmp") ==> ujson.Bool(false)
+      eval(s"$maxBmp <= $maxBmp") ==> ujson.Bool(true) // Reflexivity
+
+      // Greater than: U+10000 > U+FFFF
+      eval(s"$minSupplementary > $maxBmp") ==> ujson.Bool(true)
+      eval(s"$maxBmp > $minSupplementary") ==> ujson.Bool(false)
+
+      // Greater than or equal: U+10000 >= U+FFFF
+      eval(s"$minSupplementary >= $maxBmp") ==> ujson.Bool(true)
+      eval(s"$maxBmp >= $minSupplementary") ==> ujson.Bool(false)
+      eval(s"$maxBmp >= $maxBmp") ==> ujson.Bool(true) // Reflexivity
+
+      // Equality and inequality
+      eval(s"$maxBmp == $minSupplementary") ==> ujson.Bool(false)
+      eval(s"$maxBmp != $minSupplementary") ==> ujson.Bool(true)
+      eval(s"$maxBmp == $maxBmp") ==> ujson.Bool(true) // Reflexivity
+      eval(s"$maxBmp != $maxBmp") ==> ujson.Bool(false)
+
+      // Array sorting must also use codepoint ordering
+      eval(s"std.sort([$minSupplementary, $maxBmp, 'Z', 'A'])") ==> ujson.Arr("A", "Z", "\uFFFF", "\uD800\uDC00")
+    }
+
+
+    test("objectFieldOrdering") {
+      // Test object field ordering with the critical UTF-16 vs Unicode boundary case
+      // Input deliberately in REVERSE codepoint order to make the test non-trivial
+      val testObject = "{\"\uD800\uDC00\": 4, \"\uFFFF\": 3, \"z\": 2, \"a\": 1}"
+
+      // All object field functions should sort by Unicode codepoint order
+      eval(s"std.objectFields($testObject)") ==> ujson.Arr("a", "z", "\uFFFF", "\uD800\uDC00")
+      eval(s"std.objectFieldsAll($testObject)") ==> ujson.Arr("a", "z", "\uFFFF", "\uD800\uDC00")
+
+      // Default object rendering also uses codepoint ordering
+      eval(testObject).toString ==> "{\"a\":1,\"z\":2,\"\uFFFF\":3,\"\uD800\uDC00\":4}"
+
+      // JSON manifest should maintain the same ordering
+      eval(s"std.manifestJsonMinified($testObject)") ==>
+        ujson.Str("{\"a\":1,\"z\":2,\"\uFFFF\":3,\"\uD800\uDC00\":4}")
+
+      // TOML manifest should also use codepoint ordering (with escaped Unicode)
+      eval(s"std.manifestTomlEx($testObject, '  ')") ==>
+        ujson.Str("a = 1\nz = 2\n\"\\uffff\" = 3\n\"\\ud800\\udc00\" = 4")
+    }
+  }
+}

--- a/sjsonnet/test/src/sjsonnet/UnicodeHandlingTests.scala
+++ b/sjsonnet/test/src/sjsonnet/UnicodeHandlingTests.scala
@@ -115,7 +115,7 @@ object UnicodeHandlingTests extends TestSuite {
       // Comprehensive test of ALL comparison operators with the critical UTF-16 vs Unicode boundary case
       // This ensures mutation testing catches bugs in any specific comparison implementation
 
-      val maxBmp = "'\\uFFFF'"      // U+FFFF (max Basic Multilingual Plane)
+      val maxBmp = "'\\uFFFF'" // U+FFFF (max Basic Multilingual Plane)
       val minSupplementary = "'\\uD800\\uDC00'" // U+10000 (min Supplementary Plane)
 
       // All comparison operators must use Unicode codepoint ordering
@@ -146,9 +146,13 @@ object UnicodeHandlingTests extends TestSuite {
       eval(s"$maxBmp != $maxBmp") ==> ujson.Bool(false)
 
       // Array sorting must also use codepoint ordering
-      eval(s"std.sort([$minSupplementary, $maxBmp, 'Z', 'A'])") ==> ujson.Arr("A", "Z", "\uFFFF", "\uD800\uDC00")
+      eval(s"std.sort([$minSupplementary, $maxBmp, 'Z', 'A'])") ==> ujson.Arr(
+        "A",
+        "Z",
+        "\uFFFF",
+        "\uD800\uDC00"
+      )
     }
-
 
     test("objectFieldOrdering") {
       // Test object field ordering with the critical UTF-16 vs Unicode boundary case
@@ -164,11 +168,11 @@ object UnicodeHandlingTests extends TestSuite {
 
       // JSON manifest should maintain the same ordering
       eval(s"std.manifestJsonMinified($testObject)") ==>
-        ujson.Str("{\"a\":1,\"z\":2,\"\uFFFF\":3,\"\uD800\uDC00\":4}")
+      ujson.Str("{\"a\":1,\"z\":2,\"\uFFFF\":3,\"\uD800\uDC00\":4}")
 
       // TOML manifest should also use codepoint ordering (with escaped Unicode)
       eval(s"std.manifestTomlEx($testObject, '  ')") ==>
-        ujson.Str("a = 1\nz = 2\n\"\\uffff\" = 3\n\"\\ud800\\udc00\" = 4")
+      ujson.Str("a = 1\nz = 2\n\"\\uffff\" = 3\n\"\\ud800\\udc00\" = 4")
     }
 
     test("flatMap") {
@@ -183,12 +187,14 @@ object UnicodeHandlingTests extends TestSuite {
 
       // Critical test: surrogate pair boundary case
       // U+FFFF followed by U+10000 (which needs surrogate pair)
-      eval("std.flatMap(function(x) x + '-', '\\uFFFF\\uD800\\uDC00')") ==> ujson.Str("\uFFFF-\uD800\uDC00-")
+      eval("std.flatMap(function(x) x + '-', '\\uFFFF\\uD800\\uDC00')") ==> ujson.Str(
+        "\uFFFF-\uD800\uDC00-"
+      )
 
       // Test consistency with std.map behavior
       val testStr = "'A🌍B'";
       eval(s"std.length(std.flatMap(function(x) x, $testStr))") ==>
-        eval(s"std.length(std.map(function(x) x, $testStr))")
+      eval(s"std.length(std.map(function(x) x, $testStr))")
 
       // Test with function that returns null (should be converted to empty string)
       eval("std.flatMap(function(x) if x == '🌍' then null else x, 'A🌍B')") ==> ujson.Str("AB")
@@ -232,7 +238,9 @@ object UnicodeHandlingTests extends TestSuite {
       val testString = "'Hello 🌍 World'";
       val searchPattern = "'🌍'";
       // This verifies that the index returned by findSubstr works with substr to extract the same pattern
-      eval(s"std.substr($testString, std.findSubstr($searchPattern, $testString)[0], std.length($searchPattern))") ==> ujson.Str("🌍")
+      eval(
+        s"std.substr($testString, std.findSubstr($searchPattern, $testString)[0], std.length($searchPattern))"
+      ) ==> ujson.Str("🌍")
     }
   }
 }


### PR DESCRIPTION
**TL;DR**: sjsonnet string operations (length, indexing, ordering) were operating on UTF-16 code units (i.e. Java / Scala chars) but this is inconsistent with the jsonnet language reference, which [defines](https://jsonnet.org/ref/language.html#string) jsonnet strings as sequences of Unicode codepoints.

As a consequence, sjsonnet returned incorrect results (w.r.t. the go/c++ reference implementations) for several operations involving strings containing Unicode characters with codepoints outside of the [Basic Multilingual Plane](https://en.wikipedia.org/wiki/Plane_(Unicode)#Basic_Multilingual_Plane). 

For example, the string "🌍" consists of a single codepoint (`\u1F30D`, "earth globe europe-africa") and its UTF-16 representation is the surrogate pair `\uD83C\uDF0D`. In Java, this string has `.length == 2` but `.codePointCount == 1`. Sjsonnet was returning `std.length("🌍") == 2` instead of `1`. Similar issues affected string indexing, slicing, and sorting.

https://github.com/google/go-jsonnet/issues/600 is a related past issue in go-jsonnet.

---

This PR aims to holistically update string operations and `std` functions to operate over codepoints:

- `std.codepoint`: now handles non-BMP characters; previously, errored with a complaint about a too-long input string.
- Slicing and indexing:
  - `[]` operator
  - `std.substr`
  - `std.length`
  - `std.findSubstr`
- Iteration:
  - `std.stringChars`,
  - `std.map`
  - `std.flatMap`
- Comparison / ordering / sorting:
  - binary operations (`<`, <=`, `>`, `>=`)
  - `Evaluator.compare`
  - Materializer object field sorting
  - `std.manfiestTomlEx`, `std.manifestJson`
  - `std.objectFields`, `std.objectFieldsAll`

## Performance considerations

Since most jsonnet inputs probably contain only ASCII or Latin-1 characters, it's important that we don't regress performance _too_ much.

In some cases, Java's [compact string](https://openjdk.org/jeps/254) optimizations might hide most of the perf. impact. For example, [`String.codePointCount`](https://github.com/openjdk/jdk/blob/8d236615b7db2bd5a2a59002b79e59cf4e6a308a/src/java.base/share/classes/java/lang/String.java#L1727-L1732) has a O(1) fastpath for Latin-1 strings and similar shortcuts exist for `codePointAt`. The biggest impact is likely to be in sorting / comparison: I didn't notice huge differences in end-to-end benchmarks sorting lots of strings with long common prefixes, so I wager that this comparison performance is unlikely to be a significant issue in real practice.

## Design decision: preserving existing handling of unpaired surrogates

There are pre-existing small discrepancies in how c++ and go jsonnet handle unpaired surrogates:

- Both reject unpaired surrogates in string escapes, whereas sjsonnet permits them.
- In go-jsonnet, `std.char()` maps surrogates' codepoints to the replacement character (e.g. `std.codepoint(std.char(55296)) == 65533`), whereas c++ jsonnet preserves them as unpaired surrogates.

In this PR, I have (somewhat arbitrarily) chosen  to preserve sjsonnet's existing permissive behavior and have added new test cases to cover it.