### PR TITLE
fix: add cycle detection to Materializer for recursive object detection

### DIFF
--- a/sjsonnet/src/sjsonnet/Materializer.scala
+++ b/sjsonnet/src/sjsonnet/Materializer.scala
@@ -707,17 +707,17 @@ object Materializer extends Materializer {
       case Expr.Error(_, v) => hasSelfRefExpr(v, inNestedObj)
 
       // Apply variants
-      case Expr.Apply(_, v, args, _, _) =>
+      case Expr.Apply(_, v, args, _, _, _) =>
         hasSelfRefExpr(v, inNestedObj) || args.exists(a => hasSelfRefExpr(a, inNestedObj))
-      case Expr.Apply0(_, v, _)     => hasSelfRefExpr(v, inNestedObj)
-      case Expr.Apply1(_, v, a1, _) =>
+      case Expr.Apply0(_, v, _, _)     => hasSelfRefExpr(v, inNestedObj)
+      case Expr.Apply1(_, v, a1, _, _) =>
         hasSelfRefExpr(v, inNestedObj) || hasSelfRefExpr(a1, inNestedObj)
-      case Expr.Apply2(_, v, a1, a2, _) =>
+      case Expr.Apply2(_, v, a1, a2, _, _) =>
         hasSelfRefExpr(v, inNestedObj) || hasSelfRefExpr(a1, inNestedObj) || hasSelfRefExpr(
           a2,
           inNestedObj
         )
-      case Expr.Apply3(_, v, a1, a2, a3, _) =>
+      case Expr.Apply3(_, v, a1, a2, a3, _, _) =>
         hasSelfRefExpr(v, inNestedObj) || hasSelfRefExpr(a1, inNestedObj) ||
         hasSelfRefExpr(a2, inNestedObj) || hasSelfRefExpr(a3, inNestedObj)
 

--- a/sjsonnet/src/sjsonnet/Materializer.scala
+++ b/sjsonnet/src/sjsonnet/Materializer.scala
@@ -82,35 +82,41 @@ abstract class Materializer {
       Error.fail("Out of memory while materializing, possibly due to recursive value", v.pos)
   }
 
-  @inline private def materializeRecursiveObj[T](
+  private def materializeRecursiveObj[T](
       obj: Val.Obj,
       visitor: Visitor[T, T],
       depth: Int,
       ctx: Materializer.MaterializeContext)(implicit evaluator: EvalScope): T = {
-    storePos(obj.pos)
-    obj.triggerAllAsserts(ctx.brokenAssertionLogic)
-    if (obj.canDirectIterate) {
-      // Fast path for inline objects (1-8 fields, no super chain, no excludedKeys).
-      // Bypasses visibleKeyNames allocation, value() HashMap lookup per key,
-      // and sortedVisibleKeyNames lazy val. Instead iterates raw arrays directly.
-      if (ctx.sort) materializeSortedInlineObj(obj, visitor, depth, ctx)
-      else materializeInlineObj(obj, visitor, depth, ctx)
-    } else {
-      val keys =
-        if (ctx.sort) obj.visibleKeyNames.sorted(Util.CodepointStringOrdering)
-        else obj.visibleKeyNames
-      val ov = visitor.visitObject(keys.length, jsonableKeys = true, -1)
-      var i = 0
-      while (i < keys.length) {
-        val key = keys(i)
-        val childVal = obj.value(key, ctx.emptyPos)
-        storePos(childVal)
-        ov.visitKeyValue(ov.visitKey(-1).visitString(key, -1))
-        val sub = ov.subVisitor.asInstanceOf[Visitor[T, T]]
-        ov.visitValue(materializeRecursiveChild(childVal, sub, depth, ctx), -1)
-        i += 1
+    if (!ctx.enterObject(obj))
+      Error.fail("Stackoverflow while materializing, possibly due to recursive value", obj.pos)
+    try {
+      storePos(obj.pos)
+      obj.triggerAllAsserts(ctx.brokenAssertionLogic)
+      if (obj.canDirectIterate) {
+        // Fast path for inline objects (1-8 fields, no super chain, no excludedKeys).
+        // Bypasses visibleKeyNames allocation, value() HashMap lookup per key,
+        // and sortedVisibleKeyNames lazy val. Instead iterates raw arrays directly.
+        if (ctx.sort) materializeSortedInlineObj(obj, visitor, depth, ctx)
+        else materializeInlineObj(obj, visitor, depth, ctx)
+      } else {
+        val keys =
+          if (ctx.sort) obj.visibleKeyNames.sorted(Util.CodepointStringOrdering)
+          else obj.visibleKeyNames
+        val ov = visitor.visitObject(keys.length, jsonableKeys = true, -1)
+        var i = 0
+        while (i < keys.length) {
+          val key = keys(i)
+          val childVal = obj.value(key, ctx.emptyPos)
+          storePos(childVal)
+          ov.visitKeyValue(ov.visitKey(-1).visitString(key, -1))
+          val sub = ov.subVisitor.asInstanceOf[Visitor[T, T]]
+          ov.visitValue(materializeRecursiveChild(childVal, sub, depth, ctx), -1)
+          i += 1
+        }
+        ov.visitEnd(-1)
       }
-      ov.visitEnd(-1)
+    } finally {
+      ctx.exitObject(obj)
     }
   }
 
@@ -167,11 +173,6 @@ abstract class Materializer {
     }
   }
 
-  /**
-   * Sorted direct iteration for inline objects. Computes sorted field indices via insertion sort
-   * (optimal for 2-8 fields), then iterates via direct member invocation in sorted key order.
-   * Avoids: sortedVisibleKeyNames lazy val, value() linear scan, validation check.
-   */
   /**
    * Sorted direct iteration for inline objects. Uses cached sorted field order when available
    * (shared across all objects from the same MemberList), falling back to per-object computation.
@@ -346,6 +347,7 @@ abstract class Materializer {
             val sub = ov.subVisitor.asInstanceOf[Visitor[T, T]]
             materializeChild(childVal, sub, ov, stack, ctx)
           } else {
+            ctx.exitObject(frame.obj)
             val result = ov.visitEnd(-1)
             stack.removeFirst()
             if (stack.isEmpty) return result
@@ -425,6 +427,8 @@ abstract class Materializer {
       stack: java.util.ArrayDeque[Materializer.MaterializeFrame],
       ctx: Materializer.MaterializeContext)(implicit evaluator: EvalScope): Unit = {
     checkDepth(obj.pos, stack.size, ctx.maxDepth)
+    if (!ctx.enterObject(obj))
+      Error.fail("Stackoverflow while materializing, possibly due to recursive value", obj.pos)
     storePos(obj.pos)
     obj.triggerAllAsserts(ctx.brokenAssertionLogic)
     val keyNames =
@@ -814,7 +818,22 @@ object Materializer extends Materializer {
       val brokenAssertionLogic: Boolean,
       val emptyPos: Position,
       val recursiveDepthLimit: Int,
-      val maxDepth: Int)
+      val maxDepth: Int) {
+
+    // Tracks objects currently being materialized on the current path (entry → exit).
+    // Used to detect cycles like `{ x: self }` early, before any significant output
+    // is written. Uses identity equality so structurally equal but distinct objects
+    // can still be materialized independently.
+    val visitedObjects: java.util.IdentityHashMap[Val.Obj, java.lang.Boolean] =
+      new java.util.IdentityHashMap[Val.Obj, java.lang.Boolean]()
+
+    /** Returns true if `obj` was NOT already being materialized (safe to proceed). */
+    @inline def enterObject(obj: Val.Obj): Boolean =
+      visitedObjects.put(obj, java.lang.Boolean.TRUE) eq null
+
+    @inline def exitObject(obj: Val.Obj): Unit =
+      visitedObjects.remove(obj)
+  }
 
   private[sjsonnet] object MaterializeContext {
     def apply(ev: EvalScope): MaterializeContext = new MaterializeContext(

--- a/sjsonnet/src/sjsonnet/Materializer.scala
+++ b/sjsonnet/src/sjsonnet/Materializer.scala
@@ -246,7 +246,7 @@ abstract class Materializer {
     av.visitEnd(-1)
   }
 
-  @inline private def materializeRecursiveChild[T](
+  private def materializeRecursiveChild[T](
       childVal: Val,
       childVisitor: Visitor[T, T],
       depth: Int,


### PR DESCRIPTION
## Motivation

The Materializer's iterative mode (`materializeStackless`) could process deeply recursive objects like `{ x: self }` without hitting `StackOverflowError` on platforms with larger stacks or more efficient writers. On such platforms, the recursive object would materialize indefinitely (producing megabytes of output) before eventually being killed by a timeout or OOM, instead of producing the expected error message.

This is especially problematic when output goes directly to a stream (e.g., `BufferedOutputStream(stdout)`) because partial output is irrevocably committed before the error is detected.

## Key Design Decision

Use an `IdentityHashMap`-based cycle detector that tracks `Val.Obj` instances **currently being materialized** on the active path. This uses reference equality (not structural equality), so:
- `{ x: self }` is detected at depth 2 — the same object instance is encountered again
- Structural sharing (same object appearing at independent locations) works correctly — objects are removed from the visited set when their materialization completes

The overhead is minimal: one `IdentityHashMap.put` + `remove` per object, with the map size bounded by the current nesting depth (not total object count).

## Modification

- Added `visitedObjects` `IdentityHashMap` to `MaterializeContext`
- Added `enterObject()` / `exitObject()` methods for clean tracking API
- **Recursive path** (`materializeRecursiveObj`): check on entry via `enterObject()`, cleanup in `finally` block via `exitObject()`
- **Iterative path** (`pushObjFrame` / frame completion loop): check on push, cleanup when `ObjFrame` finishes all its keys

## Result

- `error.obj_recursive` and `error.obj_recursive_manifest` tests now produce consistent error messages across all platforms (JVM, Scala Native, GraalVM Native) regardless of writer implementation
- Cycles are detected in O(1) time per object via identity hashing
- No behavioral change for non-cyclic objects
- No performance regression — the IdentityHashMap tracks at most `maxMaterializeDepth` entries