### PR TITLE
fix: replace insecure pull_request_target with pull_request + dep cache warmer

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -32,6 +32,16 @@ runs:
       uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version: '24'
+    - name: Restore warmed dependency cache
+      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: |
+          ~/.cache/coursier/v1
+          ~/.cache/mill
+          ~/.sbt
+          ~/.ivy2/cache
+        key: dep-cache-${{ hashFiles('build.mill') }}
+        restore-keys: dep-cache-
     - name: Cache Coursier cache
       if: inputs.coursier-cache == 'true'
       uses: coursier/cache-action@90c37294538be80a558fd665531fcdc2b467b475 # 8.1.0

--- a/.github/scripts/fix-build-config.sh
+++ b/.github/scripts/fix-build-config.sh
@@ -6,6 +6,14 @@ if [ "${GITHUB_REPOSITORY:-}" != "databricks/sjsonnet" ]; then
   exit 0
 fi
 
+# If JFrog token is not available (e.g. fork PRs without OIDC), skip
+# JFrog configuration. The build will use the pre-warmed dependency
+# cache and fall back to Maven Central for any missing artifacts.
+if [ -z "${JFROG_ACCESS_TOKEN:-}" ]; then
+  echo "Skipping Mill/sbt JFrog config: JFROG_ACCESS_TOKEN not set (likely a fork PR)"
+  exit 0
+fi
+
 JFROG_HOSTNAME="databricks.jfrog.io"
 JFROG_REALM="Artifactory Realm"
 JFROG_USERNAME="gha-service-account"

--- a/.github/scripts/get-jfrog-token.sh
+++ b/.github/scripts/get-jfrog-token.sh
@@ -6,6 +6,13 @@ if [ "${GITHUB_REPOSITORY:-}" != "databricks/sjsonnet" ]; then
   exit 0
 fi
 
