### PR TITLE
chore: bump scalajs to 1.20.2 and scalaNative to 0.5.10 and other dependencies

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -47,8 +47,8 @@ trait SjsonnetCrossModule extends CrossScalaModule with ScalafmtModule {
   def crossValue: String
   def mvnDeps = Seq(
     mvn"com.lihaoyi::fastparse::3.1.1",
-    mvn"com.lihaoyi::pprint::0.9.4",
-    mvn"com.lihaoyi::ujson::4.4.1",
+    mvn"com.lihaoyi::pprint::0.9.6",
+    mvn"com.lihaoyi::ujson::4.4.2",
     mvn"com.lihaoyi::scalatags::0.13.1",
     mvn"org.scala-lang.modules::scala-collection-compat::2.14.0"
   )
@@ -83,15 +83,15 @@ trait SjsonnetCrossModule extends CrossScalaModule with ScalafmtModule {
     else Seq[String]("-Wconf:origin=scala.collection.compat.*:s", "-Xlint:all")
   )
   trait CrossTests extends ScalaModule with TestModule.Utest {
-    def mvnDeps = Seq(mvn"com.lihaoyi::utest::0.9.1")
+    def mvnDeps = Seq(mvn"com.lihaoyi::utest::0.9.5")
     def testSandboxWorkingDir = false
   }
 }
 
 trait SjsonnetJvmNative extends ScalaModule {
   def mvnDeps = super.mvnDeps() ++ Seq(
-    mvn"com.lihaoyi::os-lib::0.11.6",
-    mvn"com.lihaoyi::mainargs::0.7.7"
+    mvn"com.lihaoyi::os-lib::0.11.8",
+    mvn"com.lihaoyi::mainargs::0.7.8"
   )
 }
 
@@ -281,8 +281,8 @@ object sjsonnet extends VersionFileModule {
     def sources = Task.Sources(sourceDirs.map(d => this.moduleDir / d)*)
 
     def mvnDeps = super.mvnDeps() ++ Seq(
-      mvn"org.tukaani:xz::1.10",
-      mvn"at.yawk.lz4:lz4-java::1.10.1",
+      mvn"org.tukaani:xz::1.11",
+      mvn"at.yawk.lz4:lz4-java::1.10.3",
       mvn"org.yaml:snakeyaml::2.4",
       mvn"com.google.re2j:re2j:1.8"
     )

--- a/build.sbt
+++ b/build.sbt
@@ -19,19 +19,19 @@ lazy val main = (project in file("sjsonnet"))
     Test / baseDirectory := (ThisBuild / baseDirectory).value,
     libraryDependencies ++= Seq(
       "com.lihaoyi" %% "fastparse" % "3.1.1",
-      "com.lihaoyi" %% "pprint" % "0.9.4",
-      "com.lihaoyi" %% "ujson" % "4.4.1",
+      "com.lihaoyi" %% "pprint" % "0.9.6",
+      "com.lihaoyi" %% "ujson" % "4.4.2",
       "com.lihaoyi" %% "scalatags" % "0.13.1",
-      "com.lihaoyi" %% "os-lib" % "0.11.6",
-      "com.lihaoyi" %% "mainargs" % "0.7.7",
-      "at.yawk.lz4" % "lz4-java" % "1.10.1",
+      "com.lihaoyi" %% "os-lib" % "0.11.8",
+      "com.lihaoyi" %% "mainargs" % "0.7.8",
+      "at.yawk.lz4" % "lz4-java" % "1.10.3",
       "org.scala-lang.modules" %% "scala-collection-compat" % "2.14.0",
-      "org.tukaani" % "xz" % "1.10",
+      "org.tukaani" % "xz" % "1.11",
       "org.yaml" % "snakeyaml" % "2.5",
       "com.google.re2j" % "re2j" % "1.8"
     ),
     libraryDependencies ++= Seq(
-      "com.lihaoyi" %% "utest" % "0.9.1"
+      "com.lihaoyi" %% "utest" % "0.9.5"
     ).map(_ % "test"),
     testFrameworks += new TestFramework("utest.runner.Framework"),
     (Compile / unmanagedSourceDirectories) := Seq(
@@ -53,7 +53,7 @@ lazy val main = (project in file("sjsonnet"))
         file,
         s"""package sjsonnet
            |object Version{
-           |  val version = "${sjsonnetVersion}"
+           |  val version = "$sjsonnetVersion"
            |}
            |""".stripMargin
       )


### PR DESCRIPTION
refs: https://github.com/scala-native/scala-native/issues/4764

need a new release of [scala-native-crypto](https://github.com/lolgab/scala-native-crypto)