### PR TITLE
Really fix warm-cache workflow and build for PR coming from forks

### DIFF
--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -22,7 +22,6 @@ runs:
           ~/.cache/mill
           ~/.sbt
           ~/.ivy2/cache
-          ~/.ivy2/local
         key: dep-cache-${{ hashFiles('build.mill') }}
         restore-keys: dep-cache-
     - name: Set up JDK 21

--- a/.github/scripts/fix-build-config.sh
+++ b/.github/scripts/fix-build-config.sh
@@ -1,19 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ "${GITHUB_REPOSITORY:-}" != "databricks/sjsonnet" ]; then
-  echo "Skipping Mill/sbt JFrog config: GITHUB_REPOSITORY is ${GITHUB_REPOSITORY:-unset}, expected databricks/sjsonnet"
-  exit 0
-fi
-
-# If JFrog token is not available (e.g. fork PRs without OIDC), skip
-# JFrog configuration. The build will use the pre-warmed dependency
-# cache and fall back to Maven Central for any missing artifacts.
-if [ -z "${JFROG_ACCESS_TOKEN:-}" ]; then
-  echo "Skipping Mill/sbt JFrog config: JFROG_ACCESS_TOKEN not set (likely a fork PR)"
-  exit 0
-fi
-
 JFROG_HOSTNAME="databricks.jfrog.io"
 JFROG_REALM="Artifactory Realm"
 JFROG_USERNAME="gha-service-account"

--- a/.github/scripts/get-jfrog-token.sh
+++ b/.github/scripts/get-jfrog-token.sh
@@ -1,15 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ "${GITHUB_REPOSITORY:-}" != "databricks/sjsonnet" ]; then
-  echo "Skipping JFrog token: GITHUB_REPOSITORY is ${GITHUB_REPOSITORY:-unset}, expected databricks/sjsonnet"
-  exit 0
-fi
-
 # Fork PRs using the pull_request trigger don't have OIDC access.
 # They rely on the pre-warmed dependency cache instead of JFrog.
 if [ -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ] || [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ]; then
   echo "Skipping JFrog token: OIDC not available (likely a fork PR)"
+  echo "JFROG_ACCESS_TOKEN=dummy" >> "$GITHUB_ENV"
   exit 0
 fi
 

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -12,7 +12,9 @@ permissions:
 jobs:
   # Forks cannot use org runner groups; use GitHub-hosted runners instead.
   build-jvm:
-    runs-on: ${{ github.repository == 'databricks/sjsonnet' && fromJSON('{"group":"databricks-protected-runner-group","labels":"linux-ubuntu-latest"}') || 'ubuntu-latest' }}
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     timeout-minutes: 20
     name: Sjsonnet jvm build
     steps:
@@ -27,7 +29,9 @@ jobs:
       - name: Run sbt tests
         run: sbt test
   build-graal:
-    runs-on: ${{ github.repository == 'databricks/sjsonnet' && fromJSON('{"group":"databricks-protected-runner-group","labels":"linux-ubuntu-latest"}') || 'ubuntu-latest' }}
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     timeout-minutes: 20
     name: Sjsonnet Graal Native build
     steps:
@@ -36,7 +40,9 @@ jobs:
       - name: Run Native Image Test Suites
         run: sjsonnet/test/graalvm/run_test_suites.py
   build-other:
-    runs-on: ${{ github.repository == 'databricks/sjsonnet' && fromJSON('{"group":"databricks-protected-runner-group","labels":"linux-ubuntu-latest"}') || 'ubuntu-latest' }}
+    runs-on:
+      group: databricks-protected-runner-group
+      labels: linux-ubuntu-latest
     timeout-minutes: 20
     strategy:
       fail-fast: false

--- a/.github/workflows/warm-dep-cache.yaml
+++ b/.github/workflows/warm-dep-cache.yaml
@@ -36,11 +36,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
-
       - uses: ./.github/actions/setup-build
         with:
           sbt: 'true'
-
       - name: Resolve all dependencies
         run: |
           set -euo pipefail
@@ -71,5 +69,4 @@ jobs:
             ~/.cache/mill
             ~/.sbt
             ~/.ivy2/cache
-            ~/.ivy2/local
           key: ${{ steps.cache-key.outputs.key }}


### PR DESCRIPTION
The key issue was that coursier caches the hostname, which we did not set when skipping downloading in the previous attempts