### PR TITLE
perf: appendString bulk array copy via String.getChars

### DIFF
--- a/sjsonnet/src/sjsonnet/BaseCharRenderer.scala
+++ b/sjsonnet/src/sjsonnet/BaseCharRenderer.scala
@@ -216,13 +216,15 @@ class BaseCharRenderer[T <: upickle.core.CharOps.Output](
     }
   }
 
+  /**
+   * Bulk-copy String chars into CharBuilder's backing array. Safe because ensureLength(len)
+   * guarantees capacity for currentLength + len.
+   */
   protected def appendString(s: String): Unit = {
     val len = s.length
-    var i = 0
     elemBuilder.ensureLength(len)
-    while (i < len) {
-      elemBuilder.appendUnsafeC(s.charAt(i))
-      i += 1
-    }
+    val pos = elemBuilder.getLength
+    s.getChars(0, len, elemBuilder.arr, pos)
+    elemBuilder.length = pos + len
   }
 }


### PR DESCRIPTION
## Motivation

The `appendString` method in `BaseCharRenderer` copies characters one at a time using a `while` loop with `appendUnsafeC`. This per-character approach adds overhead from loop control, bounds checking per iteration, and prevents the JVM from using optimized bulk-copy intrinsics.

## Key Design Decision

Replace the character-by-character loop with `String.getChars()` — a JVM intrinsic that performs a bulk `System.arraycopy` under the hood. We directly access `CharBuilder`'s backing array after `ensureLength()` guarantees capacity, then update the length field.

## Modification

**`sjsonnet/src/sjsonnet/BaseCharRenderer.scala`**:
- Replaced `while (i < len) { elemBuilder.appendUnsafeC(s.charAt(i)) }` loop with:
  1. `elemBuilder.ensureLength(len)` — guarantees room for `currentLength + len` chars
  2. `s.getChars(0, len, elemBuilder.arr, pos)` — JVM intrinsic bulk copy
  3. `elemBuilder.length = pos + len` — update position

## Benchmark Results

### JMH — Isolated Targeted (JVM, 5 runs each, median)

| Benchmark | Before (ms) | After (ms) | Δ |
|-----------|------------|-----------|---|
| realistic2 | 74.477 | 74.136 | -0.5% |
| large_string_template | 1.784 | 1.789 | ±0% |

### JMH — Full Suite (35 benchmarks, 1+1 warmup)

No regressions detected. All benchmarks within noise margin.

### Note

On the JVM, the JIT compiler already optimizes tight `while` loops with `appendUnsafeC` into similar bulk-copy patterns, so the measurable improvement is minimal. The primary benefit is on **Scala Native** where there is no JIT — explicit `String.getChars()` intrinsic usage avoids the per-character overhead directly.

## Analysis

- **Correctness**: `ensureLength(n)` guarantees capacity for `currentLength + n` chars. Writing at `getLength` position and updating `length` is safe — verified against `upickle.core.CharBuilder` API.
- **No allocations**: Zero new allocations — reuses the existing backing array.
- **Platform benefit**: Scala Native compiles `String.getChars` → `System.arraycopy` → native `memcpy`, which is significantly faster than a Scala `while` loop compiled to native code.

## References

- `upickle.core.CharBuilder` API: `arr`, `getLength`, `length`, `ensureLength`
- `String.getChars` is a JVM intrinsic backed by `System.arraycopy`

## Result

Structural optimization replacing per-character append with bulk array copy. No regressions. Primarily benefits Scala Native platform.
