### PR TITLE
perf: add object-related counters to --debug-stats

### DIFF
--- a/sjsonnet/src/sjsonnet/DebugStats.scala
+++ b/sjsonnet/src/sjsonnet/DebugStats.scala
@@ -23,6 +23,15 @@ final class DebugStats {
   var arrayCompIterations: Long = 0
   var objectCompIterations: Long = 0
 
+  // -- Objects --
+  var objectsCreated: Long = 0
+  var addSuperCalls: Long = 0
+  var addSuperChainWalks: Long = 0
+  var maxSuperChainDepth: Int = 0
+  var valueCacheOverflows: Long = 0
+  var fieldLookups: Long = 0
+  var fieldCacheHits: Long = 0
+
   // -- Parse / import --
   var filesParsed: Long = 0
   var importCalls: Long = 0
@@ -45,6 +54,13 @@ final class DebugStats {
     sb.append(formatLine("max_stack_depth", maxStackDepth))
     sb.append(formatLine("array_comp_iterations", arrayCompIterations))
     sb.append(formatLine("object_comp_iterations", objectCompIterations))
+    sb.append(formatLine("objects_created", objectsCreated))
+    sb.append(formatLine("add_super_calls", addSuperCalls))
+    sb.append(formatLine("add_super_chain_walks", addSuperChainWalks))
+    sb.append(formatLine("max_super_chain_depth", maxSuperChainDepth))
+    sb.append(formatLine("value_cache_overflows", valueCacheOverflows))
+    sb.append(formatLine("field_lookups", fieldLookups))
+    sb.append(formatLine("field_cache_hits", fieldCacheHits))
     sb.append(formatLine("files_parsed", filesParsed))
     sb.append(formatLine("import_calls", importCalls))
     sb.append(formatLine("import_cache_hits", importCacheHits))

--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -29,6 +29,8 @@ class Evaluator(
   implicit def evalScope: EvalScope = this
   def importer: CachedImporter = resolver
 
+  if (debugStats != null) Val.Obj.currentDebugStats = debugStats
+
   def trace(e: String): Unit = if (logger != null) logger(true, e)
   def warn(e: Error): Unit = if (logger != null) logger(false, Error.formatError(e))
 
@@ -1771,6 +1773,7 @@ class Evaluator(
     // When true, the Materializer can skip cacheFieldValue() during inline iteration, eliminating
     // HashMap allocation overhead for objects with >2 fields.
     val noSelfRef = sup == null && Materializer.computeNoSelfRef(e)
+    if (debugStats != null) debugStats.objectsCreated += 1
     cachedObj = if (fieldCount == 1 && singleKey != null) {
       // Single-field object: store key and member inline, avoid LinkedHashMap allocation entirely
       val obj = new Val.Obj(
@@ -1852,6 +1855,7 @@ class Evaluator(
         case x           => fieldNameTypeError(x, e.pos)
       }
     }
+    if (debugStats != null) debugStats.objectsCreated += 1
     new Val.Obj(e.pos, builder, false, null, sup)
   }
 

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -534,6 +534,9 @@ object Val {
 
   object Obj {
 
+    /** Package-private ref to DebugStats, set by Evaluator when --debug-stats is active. */
+    private[sjsonnet] var currentDebugStats: DebugStats = _
+
     /**
      * @param add
      *   whether this field was defined the "+:", "+::" or "+:::" separators, corresponding to the
@@ -639,7 +642,11 @@ object Val {
       if (ck1 == null) { ck1 = key; cv1 = v }
       else if (ck2 == null) { ck2 = key; cv2 = v }
       else {
-        if (valueCache == null) valueCache = new util.HashMap[Any, Val]()
+        if (valueCache == null) {
+          val ds = Obj.currentDebugStats
+          if (ds != null) ds.valueCacheOverflows += 1
+          valueCache = new util.HashMap[Any, Val]()
+        }
         valueCache.put(key, v)
       }
     }
@@ -741,6 +748,8 @@ object Val {
     }
 
     def addSuper(pos: Position, lhs: Val.Obj): Val.Obj = {
+      val ds = Obj.currentDebugStats
+      if (ds != null) ds.addSuperCalls += 1
       // Fast path: no super chain — avoid ArrayBuilder + Array allocation.
       // Invariant: excludedKeys != null implies getSuper != null (removeKeys always sets super),
       // so when getSuper == null, excludedKeys is always null and the re-introduction logic
@@ -758,6 +767,7 @@ object Val {
           null
         )
       }
+      if (ds != null) ds.addSuperChainWalks += 1
       // Single traversal: collect chain in this-first order
       val builder = new mutable.ArrayBuilder.ofRef[Val.Obj]
       var current = this
@@ -766,6 +776,8 @@ object Val {
         current = current.getSuper
       }
       val chain = builder.result()
+      if (ds != null && chain.length > ds.maxSuperChainDepth)
+        ds.maxSuperChainDepth = chain.length
 
       // Pre-collect all keys defined in this chain once (only needed if any obj has excludedKeys)
       lazy val keysInThisChain: java.util.Set[String] = {
@@ -1023,24 +1035,31 @@ object Val {
     }
 
     def value(k: String, pos: Position, self: Obj = this)(implicit evaluator: EvalScope): Val = {
+      val ds = evaluator.debugStats
+      if (ds != null) ds.fieldLookups += 1
       if (static) {
         valueCache.get(k) match {
           case null => Error.fail("Field does not exist: " + k, pos)
-          case x    => x
+          case x    =>
+            if (ds != null) ds.fieldCacheHits += 1
+            x
         }
       } else {
-        // Check if the key is excluded (used by objectRemoveKey)
-        // When self != this, we need to check if the key exists in self's visible keys
         if ((self eq this) && excludedKeys != null && excludedKeys.contains(k)) {
           Error.fail("Field does not exist: " + k, pos)
         }
         val cacheKey: Any = if (self eq this) k else (k, self)
-        // Check inline cache first (avoids HashMap lookup for ≤2 cached fields)
-        if (ck1 != null && ck1 == cacheKey) return cv1
-        if (ck2 != null && ck2 == cacheKey) return cv2
-        // Check overflow HashMap
+        if (ck1 != null && ck1 == cacheKey) {
+          if (ds != null) ds.fieldCacheHits += 1
+          return cv1
+        }
+        if (ck2 != null && ck2 == cacheKey) {
+          if (ds != null) ds.fieldCacheHits += 1
+          return cv2
+        }
         val cachedValue = if (valueCache != null) valueCache.get(cacheKey) else null
         if (cachedValue != null) {
+          if (ds != null) ds.fieldCacheHits += 1
           cachedValue
         } else {
           valueRaw(k, self, pos, this, cacheKey) match {
@@ -1711,6 +1730,7 @@ abstract class EvalScope extends EvalErrorScope with Ordering[Val] {
   val emptyMaterializeFileScopePos = new Position(emptyMaterializeFileScope, -1)
 
   def settings: Settings
+  def debugStats: DebugStats
   def trace(msg: String): Unit
   def warn(e: Error): Unit
 


### PR DESCRIPTION
Add counters for Val.Obj hot paths to enable data-driven optimization:
- objects_created: total Val.Obj constructions (visitMemberList, visitObjComp)
- add_super_calls / add_super_chain_walks: object merge (+) frequency and slow-path (existing super chain) frequency
- max_super_chain_depth: deepest inheritance chain seen
- value_cache_overflows: 2-slot inline cache -> HashMap spills
- field_lookups / field_cache_hits: field access volume and cache hit rate