+# Fork PRs using the pull_request trigger don't have OIDC access.
+# They rely on the pre-warmed dependency cache instead of JFrog.
+if [ -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ] || [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then
+  echo "Skipping JFrog token: OIDC not available (likely a fork PR)"
+  exit 0
+fi
+
 # Exchange a GitHub Actions OIDC token for a JFrog access token and
 # write JFROG_ACCESS_TOKEN to $GITHUB_ENV so subsequent steps can use it.
 

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -1,26 +1,23 @@
 name: Pull Request Validation
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [master]
     types: [assigned, opened, synchronize, reopened]
-    paths-ignore:
-      - .github/**
 
 permissions:
   contents: read
-  id-token: write
+  id-token: write # Needed for JFrog OIDC on internal PRs; unavailable for fork PRs
 
 jobs:
-  # Forks cannot use org runner groups; use GitHub-hosted runners instead.
+  # Fork PRs use GitHub-hosted runners (no org runner group access).
+  # Internal PRs use protected runners with JFrog fallback.
   build-jvm:
-    runs-on: ${{ github.repository == 'databricks/sjsonnet' && fromJSON('{"group":"databricks-protected-runner-group","labels":"linux-ubuntu-latest"}') || 'ubuntu-latest' }}
+    runs-on: ${{ (github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name) && 'ubuntu-latest' || github.repository == 'databricks/sjsonnet' && fromJSON('{"group":"databricks-protected-runner-group","labels":"linux-ubuntu-latest"}') || 'ubuntu-latest' }}
     timeout-minutes: 20
     name: Sjsonnet jvm build
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
-        with:
-            ref: ${{ github.event.pull_request.head.sha }}
       - uses: ./.github/actions/setup-build
         with:
           sbt: 'true'
@@ -32,20 +29,18 @@ jobs:
       - name: Run sbt tests
         run: sbt test
   build-graal:
-    runs-on: ${{ github.repository == 'databricks/sjsonnet' && fromJSON('{"group":"databricks-protected-runner-group","labels":"linux-ubuntu-latest"}') || 'ubuntu-latest' }}
+    runs-on: ${{ (github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name) && 'ubuntu-latest' || github.repository == 'databricks/sjsonnet' && fromJSON('{"group":"databricks-protected-runner-group","labels":"linux-ubuntu-latest"}') || 'ubuntu-latest' }}
     timeout-minutes: 20
     name: Sjsonnet Graal Native build
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
-        with:
-            ref: ${{ github.event.pull_request.head.sha }}
       - uses: ./.github/actions/setup-build
         with:
           coursier-cache: 'true'
       - name: Run Native Image Test Suites
         run: sjsonnet/test/graalvm/run_test_suites.py
   build-other:
-    runs-on: ${{ github.repository == 'databricks/sjsonnet' && fromJSON('{"group":"databricks-protected-runner-group","labels":"linux-ubuntu-latest"}') || 'ubuntu-latest' }}
+    runs-on: ${{ (github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name) && 'ubuntu-latest' || github.repository == 'databricks/sjsonnet' && fromJSON('{"group":"databricks-protected-runner-group","labels":"linux-ubuntu-latest"}') || 'ubuntu-latest' }}
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -54,8 +49,6 @@ jobs:
     name: Sjsonnet ${{ matrix.lang }} build
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
-        with:
-            ref: ${{ github.event.pull_request.head.sha }}
       - uses: ./.github/actions/setup-build
         with:
           node: ${{ matrix.lang == 'js' || matrix.lang == 'wasm' }}

--- a/.github/workflows/warm-dep-cache.yaml
+++ b/.github/workflows/warm-dep-cache.yaml
@@ -1,0 +1,95 @@
+name: Warm Dependency Cache
+
+# Pre-downloads all Coursier/sbt dependencies via JFrog Artifactory and
+# saves them to the GitHub Actions cache. Fork PRs (which cannot
+# authenticate to JFrog) restore this cache to build without credentials.
+#
+# Unlike Maven's pom.xml, Mill's build.mill is executable Scala code, so
+# PR-specific cache warming (checking out a fork's build.mill) is
+# intentionally not supported — it would run untrusted code on protected
+# runners with JFrog credentials.
+#
+# Triggers:
+#   - push to master when build.mill changes (keeps cache fresh after dep updates)
+#   - daily schedule (prevents 7-day cache eviction)
+#   - manual dispatch
+
+on:
+  push:
+    branches: [master]
+    paths: ['build.mill']
+  schedule:
+    - cron: '0 6 * * *' # Daily at 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  warm-cache:
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+
+      - uses: ./.github/actions/setup-build
+        with:
+          sbt: 'true'
+          coursier-cache: 'false' # We save the cache ourselves below
+
+      - name: Resolve all dependencies
+        run: |
+          set -euo pipefail
+
+          # Run the same build commands as the PR CI workflows to ensure
+          # every plugin and transitive dependency is resolved and cached.
+
+          echo "=== 1/7: Mill bootstrap ==="
+          ./mill version
+
+          echo "=== 2/7: JVM compile + test deps ==="
+          ./mill 'sjsonnet.jvm[_].compile' || true
+          ./mill 'sjsonnet.jvm[_].test.compile' || true
+
+          echo "=== 3/7: JS deps ==="
+          ./mill 'sjsonnet.js[_].compile' || true
+
+          echo "=== 4/7: WASM deps ==="
+          ./mill 'sjsonnet.wasm[_].compile' || true
+
+          echo "=== 5/7: Native deps ==="
+          ./mill 'sjsonnet.native[_].compile' || true
+
+          echo "=== 6/7: Bench deps ==="
+          ./mill bench.compile || true
+
+          echo "=== 7/7: sbt deps ==="
+          sbt update || true
+
+          echo "Dependency resolution complete"
+
+      - name: Generate cache key with timestamp
+        id: cache-key
+        shell: bash
+        run: |
+          # Include timestamp so each warmer run creates a new cache entry
+          # (GitHub Actions caches are immutable — can't overwrite existing keys).
+          # The restore step uses prefix 'dep-cache-' to match the latest entry.
+          # Old entries auto-expire after 7 days of no access.
+          TIMESTAMP=$(date -u +%Y%m%d%H%M%S)
+          BUILD_HASH=${{ hashFiles('build.mill') }}
+          echo "key=dep-cache-${TIMESTAMP}-${BUILD_HASH}" >> "$GITHUB_OUTPUT"
+
+      - name: Save dependency cache
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            ~/.cache/coursier/v1
+            ~/.cache/mill
+            ~/.sbt
+            ~/.ivy2/cache
+          key: ${{ steps.cache-key.outputs.key }}


### PR DESCRIPTION
## Summary

- Switch `pr-build.yaml` from `pull_request_target` to `pull_request` to prevent fork PRs from running untrusted code with secret access and OIDC tokens
- Add fork detection to runner selection so fork PRs use `ubuntu-latest` instead of protected runners
- Add `warm-dep-cache.yaml` workflow that pre-populates the Coursier/sbt dependency cache via JFrog on trusted triggers (push to master, daily schedule, manual dispatch)
- Make JFrog scripts (`get-jfrog-token.sh`, `fix-build-config.sh`) degrade gracefully when OIDC is unavailable, falling back to the warmed cache + Maven Central
- Add `actions/cache/restore` step to `setup-build` action to restore the pre-warmed dependency cache

## Test plan

- [ ] Verify internal PRs still use protected runners and JFrog OIDC
- [ ] Verify fork PRs route to `ubuntu-latest` and skip JFrog gracefully
- [ ] Manually trigger the `warm-dep-cache` workflow and confirm cache is saved
- [ ] Open a test fork PR and confirm it restores the warmed cache and builds successfully

This pull request was AI-assisted by Isaac.