### PR TITLE
Fix right-side stripping of Unicode surrogate pairs in stripChars/trim

### DIFF
--- a/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
@@ -123,16 +123,19 @@ object StringModule extends AbstractFunctionModule {
         right: Boolean): String = {
       if (str.isEmpty) return str
       var start = 0
-      var end = str.length - 1
+      // Use exclusive end position with codePointBefore() for right-to-left iteration.
+      // Unlike codePointAt(), codePointBefore() correctly reads surrogate pairs when
+      // scanning backwards (codePointAt on a low surrogate returns the wrong value).
+      var end = str.length
 
-      while (left && start <= end && charsSet.contains(str.codePointAt(start))) {
+      while (left && start < end && charsSet.contains(str.codePointAt(start))) {
         start = str.offsetByCodePoints(start, 1)
       }
 
-      while (right && end >= start && charsSet.contains(str.codePointAt(end))) {
+      while (right && end > start && charsSet.contains(str.codePointBefore(end))) {
         end = str.offsetByCodePoints(end, -1)
       }
-      str.substring(start, end + 1)
+      str.substring(start, end)
     }
   }
 

--- a/sjsonnet/test/src/sjsonnet/UnicodeHandlingTests.scala
+++ b/sjsonnet/test/src/sjsonnet/UnicodeHandlingTests.scala
@@ -247,7 +247,14 @@ object UnicodeHandlingTests extends TestSuite {
       eval("std.stripChars('Hello 🌍 World🌍H', 'Hello 🌍')") ==> ujson.Str("World")
       eval("std.lstripChars('Hello 🌍 World🌍H', 'Hello 🌍')") ==> ujson.Str("World🌍H")
       eval("std.rstripChars('Hello 🌍 World🌍H', 'Hello 🌍')") ==> ujson.Str("Hello 🌍 World")
-
+      // Regression test for rstripChars with emoji (surrogate pairs) at end of string
+      eval("""std.rstripChars("hello🎉🎉🎉", "🎉")""") ==> ujson.Str("hello")
+      eval("""std.lstripChars("🎉🎉🎉hello", "🎉")""") ==> ujson.Str("hello")
+      eval("""std.stripChars("🎉🎉hello🎉🎉", "🎉")""") ==> ujson.Str("hello")
+      // Regression test for right-stripping ASCII chars after emoji (must not corrupt emoji)
+      eval("""std.rstripChars("🌍 ", " ")""") ==> ujson.Str("🌍")
+      eval("""std.trim("🌍   ")""") ==> ujson.Str("🌍")
+      eval("""std.trim("   🌍   ")""") ==> ujson.Str("🌍")
     }
   }
 }


### PR DESCRIPTION
This is a followup to https://github.com/databricks/sjsonnet/pull/555 and the subsequent fix in https://github.com/databricks/sjsonnet/pull/557. 

Even after that fix, there are two remaining bugs related to stripping from the right side of a string:

1. Stripping emoji from end: `std.rstripChars("hello🎉🎉🎉", "🎉")` returned `"hello🎉🎉🎉"` instead of `"hello"` (nothing stripped)
2. Stripping ASCII after emoji: `std.trim("🌍   ")` returned `"?"` instead of`"🌍"` (i.e. the emoji was corrupted)

The root cause (explained by Claude) is that when iterating from the right of a string, `codePointAt(str.length - 1)` points to a low surrogate and it gets treated as an unpaired surrogate rather than seeking backwards to find the full code point.

The fix: use `codePointBefore(end)` (where `end` ranges from `string.length` down to `1`) for right-to-left iteration. Unlike `codePointAt()`, `codePointBefore()` correctly reads surrogate pairs when scanning backwards.

Fix + test are authored by Claude Code.