### PR TITLE
fix: handle non-BMP Unicode codepoints in foldl, foldr, and %c format

### DIFF
--- a/sjsonnet/src/sjsonnet/Format.scala
+++ b/sjsonnet/src/sjsonnet/Format.scala
@@ -196,7 +196,7 @@ object Format {
                 case 'f' | 'F'       => formatFloat(formatted, s)
                 case 'g'             => formatGeneric(formatted, s).toLowerCase
                 case 'G'             => formatGeneric(formatted, s)
-                case 'c'             => widenRaw(formatted, s.toChar.toString)
+                case 'c'             => widenRaw(formatted, Character.toString(s.toInt))
                 case 's'             =>
                   if (s.toLong == s) widenRaw(formatted, s.toLong.toString)
                   else widenRaw(formatted, s.toString)

--- a/sjsonnet/src/sjsonnet/stdlib/ArrayModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/ArrayModule.scala
@@ -296,12 +296,16 @@ object ArrayModule extends AbstractFunctionModule {
 
         case s: Val.Str =>
           var current = init.force
-          for (char <- s.value) {
+          val str = s.value
+          var i = 0
+          while (i < str.length) {
             val c = current
-            current = func.apply2(c, Val.Str(pos, new String(Array(char))), pos.noOffset)(
+            val codePoint = str.codePointAt(i)
+            current = func.apply2(c, Val.Str(pos, Character.toString(codePoint)), pos.noOffset)(
               ev,
               TailstrictModeDisabled
             )
+            i += Character.charCount(codePoint)
           }
           current
 
@@ -324,9 +328,13 @@ object ArrayModule extends AbstractFunctionModule {
           current
         case s: Val.Str =>
           var current = init.force
-          for (char <- s.value.reverse) {
+          val str = s.value
+          var i = str.length
+          while (i > 0) {
+            val codePoint = str.codePointBefore(i)
+            i -= Character.charCount(codePoint)
             val c = current
-            current = func.apply2(Val.Str(pos, new String(Array(char))), c, pos.noOffset)(
+            current = func.apply2(Val.Str(pos, Character.toString(codePoint)), c, pos.noOffset)(
               ev,
               TailstrictModeDisabled
             )


### PR DESCRIPTION
This PR fixes two more non-BMP Unicode bugs:

- foldl/foldr iterated strings by UTF-16 code unit (`for (char <- s.value)`), splitting non-BMP characters like emoji into surrogate pair halves. Use `codePointAt`/`codePointBefore` with `Character.charCount` for correct codepoint iteration.
- The `%c` format conversion used `s.toChar.toString` which truncates codepoints above U+FFFF to 16 bits. Use `Character.toString(s.toInt)` instead.

---

All code written by Claude Opus 4.6.