### PR TITLE
chore: Reduce size of Lazy.

### DIFF
--- a/sjsonnet/src/sjsonnet/stdlib/ArrayModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/ArrayModule.scala
@@ -166,7 +166,9 @@ object ArrayModule extends AbstractFunctionModule {
         pos: Position): Val.Arr = {
       Val.Arr(
         pos,
-        arg.map(v => (() => _func.apply1(v, pos.noOffset)(ev, TailstrictModeDisabled)): Lazy)
+        arg.map(v =>
+          new LazyWithComputeFunc(() => _func.apply1(v, pos.noOffset)(ev, TailstrictModeDisabled))
+        )
       )
     }
 
@@ -184,7 +186,9 @@ object ArrayModule extends AbstractFunctionModule {
       while (i < a.length) {
         val x = arr(i)
         val idx = Val.Num(pos, i)
-        a(i) = () => func.apply2(idx, x, pos.noOffset)(ev, TailstrictModeDisabled)
+        a(i) = new LazyWithComputeFunc(() =>
+          func.apply2(idx, x, pos.noOffset)(ev, TailstrictModeDisabled)
+        )
         i += 1
       }
       Val.Arr(pos, a)
@@ -414,7 +418,11 @@ object ArrayModule extends AbstractFunctionModule {
             if (!filter_func.apply1(i, pos.noOffset)(ev, TailstrictModeDisabled).asBoolean) {
               None
             } else {
-              Some[Lazy](() => map_func.apply1(i, pos.noOffset)(ev, TailstrictModeDisabled))
+              Some[Lazy](
+                new LazyWithComputeFunc(() =>
+                  map_func.apply1(i, pos.noOffset)(ev, TailstrictModeDisabled)
+                )
+              )
             }
           }
         )
@@ -451,8 +459,9 @@ object ArrayModule extends AbstractFunctionModule {
           var i = 0
           while (i < sz) {
             val forcedI = i
-            a(i) =
-              () => func.apply1(Val.Num(pos, forcedI), pos.noOffset)(ev, TailstrictModeDisabled)
+            a(i) = new LazyWithComputeFunc(() =>
+              func.apply1(Val.Num(pos, forcedI), pos.noOffset)(ev, TailstrictModeDisabled)
+            )
             i += 1
           }
           a

--- a/sjsonnet/src/sjsonnet/stdlib/ObjectModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/ObjectModule.scala
@@ -105,7 +105,11 @@ object ObjectModule extends AbstractFunctionModule {
         val k = allKeys(i)
         val v = new Val.Obj.Member(false, Visibility.Normal, deprecatedSkipAsserts = true) {
           def invoke(self: Val.Obj, sup: Val.Obj, fs: FileScope, ev: EvalScope): Val =
-            func.apply2(Val.Str(pos, k), () => obj.value(k, pos.noOffset)(ev), pos.noOffset)(
+            func.apply2(
+              Val.Str(pos, k),
+              new LazyWithComputeFunc(() => obj.value(k, pos.noOffset)(ev)),
+              pos.noOffset
+            )(
               ev,
               TailstrictModeDisabled
             )
@@ -135,7 +139,7 @@ object ObjectModule extends AbstractFunctionModule {
     Val.Arr(
       pos,
       keys.map { k =>
-        (() => v1.value(k, pos.noOffset)(ev)): Lazy
+        new LazyWithComputeFunc(() => v1.value(k, pos.noOffset)(ev))
       }
     )
 


### PR DESCRIPTION
Motivation:
By making Lazy an empty abstract class, we can reduce the size of Val.

refs: https://github.com/databricks/sjsonnet/issues/319