### PR TITLE
Remove common reasons for materialization to fail due to stack overflows

### DIFF
--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -266,8 +266,8 @@ object Val {
   final class Obj(
       val pos: Position,
       private var value0: util.LinkedHashMap[String, Obj.Member],
-      static: Boolean,
-      triggerAsserts: (Val.Obj, Val.Obj) => Unit,
+      private val static: Boolean,
+      private val triggerAsserts: (Val.Obj, Val.Obj) => Unit,
       `super`: Obj,
       valueCache: util.HashMap[Any, Val] = new util.HashMap[Any, Val](),
       private var allKeys: util.LinkedHashMap[String, java.lang.Boolean] = null)
@@ -313,24 +313,41 @@ object Val {
     }
 
     def addSuper(pos: Position, lhs: Val.Obj): Val.Obj = {
-      `super` match {
-        case null => new Val.Obj(pos, getValue0, false, triggerAsserts, lhs)
-        case x    => new Val.Obj(pos, getValue0, false, triggerAsserts, x.addSuper(pos, lhs))
+      val objs = mutable.ArrayBuffer(this)
+      var current = this
+      while (current.getSuper != null) {
+        objs += current.getSuper
+        current = current.getSuper
       }
+
+      current = lhs
+      for (s <- objs.reverse) {
+        current = new Val.Obj(s.pos, s.getValue0, false, s.triggerAsserts, current)
+      }
+      current
     }
 
     def prettyName = "object"
     override def asObj: Val.Obj = this
 
     private def gatherKeys(mapping: util.LinkedHashMap[String, java.lang.Boolean]): Unit = {
-      if (static) mapping.putAll(allKeys)
-      else {
-        if (`super` != null) `super`.gatherKeys(mapping)
-        getValue0.forEach { (k, m) =>
-          val vis = m.visibility
-          if (!mapping.containsKey(k)) mapping.put(k, vis == Visibility.Hidden)
-          else if (vis == Visibility.Hidden) mapping.put(k, true)
-          else if (vis == Visibility.Unhide) mapping.put(k, false)
+      val objs = mutable.ArrayBuffer(this)
+      var current = this
+      while (current.getSuper != null) {
+        objs += current.getSuper
+        current = current.getSuper
+      }
+
+      for (s <- objs.reverse) {
+        if (s.static) {
+          mapping.putAll(s.allKeys)
+        } else {
+          s.getValue0.forEach { (k, m) =>
+            val vis = m.visibility
+            if (!mapping.containsKey(k)) mapping.put(k, vis == Visibility.Hidden)
+            else if (vis == Visibility.Hidden) mapping.put(k, true)
+            else if (vis == Visibility.Unhide) mapping.put(k, false)
+          }
         }
       }
     }

--- a/sjsonnet/test/resources/new_test_suite/deeply_recursive_manifestation.jsonnet
+++ b/sjsonnet/test/resources/new_test_suite/deeply_recursive_manifestation.jsonnet
@@ -1,0 +1,105 @@
+local reduce(func, array, default) =
+  //  assert std.isFunction(func) : error 'reduce(func=...) should be a `function`';
+  //  assert std.isArray(array) : error 'reduce(array=...) should be an `array`';
+  //  assert std.length(array) > 0 : error 'reduce(array=...) should be a non-0 `array`';
+  local aux(func, array, current, index) =
+    if index < 0 then
+      current
+    else
+      aux(func, array, func(array[index], current), index - 1) tailstrict;
+  local length = std.length(array);
+  if length == 0 then
+    default
+  else
+    aux(func, array, array[length - 1], length - 2);
+
+local visit(
+  value,
+  visitor,
+  ctx,
+  ctx_reducer,
+      ) =
+  local new_item = if std.isObject(value) then
+    local merged = {
+      [prop]: visit(value[prop], visitor, ctx, ctx_reducer)
+      for prop in std.objectFields(value)
+    };
+
+    local new_item = {
+      [prop]: merged[prop].item
+      for prop in std.objectFields(merged)
+    };
+    local new_ctx = reduce(ctx_reducer, std.map(
+      function(item) item.ctx,
+      std.objectValues(merged)
+    ), ctx);
+
+    {
+      item: new_item,
+      ctx: new_ctx,
+    }
+  else if std.isArray(value) then
+    local merged = std.map(
+      function(item) visit(item, visitor, ctx, ctx_reducer),
+      value,
+    );
+
+    // If we had a way to tee collections, that would be great... :(
+    local new_item = std.map(function(item) item.item, merged);
+    local all_ctx = std.map(function(item) item.ctx, merged);
+
+    // Reduce all of the contexts
+    local new_ctx = reduce(ctx_reducer, all_ctx, ctx);
+
+    {
+      item: new_item,
+      ctx: new_ctx,
+    }
+  else
+    {
+      item: value,
+      ctx: ctx,
+    };
+  local replacement = visitor(new_item.ctx, new_item.item);
+  if replacement != null then
+    local new_ctx = ctx_reducer(replacement.ctx, new_item.ctx);
+
+    {
+      item: replacement.item,
+      ctx: new_ctx,
+    }
+  else
+    new_item;
+
+
+local routes = {
+  '/inc/users/whoami': {
+    get: {
+      responses: {
+        '200': {
+          content: {
+            'application/json': {
+              schema: {
+                properties: {
+                  user: {
+                    properties: {
+                      '#id': 'the id this entity',
+                      id: {
+                        format: 'uuid',
+                        type: 'string',
+                        'x-name': 'users.User',
+                      },
+                    },
+                    type: 'object',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+visit(routes, function(ctx, item) { ctx: ctx, item: item }, {}, function(left, right) left + right)

--- a/sjsonnet/test/resources/new_test_suite/deeply_recursive_manifestation.jsonnet.golden
+++ b/sjsonnet/test/resources/new_test_suite/deeply_recursive_manifestation.jsonnet.golden
@@ -1,0 +1,32 @@
+{
+   "ctx": { },
+   "item": {
+      "/inc/users/whoami": {
+         "get": {
+            "responses": {
+               "200": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "properties": {
+                              "user": {
+                                 "properties": {
+                                    "#id": "the id this entity",
+                                    "id": {
+                                       "format": "uuid",
+                                       "type": "string",
+                                       "x-name": "users.User"
+                                    }
+                                 },
+                                 "type": "object"
+                              }
+                           }
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      }
+   }
+}

--- a/sjsonnet/test/src-js/sjsonnet/FileTests.scala
+++ b/sjsonnet/test/src-js/sjsonnet/FileTests.scala
@@ -55,7 +55,7 @@ object FileTests extends BaseFileTests {
 
     test("new_test_suite") - {
       val t = TestResources_new_test_suite.files.keys.toSeq
-        .filter(f => f.matches("[^/]+-js\\.jsonnet"))
+        .filter(f => f.matches("[^/]+-js\\.jsonnet") || (f.matches("[^/]+\\.jsonnet") && !f.contains("-jvm")))
         .sorted
       assert(t.nonEmpty)
       t.foreach { file =>

--- a/sjsonnet/test/src-jvm-native/sjsonnet/FileTests.scala
+++ b/sjsonnet/test/src-jvm-native/sjsonnet/FileTests.scala
@@ -45,7 +45,7 @@ object FileTests extends BaseFileTests {
     test("new_test_suite") - {
       val t = os
         .list(testSuiteRoot / "new_test_suite")
-        .filter(f => f.ext == "jsonnet" && f.last.contains("jvm-native"))
+        .filter(f => f.ext == "jsonnet" && !f.last.contains("-js"))
       assert(t.nonEmpty)
       t.foreach { file =>
         check(file, "new_test_suite")


### PR DESCRIPTION
This rewrite Val.Obj addSuper and gatherKeys to be iterative instead of recursive.

Fixes https://github.com/databricks/sjsonnet/issues/392