### PR TITLE
perf: direct-write stdout with unsynchronized CompactByteArrayOutputStream

### DIFF
--- a/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMainBase.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMainBase.scala
@@ -5,6 +5,7 @@ import upickle.core.SimpleVisitor
 import java.io.{
   BufferedOutputStream,
   InputStream,
+  OutputStream,
   OutputStreamWriter,
   PrintStream,
   StringWriter,
@@ -16,6 +17,50 @@ import scala.annotation.unused
 import scala.util.Try
 
 object SjsonnetMainBase {
+
+  /**
+   * Unsynchronized byte array output stream, inspired by Apache Pekko's approach.
+   *
+   * Unlike `java.io.ByteArrayOutputStream`, this class:
+   *   - Does NOT synchronize on write operations (no mutex overhead on Scala Native)
+   *   - Exposes `writeTo(OutputStream)` for zero-copy transfer to stdout
+   *   - Uses 1.5x growth factor instead of 2x for reduced memory waste
+   *
+   * The `writeTo` method writes directly from the internal buffer without creating an intermediate
+   * String or byte array copy, unlike StringWriter's `.toString()`.
+   */
+  private final class CompactByteArrayOutputStream(initialCapacity: Int) extends OutputStream {
+    private var buf: Array[Byte] = new Array[Byte](initialCapacity)
+    private var count: Int = 0
+
+    private def ensureCapacity(minCapacity: Int): Unit = {
+      if (minCapacity > buf.length) {
+        // Grow by at least 1.5x to amortize copies (Pekko-style growth factor)
+        val newCapacity = math.max(buf.length + (buf.length >> 1), minCapacity)
+        buf = java.util.Arrays.copyOf(buf, newCapacity)
+      }
+    }
+
+    override def write(b: Int): Unit = {
+      ensureCapacity(count + 1)
+      buf(count) = b.toByte
+      count += 1
+    }
+
+    override def write(b: Array[Byte], off: Int, len: Int): Unit = {
+      if (len > 0) {
+        ensureCapacity(count + len)
+        System.arraycopy(b, off, buf, count, len)
+        count += len
+      }
+    }
+
+    /** Write internal buffer directly to the target stream — no intermediate copy. */
+    def writeTo(out: OutputStream): Unit = out.write(buf, 0, count)
+
+    def size(): Int = count
+  }
+
   class SimpleImporter(
       searchRoots0: Seq[Path], // Evaluated in order, first occurrence wins
       allowedInputs: Option[Set[os.Path]] = None,
@@ -170,7 +215,8 @@ object SjsonnetMainBase {
         warn,
         std,
         debugStats = debugStats,
-        profileOpt = config.profile
+        profileOpt = config.profile,
+        stdout = if (config.outputFile.isEmpty) stdout else null
       )
       res <- {
         if (hasWarnings && config.fatalWarnings.value) Left("")
@@ -236,9 +282,23 @@ object SjsonnetMainBase {
       )
     )
 
-  private def writeToFile(config: Config, wd: os.Path)(
+  private def writeToFile(config: Config, wd: os.Path, stdout: PrintStream)(
       materialize: Writer => Either[String, ?]): Either[String, String] = {
     config.outputFile match {
+      case None if stdout != null =>
+        // Direct-write mode: bypass StringWriter → toString → println overhead.
+        // Uses CompactByteArrayOutputStream (unsynchronized, 1.5x growth) so that
+        // on rendering error, nothing reaches stdout (the buffer is simply discarded).
+        val baos = new CompactByteArrayOutputStream(65536)
+        val wr = new OutputStreamWriter(baos, StandardCharsets.UTF_8)
+        val result = materialize(wr)
+        result.map { _ =>
+          if (!config.noTrailingNewline.value) wr.write('\n')
+          wr.flush()
+          baos.writeTo(stdout)
+          stdout.flush()
+          ""
+        }
       case None =>
         val sw = new StringWriter
         materialize(sw).map(_ => sw.toString)
@@ -263,8 +323,9 @@ object SjsonnetMainBase {
       jsonnetCode: String,
       path: os.Path,
       wd: os.Path,
-      getCurrentPosition: () => Position) = {
-    writeToFile(config, wd) { writer =>
+      getCurrentPosition: () => Position,
+      stdout: PrintStream) = {
+    writeToFile(config, wd, stdout) { writer =>
       val renderer = rendererForConfig(writer, config, getCurrentPosition)
       val res = interp.interpret0(jsonnetCode, OsPath(path), renderer)
       if (config.yamlOut.value && !config.noTrailingNewline.value) writer.write('\n')
@@ -320,7 +381,8 @@ object SjsonnetMainBase {
       std: Val.Obj,
       evaluatorOverride: Option[Evaluator] = None,
       debugStats: DebugStats = null,
-      profileOpt: Option[String] = None): Either[String, String] = {
+      profileOpt: Option[String] = None,
+      stdout: PrintStream = null): Either[String, String] = {
 
     val (jsonnetCode, path) =
       if (config.exec.value) (file, wd / Util.wrapInLessThanGreaterThan("exec"))
@@ -431,7 +493,7 @@ object SjsonnetMainBase {
 
         interp.interpret(jsonnetCode, OsPath(path)).flatMap {
           case arr: ujson.Arr =>
-            writeToFile(config, wd) { writer =>
+            writeToFile(config, wd, stdout) { writer =>
               arr.value.toSeq match {
                 case Nil         => // donothing
                 case Seq(single) =>
@@ -455,9 +517,9 @@ object SjsonnetMainBase {
               Right("")
             }
 
-          case _ => renderNormal(config, interp, jsonnetCode, path, wd, () => currentPos)
+          case _ => renderNormal(config, interp, jsonnetCode, path, wd, () => currentPos, stdout)
         }
-      case _ => renderNormal(config, interp, jsonnetCode, path, wd, () => currentPos)
+      case _ => renderNormal(config, interp, jsonnetCode, path, wd, () => currentPos, stdout)
     }
 
     if (profilerInstance != null)


### PR DESCRIPTION
## Motivation

When outputting to stdout (no `--output-file`), sjsonnet renders JSON into a `StringWriter` backed by `StringBuffer`, calls `toString()` to create the full string, then `println()` to encode and write it. For realistic2 (28.6 MB JSON output), this creates three sources of overhead:

1. **StringBuffer synchronization**: Every `write()` call on `StringBuffer` is `synchronized`. On Scala Native, each `synchronized` block maps to a pthread mutex lock/unlock pair — on a 28MB output with ~thousands of write calls, this is significant.
2. **Redundant memory copy**: `StringWriter.toString()` creates a full copy of the 28MB char array into a String. Combined with StringBuffer's 2x growth factor, peak memory reaches ~3x the output size.
3. **Encoding overhead**: `PrintStream.println(String)` must encode the entire 28MB String from UTF-16 chars to UTF-8 bytes for stdout.

## Key Design Decision

Inspired by [Apache Pekko's unsynchronized buffer approach](https://github.com/apache/pekko/blob/main/actor/src/main/scala/org/apache/pekko/util/ByteArrayOutputStream.scala), we render directly to bytes and write them to stdout in a single bulk operation:

- **CompactByteArrayOutputStream**: Private inner class, unsynchronized, 1.5x growth factor, `writeTo()` for zero-copy transfer
- **Error safety**: On rendering error, the buffer is simply discarded — nothing reaches stdout
- **Fallback**: When `stdout` is null (library/programmatic use) or `--output-file` is specified, the original StringWriter path is used

```
BEFORE (per write call, thousands of calls for 28MB):
  Renderer → CharBuilder → StringWriter(StringBuffer.write() [SYNCHRONIZED])
  ... → StringWriter.toString() [28MB CHAR COPY]
  ... → println(string) [28MB UTF-16→UTF-8 ENCODE]

AFTER:
  Renderer → OutputStreamWriter → CompactByteArrayOutputStream.write() [NO SYNC]
  ... → CompactByteArrayOutputStream.writeTo(stdout) [SINGLE BULK WRITE]
```

## Modification

**`sjsonnet/src-jvm-native/sjsonnet/SjsonnetMainBase.scala`**:
- Added `CompactByteArrayOutputStream` private inner class (unsynchronized, 1.5x growth, `writeTo`)
- Added `stdout: PrintStream` parameter to `writeToFile`, `renderNormal`, and `mainConfigured`
- New code path when `stdout != null` and no output file: renders through `OutputStreamWriter` → `CompactByteArrayOutputStream` → `writeTo(stdout)` → `flush()`
- On rendering error, buffer is discarded (atomicity preserved)

## Benchmark Results

**Environment**: Apple M3 Max, macOS 15.4, Scala Native 0.5.8

### Scala Native — hyperfine (warmup 3, runs 10)

| Benchmark | master (ms) | PR (ms) | Δ | vs jrsonnet |
|-----------|------------|---------|---|-------------|
| **realistic2** (28.6MB) | 258.7 ± 2.4 | **226.8 ± 9.0** | **−12.3%** | 2.21x (was 2.52x) |
| **large_string_template** | 23.6 ± 10.3 | **15.1 ± 1.7** | **−36.0%** | 1.89x (was 2.94x) |
| realistic1 | 15.2 ± 1.4 | 15.8 ± 1.9 | ~0% (noise) | 1.00x |
| gen_big_object | 10.9 ± 1.1 | 11.7 ± 2.4 | ~0% (noise) | 0.89x (we win) |
| large_string_join | 7.6 ± 1.6 | 7.9 ± 1.2 | ~0% (noise) | 1.16x |

### JMH (JVM steady-state — I/O not measured, no change expected)

| Benchmark | ms/op |
|-----------|-------|
| realistic2 | 57.1 |
| realistic1 | 1.8 |
| comparison | 21.8 |
| comparison2 | 40.1 |
| large_string_template | 1.8 |
| gen_big_object | 0.9 |

## Analysis

- **12.3% improvement on realistic2** (28.6MB output) — the largest single-benchmark improvement from eliminating StringBuffer synchronization and intermediate String copy
- **36% improvement on large_string_template** — string-heavy output benefits even more from direct byte encoding
- **No regression** on small-output benchmarks (realistic1, gen_big_object, large_string_join)
- **JMH unaffected** — JMH measures `interpret()` which returns a String, not the CLI output path
- **Error safety preserved**: CompactByteArrayOutputStream buffers all output; only on success does `writeTo(stdout)` transfer the bytes

## References

- Apache Pekko `ByteArrayOutputStream`: https://github.com/apache/pekko/blob/main/actor/src/main/scala/org/apache/pekko/util/ByteArrayOutputStream.scala
- Prior analysis: StringBuffer synchronization maps to pthread mutex on Scala Native

## Result

Eliminates StringWriter/StringBuffer synchronization overhead and intermediate String copy for stdout output. Improves realistic2 by 12.3% and large_string_template by 36% on Scala Native. No functional change — only affects the CLI I/O path.