### PR TITLE
Add flag re-introduce broken assertions evaluation, as a temporary measure to help with migration

### DIFF
--- a/sjsonnet/src-jvm-native/sjsonnet/Config.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/Config.scala
@@ -146,6 +146,12 @@ final case class Config(
     )
     maxParserRecursionDepth: Int = 1000,
     @arg(
+      name = "broken-assertion-logic",
+      doc =
+        "Re-enable pre-0.5.5 broken assertion logic. See https://github.com/databricks/sjsonnet/issues/526."
+    )
+    brokenAssertionLogic: Flag = Flag(),
+    @arg(
       doc = "The jsonnet file you wish to evaluate",
       positional = true
     )

--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -898,8 +898,8 @@ class Evaluator(
           val k2 = y.visibleKeyNames
           val k1len = k1.length
           if (k1len != k2.length) return false
-          x.triggerAllAsserts()
-          y.triggerAllAsserts()
+          x.triggerAllAsserts(settings.brokenAssertionLogic)
+          y.triggerAllAsserts(settings.brokenAssertionLogic)
           var i = 0
           while (i < k1len) {
             val k = k1(i)

--- a/sjsonnet/src/sjsonnet/Materializer.scala
+++ b/sjsonnet/src/sjsonnet/Materializer.scala
@@ -22,7 +22,7 @@ abstract class Materializer {
       case Val.Str(pos, s) => storePos(pos); visitor.visitString(s, -1)
       case obj: Val.Obj    =>
         storePos(obj.pos)
-        obj.triggerAllAsserts()
+        obj.triggerAllAsserts(evaluator.settings.brokenAssertionLogic)
         val objVisitor = visitor.visitObject(obj.visibleKeyNames.length, jsonableKeys = true, -1)
         val sort = !evaluator.settings.preserveOrder
         var prevKey: String = null

--- a/sjsonnet/src/sjsonnet/Settings.scala
+++ b/sjsonnet/src/sjsonnet/Settings.scala
@@ -9,7 +9,8 @@ final case class Settings(
     val strict: Boolean = false,
     val throwErrorForInvalidSets: Boolean = false,
     val useNewEvaluator: Boolean = false,
-    val maxParserRecursionDepth: Int = 1000
+    val maxParserRecursionDepth: Int = 1000,
+    val brokenAssertionLogic: Boolean = false
 )
 
 object Settings {

--- a/sjsonnet/test/src/sjsonnet/TestUtils.scala
+++ b/sjsonnet/test/src/sjsonnet/TestUtils.scala
@@ -8,6 +8,7 @@ object TestUtils {
       preserveOrder: Boolean = false,
       strict: Boolean = false,
       useNewEvaluator: Boolean = false,
+      brokenAssertionLogic: Boolean = false,
       std: sjsonnet.stdlib.StdLibModule = sjsonnet.stdlib.StdLibModule.Default)
       : Either[String, Value] = {
     new Interpreter(
@@ -20,7 +21,8 @@ object TestUtils {
         preserveOrder = preserveOrder,
         strict = strict,
         throwErrorForInvalidSets = true,
-        useNewEvaluator = useNewEvaluator
+        useNewEvaluator = useNewEvaluator,
+        brokenAssertionLogic = brokenAssertionLogic
       ),
       std = std.module
     ).interpret(s, DummyPath("(memory)"))
@@ -31,12 +33,14 @@ object TestUtils {
       preserveOrder: Boolean = false,
       strict: Boolean = false,
       useNewEvaluator: Boolean = false,
+      brokenAssertionLogic: Boolean = false,
       std: sjsonnet.stdlib.StdLibModule = sjsonnet.stdlib.StdLibModule.Default): Value = {
     eval0(
       s,
       preserveOrder,
       strict,
       useNewEvaluator,
+      brokenAssertionLogic,
       std
     ) match {
       case Right(x) => x
@@ -49,12 +53,14 @@ object TestUtils {
       preserveOrder: Boolean = false,
       strict: Boolean = false,
       useNewEvaluator: Boolean = false,
+      brokenAssertionLogic: Boolean = false,
       std: sjsonnet.stdlib.StdLibModule = sjsonnet.stdlib.StdLibModule.Default): String = {
     eval0(
       s,
       preserveOrder,
       strict,
       useNewEvaluator,
+      brokenAssertionLogic,
       std
     ) match {
       case Left(err) =>


### PR DESCRIPTION
Workaround for https://github.com/databricks/sjsonnet/issues/526