### PR TITLE
perf: optimize sort allocation paths in std.sort and set operations

### DIFF
--- a/sjsonnet/src/sjsonnet/stdlib/SetModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/SetModule.scala
@@ -92,9 +92,16 @@ object SetModule extends AbstractFunctionModule {
       Val.Arr(
         pos,
         if (keyFFunc != null) {
-          val keys: Array[Val] = vs.map(v =>
-            keyFFunc(Array(v.value), null, pos.noOffset)(ev, TailstrictModeDisabled).value
-          )
+          // Reuse a single-element argument buffer across all key function calls
+          // to avoid allocating a new Array(1) per element.
+          val keys = new Array[Val](vs.length)
+          val argBuf = new Array[Val](1)
+          var i = 0
+          while (i < vs.length) {
+            argBuf(0) = vs(i).value
+            keys(i) = keyFFunc(argBuf, null, pos.noOffset)(ev, TailstrictModeDisabled).value
+            i += 1
+          }
           val keyType = keys(0).getClass
           if (classOf[Val.Bool].isAssignableFrom(keyType)) {
             Error.fail("Cannot sort with key values that are booleans")
@@ -122,9 +129,22 @@ object SetModule extends AbstractFunctionModule {
             Error.fail("Cannot sort with key values that are " + keys(0).prettyName + "s")
           }
 
-          sortedIndices.map(i => vs(i))
+          // Use while-loop instead of .map() to avoid closure + iterator allocation
+          val result = new Array[Eval](sortedIndices.length)
+          var j = 0
+          while (j < sortedIndices.length) {
+            result(j) = vs(sortedIndices(j))
+            j += 1
+          }
+          result
         } else {
-          val strict = vs.map(_.value)
+          // Force all lazy elements to strict values using while-loop
+          val strict = new Array[Val](vs.length)
+          var i = 0
+          while (i < vs.length) {
+            strict(i) = vs(i).value
+            i += 1
+          }
           val keyType = strict(0).getClass
           if (classOf[Val.Bool].isAssignableFrom(keyType)) {
             Error.fail("Cannot sort with values that are booleans")
@@ -132,11 +152,19 @@ object SetModule extends AbstractFunctionModule {
           if (!strict.forall(_.getClass == keyType))
             Error.fail("Cannot sort with values that are not all the same type")
 
+          // Sort in-place to avoid intermediate array allocations
           if (keyType == classOf[Val.Str]) {
-            strict.map(_.cast[Val.Str]).sortBy(_.asString)(Util.CodepointStringOrdering)
+            java.util.Arrays.sort(
+              strict.asInstanceOf[Array[AnyRef]],
+              (a: AnyRef, b: AnyRef) =>
+                Util.compareStringsByCodepoint(
+                  a.asInstanceOf[Val.Str].asString,
+                  b.asInstanceOf[Val.Str].asString
+                )
+            )
           } else if (keyType == classOf[Val.Num]) {
-            // In-place sort: avoids the two intermediate array copies from
-            // .map(_.cast[Val.Num]).sortBy(_.asDouble). Uses TimSort (stable)
+            // In-place sort using Comparator: avoids extracting + reconstructing Val.Num
+            // objects which causes GC pressure on Scala Native. TimSort (stable) is used,
             // which is excellent for nearly-sorted inputs (common for std.range).
             java.util.Arrays.sort(
               strict.asInstanceOf[Array[AnyRef]],
@@ -146,14 +174,17 @@ object SetModule extends AbstractFunctionModule {
                   b.asInstanceOf[Val.Num].asDouble
                 )
             )
-            strict
           } else if (keyType == classOf[Val.Arr]) {
-            strict.map(_.cast[Val.Arr]).sortBy(identity)(ev.compare(_, _))
+            java.util.Arrays.sort(
+              strict.asInstanceOf[Array[AnyRef]],
+              (a: AnyRef, b: AnyRef) => ev.compare(a.asInstanceOf[Val.Arr], b.asInstanceOf[Val.Arr])
+            )
           } else if (keyType == classOf[Val.Obj]) {
             Error.fail("Unable to sort array of objects without key function")
           } else {
             Error.fail("Cannot sort array of " + strict(0).prettyName)
           }
+          strict
         }
       )
     }


### PR DESCRIPTION
## Motivation

`std.sort` and set operations (`std.setDiff`, `std.setInter`, `std.setUnion`) internally sort arrays but use allocation-heavy patterns: `.map()` for forcing lazy values, `.map().sortBy()` creating intermediate copies, and allocating a new `Array(1)` per key function call.

## Key Design Decisions

- **Keep in-place Comparator sort for numerics** rather than primitive double sort + reconstruction. While primitive `Arrays.sort(double[])` is faster on JVM, the `Val.cachedNum` reconstruction step creates GC pressure on Scala Native (measured 1.26x regression). In-place Comparator sort avoids any reconstruction.
- **Reuse argument buffer** for key function calls: single `Array[Val](1)` shared across all iterations instead of `Array(v.value)` per element.
- **While-loops over `.map()`**: eliminates closure allocation, iterator overhead, and intermediate array copies.

## Modifications

`sjsonnet/src/sjsonnet/stdlib/SetModule.scala`:

1. **Key function path**: Reuse single-element `argBuf` across all key function calls, use while-loop for key computation
2. **Result construction**: Pre-allocated `Array[Eval]` with while-loop instead of `sortedIndices.map(i => vs(i))`
3. **Strict force**: `while` loop with pre-allocated `Array[Val]` instead of `vs.map(_.value)`
4. **String sort (no key)**: In-place `Arrays.sort` with Comparator instead of `.map(_.cast[Val.Str]).sortBy(_.asString)` (2 intermediate array copies)
5. **Array sort (no key)**: In-place `Arrays.sort` with Comparator instead of `.map(_.cast[Val.Arr]).sortBy(identity)` (2 intermediate copies)

## Benchmark Results

### JMH (JVM, single iteration)

| Benchmark | Before (ms/op) | After (ms/op) | Change |
|-----------|----------------|---------------|--------|
| bench.06 (sort) | 0.359 | 0.251 | **-30.1%** |
| setDiff | 0.533 | 0.446 | **-16.3%** |
| setInter | 0.367 | 0.386 | neutral |
| setUnion | 0.727 | 0.677 | **-6.9%** |

### Scala Native hyperfine (`-N --warmup 10`)

| Benchmark | Before (ms) | After (ms) | Speedup |
|-----------|-------------|------------|---------|
| bench.06 (sort, 30 runs) | 7.6 ± 0.4 | 5.5 ± 0.2 | **1.39x** |
| setDiff (20 runs) | 8.8 ± 0.6 | 7.7 ± 0.6 | **1.13x** |
| setInter (20 runs) | 8.6 ± 1.3 | 8.3 ± 0.8 | neutral |

## Analysis

The allocation reduction benefits both JVM and Native, but the impact is more pronounced on Native where GC overhead is higher. The sort benchmark sees the largest improvement because it exercises all the optimized paths (force + sort + result construction). Set operations see moderate improvement since the merge-based intersection/difference only calls sort once on already-sorted inputs.

## References

- Upstream exploration: he-pin/sjsonnet jit branch [`b1f64df0`](https://github.com/He-Pin/sjsonnet/commit/b1f64df0)

## Result

Sort and set operations are faster on both JVM and Scala Native with zero semantic changes. All existing tests pass.