### PR TITLE
Pass broken-assertion-logic from Settings to Config

### DIFF
--- a/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMainBase.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMainBase.scala
@@ -286,7 +286,8 @@ object SjsonnetMainBase {
         preserveOrder = config.preserveOrder.value,
         strict = config.strict.value,
         throwErrorForInvalidSets = config.throwErrorForInvalidSets.value,
-        maxParserRecursionDepth = config.maxParserRecursionDepth
+        maxParserRecursionDepth = config.maxParserRecursionDepth,
+        brokenAssertionLogic = config.brokenAssertionLogic.value
       ),
       storePos = (position: Position) => if (config.yamlDebug.value) currentPos = position else (),
       logger = warnLogger,


### PR DESCRIPTION
The https://github.com/databricks/sjsonnet/pull/536 added workaround for performance issues related to assertions. Unfortunately the `--broken-assertion-logic` flag is not passed to `Settings` object used internally and is not fully effective.

Improve workaround for https://github.com/databricks/sjsonnet/issues/526