### PR TITLE
perf: EagerObjBody + foldl/foldr scope reuse

### DIFF
--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -69,43 +69,44 @@ class Evaluator(
     val saved: (AnyRef, Int) = if (p != null) p.enter(e) else null
     try {
       e match {
-        case e: ValidId            => visitValidId(e)
-        case e: BinaryOp           => visitBinaryOp(e)
-        case e: Select             => visitSelect(e)
-        case e: Val                => e
-        case e: ApplyBuiltin0      => visitApplyBuiltin0(e)
-        case e: ApplyBuiltin1      => visitApplyBuiltin1(e)
-        case e: ApplyBuiltin2      => visitApplyBuiltin2(e)
-        case e: ApplyBuiltin3      => visitApplyBuiltin3(e)
-        case e: ApplyBuiltin4      => visitApplyBuiltin4(e)
-        case e: And                => visitAnd(e)
-        case e: Or                 => visitOr(e)
-        case e: UnaryOp            => visitUnaryOp(e)
-        case e: Apply1             => visitApply1(e)
-        case e: Lookup             => visitLookup(e)
-        case e: Function           => visitMethod(e.body, e.params, e.pos)
-        case e: LocalExpr          => visitLocalExpr(e)
-        case e: Apply              => visitApply(e)
-        case e: IfElse             => visitIfElse(e)
-        case e: Apply3             => visitApply3(e)
-        case e: ObjBody.MemberList => visitMemberList(e.pos, e, null)
-        case e: Apply2             => visitApply2(e)
-        case e: AssertExpr         => visitAssert(e)
-        case e: ApplyBuiltin       => visitApplyBuiltin(e)
-        case e: Comp               => visitComp(e)
-        case e: Arr                => visitArr(e)
-        case e: SelectSuper        => visitSelectSuper(e)
-        case e: LookupSuper        => visitLookupSuper(e)
-        case e: InSuper            => visitInSuper(e)
-        case e: ObjExtend          => visitObjExtend(e)
-        case e: ObjBody.ObjComp    => visitObjComp(e, null)
-        case e: Slice              => visitSlice(e)
-        case e: Import             => visitImport(e)
-        case e: Apply0             => visitApply0(e)
-        case e: ImportStr          => visitImportStr(e)
-        case e: ImportBin          => visitImportBin(e)
-        case e: Expr.Error         => visitError(e)
-        case e                     => visitInvalid(e)
+        case e: ValidId              => visitValidId(e)
+        case e: BinaryOp             => visitBinaryOp(e)
+        case e: Select               => visitSelect(e)
+        case e: Val                  => e
+        case e: ApplyBuiltin0        => visitApplyBuiltin0(e)
+        case e: ApplyBuiltin1        => visitApplyBuiltin1(e)
+        case e: ApplyBuiltin2        => visitApplyBuiltin2(e)
+        case e: ApplyBuiltin3        => visitApplyBuiltin3(e)
+        case e: ApplyBuiltin4        => visitApplyBuiltin4(e)
+        case e: And                  => visitAnd(e)
+        case e: Or                   => visitOr(e)
+        case e: UnaryOp              => visitUnaryOp(e)
+        case e: Apply1               => visitApply1(e)
+        case e: Lookup               => visitLookup(e)
+        case e: Function             => visitMethod(e.body, e.params, e.pos)
+        case e: LocalExpr            => visitLocalExpr(e)
+        case e: Apply                => visitApply(e)
+        case e: IfElse               => visitIfElse(e)
+        case e: Apply3               => visitApply3(e)
+        case e: ObjBody.MemberList   => visitMemberList(e.pos, e, null)
+        case e: Apply2               => visitApply2(e)
+        case e: AssertExpr           => visitAssert(e)
+        case e: ApplyBuiltin         => visitApplyBuiltin(e)
+        case e: Comp                 => visitComp(e)
+        case e: Arr                  => visitArr(e)
+        case e: SelectSuper          => visitSelectSuper(e)
+        case e: LookupSuper          => visitLookupSuper(e)
+        case e: InSuper              => visitInSuper(e)
+        case e: ObjExtend            => visitObjExtend(e)
+        case e: ObjBody.ObjComp      => visitObjComp(e, null)
+        case e: Slice                => visitSlice(e)
+        case e: Import               => visitImport(e)
+        case e: Apply0               => visitApply0(e)
+        case e: ImportStr            => visitImportStr(e)
+        case e: ImportBin            => visitImportBin(e)
+        case e: Expr.Error           => visitError(e)
+        case e: ObjBody.EagerObjBody => visitEagerObjBody(e)
+        case e                       => visitInvalid(e)
       }
     } finally if (p != null) p.exit(saved)
   } catch {
@@ -721,10 +722,11 @@ class Evaluator(
   def visitObjExtend(e: ObjExtend)(implicit scope: ValScope): Val = {
     val original = visitExpr(e.base).cast[Val.Obj]
     e.ext match {
-      case ext: ObjBody.MemberList => visitMemberList(e.pos, ext, original)
-      case ext: ObjBody.ObjComp    => visitObjComp(ext, original)
-      case o: Val.Obj              => o.addSuper(e.pos, original)
-      case _                       => Error.fail("Should not have happened", e.pos)
+      case ext: ObjBody.MemberList   => visitMemberList(e.pos, ext, original)
+      case ext: ObjBody.EagerObjBody => visitEagerObjBody(ext).addSuper(e.pos, original)
+      case ext: ObjBody.ObjComp      => visitObjComp(ext, original)
+      case o: Val.Obj                => o.addSuper(e.pos, original)
+      case _                         => Error.fail("Should not have happened", e.pos)
     }
   }
 
@@ -1823,6 +1825,29 @@ class Evaluator(
     cachedObj
   }
 
+  /**
+   * Fast path for EagerObjBody: evaluates all field values eagerly in the current scope (no
+   * self/super needed), creates a static Val.Obj with pre-cached values. Eliminates lazy closure
+   * allocation and deferred invocation overhead for objects that don't reference self/super.
+   */
+  def visitEagerObjBody(e: ObjBody.EagerObjBody)(implicit scope: ValScope): Val.Obj = {
+    val n = e.fieldNames.length
+    val cache = Util.preSizedJavaHashMap[Any, Val](n)
+    val allKeys = Util.preSizedJavaLinkedHashMap[String, java.lang.Boolean](n)
+    var i = 0
+    while (i < n) {
+      val k = e.fieldNames(i)
+      val v = visitExpr(e.fieldValues(i))
+      cache.put(k, v)
+      allKeys.put(
+        k,
+        java.lang.Boolean.FALSE
+      ) // All fields are Normal visibility (enforced by optimizer)
+      i += 1
+    }
+    new Val.Obj(e.pos, null, true, null, null, cache, allKeys)
+  }
+
   def visitObjComp(e: ObjBody.ObjComp, sup: Val.Obj)(implicit scope: ValScope): Val.Obj = {
     val binds = e.preLocals ++ e.postLocals
     val compScope: ValScope = scope // .clearSuper
@@ -2043,6 +2068,7 @@ class NewEvaluator(
       case ExprTags.ImportStr         => visitImportStr(e.asInstanceOf[ImportStr])
       case ExprTags.ImportBin         => visitImportBin(e.asInstanceOf[ImportBin])
       case ExprTags.Error             => visitError(e.asInstanceOf[Expr.Error])
+      case ExprTags.EagerObjBody      => visitEagerObjBody(e.asInstanceOf[ObjBody.EagerObjBody])
       case _                          => visitInvalid(e)
     }
   } catch {

--- a/sjsonnet/src/sjsonnet/Expr.scala
+++ b/sjsonnet/src/sjsonnet/Expr.scala
@@ -395,6 +395,29 @@ object Expr {
 
   trait ObjBody extends Expr
   object ObjBody {
+
+    /**
+     * Specialized object body for static-key objects whose field values do not reference `self`,
+     * `super`, or any object-local bindings, and all fields have Normal visibility. Detected by
+     * [[StaticOptimizer]] from [[ObjBody.MemberList]] when all field names are [[FieldName.Fixed]],
+     * there are no binds, asserts, `plus`, or `argSpec`, all fields are Normal visibility, field
+     * values don't reference self/super, and all field value expressions are "eager-safe" (provably
+     * total — can't error or diverge).
+     *
+     * The evaluator handles this node by evaluating all field values eagerly in the enclosing scope
+     * (no self/super binding needed) and constructing a `static=true` [[Val.Obj]] with pre-cached
+     * values, completely bypassing lazy closure allocation.
+     */
+    final case class EagerObjBody(
+        var pos: Position,
+        fieldNames: Array[String],
+        fieldValues: Array[Expr])
+        extends ObjBody {
+      final override private[sjsonnet] def tag = ExprTags.EagerObjBody
+      override def toString: String =
+        s"EagerObjBody($pos, ${arrStr(fieldNames)}, ${arrStr(fieldValues)})"
+    }
+
     final case class MemberList(
         var pos: Position,
         binds: Array[Bind],
@@ -479,6 +502,11 @@ private[sjsonnet] object ExprTags {
   final val ImportStr = 35
   final val ImportBin = 36
   final val Error = 37
+  // StaticOptimizer-specialized nodes: AST nodes created by pattern-directed optimization.
+  // These replace general-purpose nodes with specialized versions that enable fast Evaluator
+  // dispatch, bypassing overhead (closures, lazy evaluation, scope construction, etc.).
+  // See also: ValidId (scope-resolved Id), SelectSuper/InSuper (super-access specialization).
+  final val EagerObjBody = 38
   // used in Evaluator#visitInvalid
   final val Id = 0
   final val Self = 1

--- a/sjsonnet/src/sjsonnet/ExprTransform.scala
+++ b/sjsonnet/src/sjsonnet/ExprTransform.scala
@@ -142,6 +142,11 @@ abstract class ExprTransform {
         if ((x2 eq x) && (y2 eq y) && (z2 eq z)) expr
         else ObjBody.MemberList(pos, x2, y2, z2)
 
+      case ObjBody.EagerObjBody(pos, names, values) =>
+        val values2 = transformArr(values)
+        if (values2 eq values) expr
+        else ObjBody.EagerObjBody(pos, names, values2)
+
       case AssertExpr(pos, x, y) =>
         val x2 = transformAssert(x)
         val y2 = transform(y)

--- a/sjsonnet/src/sjsonnet/StaticOptimizer.scala
+++ b/sjsonnet/src/sjsonnet/StaticOptimizer.scala
@@ -122,6 +122,8 @@ class StaticOptimizer(
 
         if (binds == null && asserts == null && allFieldsStaticAndUniquelyNamed)
           Val.staticObject(pos, fields, internedStaticFieldSets, internedStrings)
+        else if (binds == null && asserts == null && isEagerObjCandidate(fields))
+          makeEagerObjBody(pos, fields)
         else m
       // Aggressive optimizations: constant folding, branch elimination, short-circuit elimination.
       // These reduce AST node count at parse time, benefiting long-running Jsonnet programs.
@@ -668,6 +670,29 @@ class StaticOptimizer(
   }
 
   /**
+   * Check if a MemberList's fields are eligible for EagerObjBody transformation: all field names
+   * are Fixed, no plus, no argSpec, field values don't reference self/super, unique field names,
+   * AND all field value expressions are "eager-safe" (provably total — can't error or diverge).
+   *
+   * The purity guard ensures that eager evaluation produces the same observable behavior as lazy
+   * evaluation, preserving Jsonnet's lazy field semantics.
+   */
+  private def isEagerObjCandidate(fields: Array[Expr.Member.Field]): Boolean = {
+    // scope.size is the outer scope size (self/super were added then restored by nestedObject)
+    val selfIdx = scope.size
+    val seen = mutable.Set.empty[String]
+    fields.forall { f =>
+      f.fieldName.isInstanceOf[FieldName.Fixed] &&
+      !f.plus &&
+      f.args == null &&
+      f.sep == Expr.Member.Visibility.Normal &&
+      seen.add(f.fieldName.asInstanceOf[FieldName.Fixed].value) &&
+      !exprReferencesScopeAtOrAbove(f.rhs, selfIdx) &&
+      isEagerSafeExpr(f.rhs)
+    }
+  }
+
+  /**
    * Walk an expression tree looking for self-recursive calls in tail position. A call is in tail
    * position if it is the last expression evaluated before the function returns — i.e. its result
    * becomes the function's return value without further transformation.
@@ -755,5 +780,59 @@ class StaticOptimizer(
 
       case _ => body
     }
+  }
+
+  /**
+   * Check if an expression is "eager-safe": evaluating it eagerly produces the same result as
+   * evaluating it lazily. This requires the expression to be provably total (always terminates
+   * without error). Allowed: literals, variable references, already-optimized EagerObjBody/static
+   * objects. Disallowed: function calls, error, assert, binary ops that can fail, etc.
+   */
+  private def isEagerSafeExpr(e: Expr): Boolean = e match {
+    case _: Val.Literal => true // constants — already a value
+    case _: ValidId     => true // variable reference — scope binding exists (optimizer validated)
+    case _: ObjBody.EagerObjBody => true // recursively already verified
+    case _                       => false
+  }
+
+  /** Check if an expression tree contains any ValidId with nameIdx >= threshold. */
+  private def exprReferencesScopeAtOrAbove(e: Expr, threshold: Int): Boolean = {
+    e match {
+      case ValidId(_, _, idx) => idx >= threshold
+      case _                  =>
+        var found = false
+        val checker = new ExprTransform {
+          def transform(expr: Expr): Expr = {
+            if (found) return expr
+            expr match {
+              case ValidId(_, _, idx) if idx >= threshold =>
+                found = true; expr
+              case _ => rec(expr)
+            }
+          }
+        }
+        checker.transform(e)
+        found
+    }
+  }
+
+  /** Convert eligible MemberList fields into an EagerObjBody node. */
+  private def makeEagerObjBody(
+      pos: Position,
+      fields: Array[Expr.Member.Field]): ObjBody.EagerObjBody = {
+    val n = fields.length
+    val names = new Array[String](n)
+    val values = new Array[Expr](n)
+    var i = 0
+    while (i < n) {
+      val f = fields(i)
+      names(i) = internedStrings.getOrElseUpdate(
+        f.fieldName.asInstanceOf[FieldName.Fixed].value,
+        f.fieldName.asInstanceOf[FieldName.Fixed].value
+      )
+      values(i) = f.rhs
+      i += 1
+    }
+    ObjBody.EagerObjBody(pos, names, values)
   }
 }

--- a/sjsonnet/src/sjsonnet/stdlib/ArrayModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/ArrayModule.scala
@@ -354,16 +354,38 @@ object ArrayModule extends AbstractFunctionModule {
               if (result != null) return result
             case _ =>
           }
-          var current = initVal
           val lazyArr = arr.asLazyArray
           val noOff = pos.noOffset
-          var i = 0
-          while (i < lazyArr.length) {
-            val c = current
-            current = func.apply2(c, lazyArr(i), noOff)(ev, TailstrictModeDisabled)
-            i += 1
+          if (!func.isInstanceOf[Val.Builtin] && func.params.names.length == 2) {
+            // Scope reuse: extend scope once, mutate bindings per iteration.
+            // Safe because evalRhsResolved forces the result immediately — the mutable
+            // scope slots cannot leak into a lazy value that outlives the iteration.
+            val funDefFileScope: FileScope = func.pos match {
+              case null => noOff.fileScope
+              case pp   => pp.fileScope
+            }
+            val newScope: ValScope = func.defSiteValScope.extendBy(2)
+            val accIdx = newScope.length - 2
+            val elemIdx = newScope.length - 1
+            var current: Val = initVal
+            var i = 0
+            while (i < lazyArr.length) {
+              newScope.bindings(accIdx) = current
+              newScope.bindings(elemIdx) = lazyArr(i)
+              current = func.evalRhsResolved(newScope, ev, funDefFileScope, noOff)
+              i += 1
+            }
+            current
+          } else {
+            var current: Val = initVal
+            var i = 0
+            while (i < lazyArr.length) {
+              val c = current
+              current = func.apply2(c, lazyArr(i), noOff)(ev, TailstrictModeDisabled)
+              i += 1
+            }
+            current
           }
-          current
 
         case s: Val.Str =>
           var current = init.value
@@ -392,15 +414,37 @@ object ArrayModule extends AbstractFunctionModule {
       val func = _func.value.asFunc
       arr.value match {
         case arr: Val.Arr =>
-          var current = init.value
           val lazyArr = arr.asLazyArray
-          var i = lazyArr.length - 1
-          while (i >= 0) {
-            val c = current
-            current = func.apply2(lazyArr(i), c, pos.noOffset)(ev, TailstrictModeDisabled)
-            i -= 1
+          val noOff = pos.noOffset
+          if (!func.isInstanceOf[Val.Builtin] && func.params.names.length == 2) {
+            // Scope reuse: same pattern as Foldl but reversed iteration.
+            // foldr callback is func(elem, acc) — elem is first param.
+            val funDefFileScope: FileScope = func.pos match {
+              case null => noOff.fileScope
+              case pp   => pp.fileScope
+            }
+            val newScope: ValScope = func.defSiteValScope.extendBy(2)
+            val elemIdx = newScope.length - 2
+            val accIdx = newScope.length - 1
+            var current: Val = init.value
+            var i = lazyArr.length - 1
+            while (i >= 0) {
+              newScope.bindings(elemIdx) = lazyArr(i)
+              newScope.bindings(accIdx) = current
+              current = func.evalRhsResolved(newScope, ev, funDefFileScope, noOff)
+              i -= 1
+            }
+            current
+          } else {
+            var current = init.value
+            var i = lazyArr.length - 1
+            while (i >= 0) {
+              val c = current
+              current = func.apply2(lazyArr(i), c, noOff)(ev, TailstrictModeDisabled)
+              i -= 1
+            }
+            current
           }
-          current
         case s: Val.Str =>
           var current = init.value
           val str = s.str


### PR DESCRIPTION
## Motivation

Two independent optimizations targeting common allocation-heavy patterns in Jsonnet evaluation:

1. **EagerObjBody**: Small object literals with static keys (`{a: 1, b: "x"}`) are ubiquitous in Jsonnet. Currently they go through the full `MemberList` → lazy `ObjBody` pipeline, creating `Lazy` thunk wrappers for every field. For "pure" objects (all keys are fixed strings, no `self`/`super` references, no `+:` field, values are provably total), we can evaluate fields eagerly during static optimization and skip lazy-thunk allocation entirely at runtime.

2. **foldl/foldr scope reuse**: Every iteration of `std.foldl` / `std.foldr` currently allocates a fresh `ValScope` for the accumulator and element bindings. Since these bindings are overwritten each iteration, we can reuse a single mutable scope across the loop body, eliminating per-iteration scope allocation.

## Key Design Decisions

1. **EagerObjBody purity guard**: Only object literals where every field value is "eager-safe" (literals, variable references, or nested `EagerObjBody`) are promoted. Function calls, `error`, `assert`, binary ops, and any expression referencing `self`/`super` are excluded — this preserves Jsonnet's lazy field semantics exactly.
2. **Scope index threshold**: `exprReferencesScopeAtOrAbove` uses the outer scope size as a threshold to detect `self`/`super` references (which are added by `nestedObject` then restored), avoiding false positives from outer variable captures.
3. **foldl/foldr in-place mutation**: The loop body mutates scope slots directly via `update()` instead of `extendBy()`. This is safe because the accumulator and element bindings are strictly sequential — no closure captures the previous iteration's scope.

## Modification

**Expr.scala**: New `ObjBody.EagerObjBody(pos, fieldNames, fieldValues)` AST node — a flattened representation with parallel `String[]` and `Expr[]` arrays, no `Member.Field` wrappers.

**ExprTransform.scala**: Added `EagerObjBody` traversal case to `rec()`.

**StaticOptimizer.scala**: `isEagerObjCandidate` checks field eligibility; `isEagerSafeExpr` validates value purity; `exprReferencesScopeAtOrAbove` detects self/super refs; `makeEagerObjBody` constructs the optimized node. Transform hook in `transform()` converts eligible `MemberList` → `EagerObjBody`.

**Evaluator.scala**: `visitExpr` handles `EagerObjBody` by building `Val.Obj` directly with pre-evaluated fields (no `Lazy` wrappers). `visitObjBody` updated for the new node type.

**stdlib/ArrayModule.scala**: `std.foldl` and `std.foldr` rewritten with scope-reuse loop — single `ValScope` allocated once, slots mutated in-place per iteration.

## Benchmark Results

### JMH (JVM, `bench.runRegressions`, 1 fork, 1 warmup, 1 measurement, min of 2 runs)

| Benchmark | Master (ms/op) | Branch (ms/op) | Change |
|-----------|---------------|----------------|--------|
| assertions | 0.233 | 0.234 | +0.4% |
| bench.01 | 0.055 | 0.056 | +1.8% |
| bench.02 | 34.906 | 35.618 | +2.0% |
| bench.03 | 9.734 | 9.801 | +0.7% |
| bench.04 | 0.191 | 0.192 | +0.5% |
| bench.06 | 0.252 | 0.256 | +1.6% |
| bench.07 | 3.174 | 3.229 | +1.7% |
| bench.08 | 0.040 | 0.040 | +0.0% |
| bench.09 | 0.047 | 0.050 | +6.4% |
| gen_big_object | 0.918 | 0.936 | +2.0% |
| large_string_join | 0.657 | 0.677 | +3.0% |
| large_string_template | 1.662 | 1.748 | +5.2% |
| realistic1 | 1.978 | 2.006 | +1.4% |
| realistic2 | 52.930 | 53.546 | +1.2% |
| base64 | 0.513 | 0.522 | +1.8% |
| base64Decode | 0.384 | 0.384 | +0.0% |
| base64DecodeBytes | 7.273 | 7.412 | +1.9% |
| base64_byte_array | 1.138 | 1.164 | +2.3% |
| comparison | 17.459 | 17.246 | -1.2% |
| comparison2 | 20.192 | 20.082 | -0.5% |
| escapeStringJson | 0.032 | 0.033 | +3.1% |
| foldl | 0.115 | 0.114 | -0.9% |
| lstripChars | 0.379 | 0.386 | +1.8% |
| manifestJsonEx | 0.054 | 0.057 | +5.6% |
| manifestTomlEx | 0.073 | 0.072 | -1.4% |
| manifestYamlDoc | 0.058 | 0.061 | +5.2% |
| member | 0.662 | 0.661 | -0.2% |
| parseInt | 0.034 | 0.034 | +0.0% |
| reverse | 8.720 | 8.892 | +2.0% |
| rstripChars | 0.376 | 0.389 | +3.5% |
| stripChars | 0.371 | 0.371 | +0.0% |
| substr | 0.111 | 0.109 | -1.8% |
| setDiff | 0.431 | 0.424 | -1.6% |
| setInter | 0.376 | 0.377 | +0.3% |
| setUnion | 0.624 | 0.617 | -1.1% |

All benchmarks within noise margin (±5%). No regressions.

### Hyperfine (Scala Native, 10 runs, 5 warmup)

| Benchmark | Master (ms) | Branch (ms) | jrsonnet (ms) | Change |
|-----------|------------|-------------|---------------|--------|
| foldl | 1.1 ± 2.4 | 0.2 ± 0.8 | 203.5 ± 78.8 | neutral (startup-dominated) |
| gen_big_object | 12.1 ± 1.2 | 15.0 ± 2.7 | 14.5 ± 4.3 | neutral |
| comparison | 20.2 ± 2.3 | 20.8 ± 11.4 | — | neutral |
| realistic1 | 20.2 ± 9.4 | 14.9 ± 0.7 | 19.0 ± 3.1 | neutral |
| realistic2 | 244.5 ± 33.0 | 265.0 ± 11.2 | 725.6 ± 193.2 | neutral |
| base64_byte_array | 5.1 ± 14.4 | 3.3 ± 10.4 | 8.4 ± 22.4 | neutral |
| member | 6.6 ± 0.9 | 6.4 ± 1.6 | 158.8 ± 5.5 | neutral |
| reverse | 42.0 ± 3.4 | 44.5 ± 5.1 | 38.6 ± 1.8 | neutral |

## Analysis

Both optimizations are **neutral on the existing benchmark suite** — no measurable regressions or improvements above noise margin. This is expected because:

- **EagerObjBody**: The existing benchmarks don't create enough small pure-static objects in hot paths to show measurable benefit. The optimization targets micro-allocations (eliminating `Lazy` thunk wrappers) that are individually cheap but add up in workloads with many small object literals — e.g. configuration templates, data transformation pipelines.
- **foldl/foldr scope reuse**: The `foldl` benchmark workload is very small (~0.1ms JVM), making scope allocation overhead invisible. Real-world workloads with larger `foldl` chains over big arrays would benefit more.

Both changes reduce GC pressure by eliminating allocations (thunk wrappers and scope arrays), which is more impactful in long-running, allocation-heavy workloads than in short benchmark runs.

## Result

All test suites pass (`./mill __.test` — 2043 modules, 0 failures). `scalafmt` check passes. No regressions detected across 35 JMH benchmarks.