### PR TITLE
Run the regression benchmarks faster

### DIFF
--- a/bench/src/sjsonnet/bench/RegressionBenchmark.scala
+++ b/bench/src/sjsonnet/bench/RegressionBenchmark.scala
@@ -20,8 +20,7 @@ object RegressionBenchmark {
 
 @BenchmarkMode(Array(Mode.AverageTime))
 @Fork(1)
-@Threads(1)
-@Warmup(iterations = 1)
+@Warmup(iterations = 1, time = 2)
 @Measurement(iterations = 1)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)

--- a/build.mill
+++ b/build.mill
@@ -18,6 +18,7 @@ import javalib.NativeImageModule
 import contrib.versionfile.VersionFileModule
 import contrib.jmh.JmhModule
 import mill.util.Jvm
+import mill.api.BuildCtx
 
 import java.util.Base64
 
@@ -101,18 +102,27 @@ object bench extends ScalaModule with JmhModule with ScalafmtModule {
     this.moduleDir / "resources" / "go_suite"
   )
 
-  def generateBenchmarkList = Task.Anon {
-    resources().map(_.path).flatMap(os.walk(_).filter(os.isFile).filter(_.ext == "jsonnet")).map(_.toString).mkString(",")
+  def listRegressions = Task {
+    resources()
+      .map(_.path)
+      .flatMap(
+        os.walk(_)
+          .filter(os.isFile)
+          .filter(_.ext == "jsonnet")
+      )
+      .sortBy(_.toString)
+      .map(_.relativeTo(BuildCtx.workspaceRoot).toString)
   }
 
-  def regressionBenchs() =     Task.Command {
+  def runRegressions(args: String*) = Task.Command {
     val (_, resources) = generateBenchmarkSources()
+    val regressionCases = if args.isEmpty then listRegressions() else args.toSeq
     val forkedArgs = forkArgs().toSeq
     Jvm.callProcess(
       mainClass = "org.openjdk.jmh.Main",
       classPath = (runClasspath() ++ generatorDeps()).map(_.path) ++
         Seq(jmhGeneratedSources().path, resources.path),
-      mainArgs = Array("sjsonnet.bench.RegressionBenchmark.main" ,s"-p=path=${generateBenchmarkList()}"),
+      mainArgs = Array("sjsonnet.bench.RegressionBenchmark.main" ,s"-p=path=${regressionCases.mkString(",")}"),
       cwd = Task.ctx().dest,
       javaHome = javaHome().map(_.path),
       jvmArgs = forkedArgs,


### PR DESCRIPTION
- add `./mill bench.listRegressions`
- rename runner to `./mill bench.runRegressions` and accepts parameters to run select test cases.
- tweak numbers of warmup/rounds

TBA:
- Add FileTest to verify golden files for the test cases.

Current results from HEAD on my laptop:
```
[1-113] Benchmark                                                                  (path)  Mode  Cnt   Score   Error  Units
[1-113] RegressionBenchmark.main             bench/resources/bug_suite/assertions.jsonnet  avgt        0.267          ms/op
[1-113] RegressionBenchmark.main               bench/resources/cpp_suite/bench.01.jsonnet  avgt        0.064          ms/op
[1-113] RegressionBenchmark.main               bench/resources/cpp_suite/bench.02.jsonnet  avgt       34.823          ms/op
[1-113] RegressionBenchmark.main               bench/resources/cpp_suite/bench.03.jsonnet  avgt       14.813          ms/op
[1-113] RegressionBenchmark.main               bench/resources/cpp_suite/bench.04.jsonnet  avgt       40.949          ms/op
[1-113] RegressionBenchmark.main               bench/resources/cpp_suite/bench.06.jsonnet  avgt        0.378          ms/op
[1-113] RegressionBenchmark.main               bench/resources/cpp_suite/bench.07.jsonnet  avgt        3.541          ms/op
[1-113] RegressionBenchmark.main               bench/resources/cpp_suite/bench.08.jsonnet  avgt        0.050          ms/op
[1-113] RegressionBenchmark.main               bench/resources/cpp_suite/bench.09.jsonnet  avgt        0.111          ms/op
[1-113] RegressionBenchmark.main         bench/resources/cpp_suite/gen_big_object.jsonnet  avgt        0.995          ms/op
[1-113] RegressionBenchmark.main      bench/resources/cpp_suite/large_string_join.jsonnet  avgt        1.688          ms/op
[1-113] RegressionBenchmark.main  bench/resources/cpp_suite/large_string_template.jsonnet  avgt        3.992          ms/op
[1-113] RegressionBenchmark.main             bench/resources/cpp_suite/realistic1.jsonnet  avgt        3.437          ms/op
[1-113] RegressionBenchmark.main             bench/resources/cpp_suite/realistic2.jsonnet  avgt       79.496          ms/op
[1-113] RegressionBenchmark.main                  bench/resources/go_suite/base64.jsonnet  avgt        0.864          ms/op
[1-113] RegressionBenchmark.main            bench/resources/go_suite/base64Decode.jsonnet  avgt        0.665          ms/op
[1-113] RegressionBenchmark.main       bench/resources/go_suite/base64DecodeBytes.jsonnet  avgt       13.101          ms/op
[1-113] RegressionBenchmark.main       bench/resources/go_suite/base64_byte_array.jsonnet  avgt        1.217          ms/op
[1-113] RegressionBenchmark.main              bench/resources/go_suite/comparison.jsonnet  avgt        7.627          ms/op
[1-113] RegressionBenchmark.main             bench/resources/go_suite/comparison2.jsonnet  avgt       63.315          ms/op
[1-113] RegressionBenchmark.main        bench/resources/go_suite/escapeStringJson.jsonnet  avgt        0.054          ms/op
[1-113] RegressionBenchmark.main                   bench/resources/go_suite/foldl.jsonnet  avgt       10.886          ms/op
[1-113] RegressionBenchmark.main             bench/resources/go_suite/lstripChars.jsonnet  avgt        0.658          ms/op
[1-113] RegressionBenchmark.main          bench/resources/go_suite/manifestJsonEx.jsonnet  avgt        0.061          ms/op
[1-113] RegressionBenchmark.main          bench/resources/go_suite/manifestTomlEx.jsonnet  avgt        0.088          ms/op
[1-113] RegressionBenchmark.main         bench/resources/go_suite/manifestYamlDoc.jsonnet  avgt        0.068          ms/op
[1-113] RegressionBenchmark.main                  bench/resources/go_suite/member.jsonnet  avgt        0.440          ms/op
[1-113] RegressionBenchmark.main                bench/resources/go_suite/parseInt.jsonnet  avgt        0.044          ms/op
[1-113] RegressionBenchmark.main                 bench/resources/go_suite/reverse.jsonnet  avgt       16.407          ms/op
[1-113] RegressionBenchmark.main             bench/resources/go_suite/rstripChars.jsonnet  avgt        0.651          ms/op
[1-113] RegressionBenchmark.main              bench/resources/go_suite/stripChars.jsonnet  avgt        0.652          ms/op
[1-113] RegressionBenchmark.main                  bench/resources/go_suite/substr.jsonnet  avgt        0.217          ms/op
```