### PR TITLE
ci: add Additional Mill targets in dep cache for JS, Native and graal builds.

### DIFF
--- a/.github/workflows/warm-dep-cache.yaml
+++ b/.github/workflows/warm-dep-cache.yaml
@@ -50,6 +50,10 @@ jobs:
           ./mill "__.scalaJSLinkerClasspath"
           ./mill "__.scalaNativeWorkerClasspath"
           ./mill "__.bridgeFullClassPath"
+          ./mill "__.scalaJSTestDeps"
+          ./mill "__.resolvedMvnDeps"
+          ./mill "__.resolvedRunMvnDeps"
+          ./mill "sjsonnet.graal.javaHome"
           sbt update || true
 
           echo "Dependency resolution complete"


### PR DESCRIPTION
Co-authored-by: Isaac