### PR TITLE
fix: update Apply pattern match arity for auto-TCO strict field

### DIFF
--- a/sjsonnet/src/sjsonnet/Materializer.scala
+++ b/sjsonnet/src/sjsonnet/Materializer.scala
@@ -707,17 +707,17 @@ object Materializer extends Materializer {
       case Expr.Error(_, v) => hasSelfRefExpr(v, inNestedObj)
 
       // Apply variants
-      case Expr.Apply(_, v, args, _, _) =>
+      case Expr.Apply(_, v, args, _, _, _) =>
         hasSelfRefExpr(v, inNestedObj) || args.exists(a => hasSelfRefExpr(a, inNestedObj))
-      case Expr.Apply0(_, v, _)     => hasSelfRefExpr(v, inNestedObj)
-      case Expr.Apply1(_, v, a1, _) =>
+      case Expr.Apply0(_, v, _, _)     => hasSelfRefExpr(v, inNestedObj)
+      case Expr.Apply1(_, v, a1, _, _) =>
         hasSelfRefExpr(v, inNestedObj) || hasSelfRefExpr(a1, inNestedObj)
-      case Expr.Apply2(_, v, a1, a2, _) =>
+      case Expr.Apply2(_, v, a1, a2, _, _) =>
         hasSelfRefExpr(v, inNestedObj) || hasSelfRefExpr(a1, inNestedObj) || hasSelfRefExpr(
           a2,
           inNestedObj
         )
-      case Expr.Apply3(_, v, a1, a2, a3, _) =>
+      case Expr.Apply3(_, v, a1, a2, a3, _, _) =>
         hasSelfRefExpr(v, inNestedObj) || hasSelfRefExpr(a1, inNestedObj) ||
         hasSelfRefExpr(a2, inNestedObj) || hasSelfRefExpr(a3, inNestedObj)
 


### PR DESCRIPTION
## Motivation

The auto-TCO commit (ecdd0b6, PR #694) added a `strict: Boolean` field to `Apply`, `Apply0`, `Apply1`, `Apply2`, and `Apply3` case classes. The `hasSelfRefExpr` pattern matches in `Materializer` were not updated, causing:

1. **Compilation failure on Scala 2.13.18**: `wrong number of arguments for pattern sjsonnet.Expr.Apply`
2. **Runtime `MatchError` on Scala 3.3.7**: The pattern match silently fell through to the wildcard case, causing incorrect materialization paths for lazy reverse arrays (`lazy_reverse_correctness.jsonnet` failure)

## Modification

Added wildcard for the new `strict` field in all five Apply pattern matches in `Materializer.hasSelfRefExpr`:

- `Apply(_, v, args, _, _)` → `Apply(_, v, args, _, _, _)`
- `Apply0(_, v, _)` → `Apply0(_, v, _, _)`
- `Apply1(_, v, a1, _)` → `Apply1(_, v, a1, _, _)`
- `Apply2(_, v, a1, a2, _)` → `Apply2(_, v, a1, a2, _, _)`
- `Apply3(_, v, a1, a2, a3, _)` → `Apply3(_, v, a1, a2, a3, _, _)`

## Result

- Scala 2.13.18 compiles and all tests pass (including `lazy_reverse_correctness.jsonnet`)
- Scala 3.3.7 all tests pass (no regressions)