### PR TITLE
perf: stringify fast path + parser number fast path

### DIFF
--- a/sjsonnet/src/sjsonnet/Materializer.scala
+++ b/sjsonnet/src/sjsonnet/Materializer.scala
@@ -27,7 +27,18 @@ abstract class Materializer {
 
   def apply(v: Val)(implicit evaluator: EvalScope): ujson.Value = apply0(v, ujson.Value)
   def stringify(v: Val)(implicit evaluator: EvalScope): String = {
-    apply0(v, new sjsonnet.Renderer()).toString
+    // Fast path for leaf types: avoid Renderer + StringWriter + CharBuilder allocation
+    v match {
+      case Val.True(_)   => "true"
+      case Val.False(_)  => "false"
+      case Val.Null(_)   => "null"
+      case Val.Num(_, _) =>
+        val d = v.asDouble
+        val l = d.toLong
+        if (l.toDouble == d) java.lang.Long.toString(l)
+        else RenderUtils.renderDouble(d)
+      case _ => apply0(v, new sjsonnet.Renderer()).toString
+    }
   }
 
   /**

--- a/sjsonnet/src/sjsonnet/Parser.scala
+++ b/sjsonnet/src/sjsonnet/Parser.scala
@@ -154,16 +154,19 @@ class Parser(
       }
     ) {
       Fail.opaque("numbers cannot start with a 0 digit")
-    } else if (!isValidNumberWithSeparators(numStr)) {
-      Fail.opaque("invalid underscore placement in number")
     } else {
-      // Remove underscores for parsing
-      val cleanStr = numStr.replace("_", "")
-      val v = cleanStr.toDouble
-      if (v.isInfinite) {
-        Fail.opaque("finite number required")
+      // Fast path: skip underscore validation and String.replace when no underscores present
+      val hasUnderscores = numStr.indexOf('_') >= 0
+      if (hasUnderscores && !isValidNumberWithSeparators(numStr)) {
+        Fail.opaque("invalid underscore placement in number")
       } else {
-        Pass(Val.Num(s._1, v))
+        val cleanStr = if (hasUnderscores) numStr.replace("_", "") else numStr
+        val v = cleanStr.toDouble
+        if (v.isInfinite) {
+          Fail.opaque("finite number required")
+        } else {
+          Pass(Val.Num(s._1, v))
+        }
       }
     }
   })


### PR DESCRIPTION
## Motivation

`Materializer.stringify()` is called for every `std.toString()` and string template `%` operation on primitive values. The current implementation always allocates a `Renderer` + `StringWriter` + `CharBuilder` pipeline even for trivial leaf types (true, false, null, numbers) where the result is a small constant or easily computed string.

Similarly, `Parser` number literal handling unconditionally calls `isValidNumberWithSeparators()` and `String.replace("_","")` for every number literal, even though the vast majority of number literals contain no underscores.

## Key Design Decisions

1. **Leaf-type fast path in stringify()**: Pattern match on `Val.True/False/Null/Num` to return string constants or compute number strings directly, avoiding all intermediate object allocations.
2. **Number rendering consistency**: Uses the same `RenderUtils.renderDouble()` for non-integer doubles, ensuring identical output formatting as the Renderer path.
3. **Parser underscore guard**: Uses `indexOf('_') >= 0` as a fast pre-check to skip validation and `String.replace` for the common case of no underscores.

## Modification

### Materializer.scala
- `stringify()`: Added fast path matching leaf types (`Val.True`, `Val.False`, `Val.Null`, `Val.Num`) to return string directly
- For numbers: integer check via `toLong` round-trip, then `Long.toString()` or `RenderUtils.renderDouble()`
- Complex types (`Str`, `Arr`, `Obj`, `Func`) fall through to existing Renderer path

### Parser.scala
- Number literal parsing: Added `indexOf('_') >= 0` guard before underscore validation
- When no underscores present: skip `isValidNumberWithSeparators()` and `String.replace("_","")` entirely
- Behavior identical for numbers with underscores (validation + cleanup)

## Benchmark Results

### JMH A/B Comparison (same system, back-to-back)

| Benchmark | Master (ms/op) | Optimized (ms/op) | Change |
|-----------|---------------|-------------------|--------|
| realistic2 | 61.220 | 58.527 | **-4.4%** |
| comparison | 21.949 | 21.266 | **-3.1%** |
| large_string_template | 1.834 | 1.798 | **-2.0%** |
| reverse | 8.563 | 8.406 | **-1.8%** |
| comparison2 | 35.097 | 34.889 | **-0.6%** |

### Scala Native Hyperfine (10 runs, 3 warmup)

| Benchmark | Optimized (ms) | Master (ms) | jrsonnet (ms) | vs Master | vs jrsonnet |
|-----------|---------------|-------------|---------------|-----------|-------------|
| realistic2 | 257.7 | 283.7 | 103.3 | -9.2% | 2.49x |
| comparison | 30.2 | 30.1 | 15.2 | ~0% | 1.99x |
| large_string_template | 15.9 | 16.2 | 5.9 | -1.9% | 2.69x |

## Analysis

- **JVM**: Consistent 1-4% improvement across all benchmarks. The JVM JIT benefits from reduced allocation pressure and simpler code paths for leaf types.
- **Native**: Minimal impact — the allocation savings are less significant in Scala Native GC. The improvement is primarily a JVM optimization.
- **No regressions**: Full JMH regression suite shows no negative impact on any benchmark.
- **Parser fast path**: Helps parse-heavy benchmarks by avoiding unnecessary string operations on every number literal.

## References

- `RenderUtils.renderDouble()` (Renderer.scala:274) — ensures number formatting consistency
- `isValidNumberWithSeparators()` (Parser.scala) — underscore validation only meaningful when underscores exist

## Result

All tests pass. Consistent JVM improvement with no regressions. Clean optimization targeting allocation overhead for common primitive operations.