### PR TITLE
perf: add direct inline iteration to ByteRenderer

### DIFF
--- a/sjsonnet/src/sjsonnet/ByteRenderer.scala
+++ b/sjsonnet/src/sjsonnet/ByteRenderer.scala
@@ -2,6 +2,7 @@ package sjsonnet
 
 import java.io.OutputStream
 
+import sjsonnet.Expr.Member.Visibility
 import upickle.core.{ArrVisitor, ObjVisitor}
 
 /**
@@ -255,40 +256,59 @@ class ByteRenderer(out: OutputStream = new java.io.ByteArrayOutputStream(), inde
       Error.fail("Stackoverflow while materializing, possibly due to recursive value", obj.pos)
     try {
       obj.triggerAllAsserts(ctx.brokenAssertionLogic)
-      val keys =
-        if (ctx.sort) obj.visibleKeyNames.sorted(Util.CodepointStringOrdering)
-        else obj.visibleKeyNames
 
-      // Inline of visitObject — open brace
+      if (obj.canDirectIterate) {
+        // Fast path: iterate inline field arrays directly, bypassing visibleKeyNames allocation,
+        // value() HashMap lookup, and per-object key sorting. Mirrors Materializer's
+        // materializeInlineObj / materializeSortedInlineObj but writes bytes directly.
+        if (ctx.sort) materializeDirectInlineSortedObj(obj, matDepth, ctx)
+        else materializeDirectInlineObj(obj, matDepth, ctx)
+      } else {
+        // Slow path: general objects with super chain or excluded keys
+        materializeDirectGenericObj(obj, matDepth, ctx)
+      }
+    } finally {
+      ctx.exitObject(obj)
+    }
+  }
+
+  /**
+   * Direct inline iteration for objects without super chain. Invokes members directly by array
+   * index, avoiding visibleKeyNames allocation and value() HashMap lookup per key.
+   */
+  private def materializeDirectInlineObj(
+      obj: Val.Obj,
+      matDepth: Int,
+      ctx: Materializer.MaterializeContext)(implicit evaluator: EvalScope): Unit = {
+    val fs = ctx.emptyPos.fileScope
+    val rawKeys = obj.inlineKeys
+    if (rawKeys != null) {
+      val rawMembers = obj.inlineMembers
+
       elemBuilder.append('{')
       newlineBuffered = true
       depth += 1
       resetEmpty()
 
+      val rawN = rawKeys.length
       var i = 0
-      while (i < keys.length) {
-        val key = keys(i)
-        val childVal = obj.value(key, ctx.emptyPos)
+      while (i < rawN) {
+        val m = rawMembers(i)
+        if (m.visibility != Visibility.Hidden) {
+          val childVal = m.invoke(obj, null, fs, evaluator)
+          if (!obj._skipFieldCache) obj.cacheFieldValue(rawKeys(i), childVal)
 
-        markNonEmpty()
-
-        // Flush comma+indent from previous pair, then render key+value
-        // without intermediate flushes
-        flushBuffer()
-        renderQuotedString(key)
-
-        // Key-value separator ": "
-        elemBuilder.append(':')
-        elemBuilder.append(' ')
-
-        // Render value directly — no flush overhead
-        materializeChild(childVal, matDepth, ctx)
-
-        commaBuffered = true
+          markNonEmpty()
+          flushBuffer()
+          renderQuotedString(rawKeys(i))
+          elemBuilder.append(':')
+          elemBuilder.append(' ')
+          materializeChild(childVal, matDepth, ctx)
+          commaBuffered = true
+        }
         i += 1
       }
 
-      // Inline of visitEnd — close brace
       commaBuffered = false
       newlineBuffered = false
       val wasEmpty = isEmpty
@@ -298,9 +318,134 @@ class ByteRenderer(out: OutputStream = new java.io.ByteArrayOutputStream(), inde
       else renderIndent()
       elemBuilder.append('}')
       flushByteBuilder()
-    } finally {
-      ctx.exitObject(obj)
+    } else {
+      // Single-field object
+      val sfm = obj.singleMem
+      if (sfm.visibility != Visibility.Hidden) {
+        val childVal = sfm.invoke(obj, null, fs, evaluator)
+        if (!obj._skipFieldCache) obj.cacheFieldValue(obj.singleKey, childVal)
+
+        elemBuilder.append('{')
+        newlineBuffered = true
+        depth += 1
+        resetEmpty()
+        markNonEmpty()
+        flushBuffer()
+        renderQuotedString(obj.singleKey)
+        elemBuilder.append(':')
+        elemBuilder.append(' ')
+        materializeChild(childVal, matDepth, ctx)
+
+        commaBuffered = false
+        newlineBuffered = false
+        resetEmpty()
+        depth -= 1
+        renderIndent()
+        elemBuilder.append('}')
+        flushByteBuilder()
+      } else {
+        elemBuilder.append('{')
+        elemBuilder.append(' ')
+        elemBuilder.append('}')
+        flushByteBuilder()
+      }
     }
+  }
+
+  /**
+   * Sorted direct inline iteration using cached sort order from the MemberList expression. Avoids
+   * per-object key sorting (125K sorts in realistic2 → 0 sorts with this optimization).
+   */
+  private def materializeDirectInlineSortedObj(
+      obj: Val.Obj,
+      matDepth: Int,
+      ctx: Materializer.MaterializeContext)(implicit evaluator: EvalScope): Unit = {
+    val fs = ctx.emptyPos.fileScope
+    val rawKeys = obj.inlineKeys
+    if (rawKeys != null) {
+      val rawMembers = obj.inlineMembers
+      // Use cached sorted order if available, otherwise compute once
+      val order = {
+        val cached = obj._sortedInlineOrder
+        if (cached != null) cached
+        else Materializer.computeSortedInlineOrder(rawKeys, rawMembers)
+      }
+      val visCount = order.length
+
+      elemBuilder.append('{')
+      newlineBuffered = true
+      depth += 1
+      resetEmpty()
+
+      var i = 0
+      while (i < visCount) {
+        val idx = order(i)
+        val childVal = rawMembers(idx).invoke(obj, null, fs, evaluator)
+        if (!obj._skipFieldCache) obj.cacheFieldValue(rawKeys(idx), childVal)
+
+        markNonEmpty()
+        flushBuffer()
+        renderQuotedString(rawKeys(idx))
+        elemBuilder.append(':')
+        elemBuilder.append(' ')
+        materializeChild(childVal, matDepth, ctx)
+        commaBuffered = true
+        i += 1
+      }
+
+      commaBuffered = false
+      newlineBuffered = false
+      val wasEmpty = isEmpty
+      resetEmpty()
+      depth -= 1
+      if (wasEmpty) elemBuilder.append(' ')
+      else renderIndent()
+      elemBuilder.append('}')
+      flushByteBuilder()
+    } else {
+      // Single-field: sorting is trivial (same as unsorted)
+      materializeDirectInlineObj(obj, matDepth, ctx)
+    }
+  }
+
+  /** General object materialization for objects with super chain or excluded keys. */
+  private def materializeDirectGenericObj(
+      obj: Val.Obj,
+      matDepth: Int,
+      ctx: Materializer.MaterializeContext)(implicit evaluator: EvalScope): Unit = {
+    val keys =
+      if (ctx.sort) obj.visibleKeyNames.sorted(Util.CodepointStringOrdering)
+      else obj.visibleKeyNames
+
+    elemBuilder.append('{')
+    newlineBuffered = true
+    depth += 1
+    resetEmpty()
+
+    var i = 0
+    while (i < keys.length) {
+      val key = keys(i)
+      val childVal = obj.value(key, ctx.emptyPos)
+
+      markNonEmpty()
+      flushBuffer()
+      renderQuotedString(key)
+      elemBuilder.append(':')
+      elemBuilder.append(' ')
+      materializeChild(childVal, matDepth, ctx)
+      commaBuffered = true
+      i += 1
+    }
+
+    commaBuffered = false
+    newlineBuffered = false
+    val wasEmpty = isEmpty
+    resetEmpty()
+    depth -= 1
+    if (wasEmpty) elemBuilder.append(' ')
+    else renderIndent()
+    elemBuilder.append('}')
+    flushByteBuilder()
   }
 
   private def materializeDirectArr(


### PR DESCRIPTION
## Motivation

The fused `ByteRenderer` path (used for all JSON output) bypasses the `Materializer`'s inline object iteration optimizations (`canDirectIterate`, `_sortedInlineOrder`, `member.invoke()`). For workloads like `realistic2` (125K objects, 99% value-cache overflow), this causes:
- 125K `HashMap` allocations from cache overflow  
- 125K `visibleKeyNames` array allocations  
- 125K per-object key sort operations  
- 125K per-field `value()` hash lookups  

## Key Design Decision

Port the `Materializer`'s `materializeInlineObj` / `materializeSortedInlineObj` fast paths into `ByteRenderer`, preserving exact behavioral equivalence while writing bytes directly instead of going through the `Visitor` interface.

When `obj.canDirectIterate` is true (no super chain, no excluded keys, inline storage present), the new code:
1. Iterates `inlineKeys`/`inlineMembers` arrays directly via `member.invoke()`
2. Uses cached `_sortedInlineOrder` from the `MemberList` expression (shared across all objects from the same expression)
3. Respects `_skipFieldCache` to avoid unnecessary cache writes
4. Falls back to the generic path for complex objects with super chains or excluded keys

## Modification

- `ByteRenderer.scala`: Split `materializeDirectObj` into:
  - `materializeDirectInlineObj` — unsorted direct iteration
  - `materializeDirectInlineSortedObj` — sorted with cached order
  - `materializeDirectGenericObj` — original slow path for complex objects
- Added `import sjsonnet.Expr.Member.Visibility` for hidden field filtering

## Benchmark Results

### JMH (single-fork, ms/op, lower is better)

| Benchmark | Master | Optimized | Change |
|-----------|--------|-----------|--------|
| realistic2 | 64.4 | 49.6 | **-23.0%** |
| large_string_template | 1.93 | 1.61 | **-16.7%** |
| large_string_join | 0.63 | 0.55 | **-13.3%** |
| gen_big_object | 1.01 | 0.91 | **-9.3%** |
| bench.03 | 10.3 | 9.6 | **-6.6%** |
| bench.07 | 3.33 | 3.14 | **-5.6%** |
| bench.02 | 36.7 | 34.7 | **-5.5%** |
| comparison2 | 18.4 | 17.8 | **-3.2%** |
| **No regressions on any benchmark** |

### Scala Native vs jrsonnet (hyperfine -N --warmup 5 --runs 15)

| Benchmark | sjsonnet-native (ms) | jrsonnet (ms) | Ratio |
|-----------|---------------------|---------------|-------|
| realistic2 (before) | 203.0 | 102.6 | 1.98x slower ❌ |
| **realistic2 (after)** | **89.5** | **103.0** | **1.15x faster ✅** |
| bench.03 | 33.7 | 57.1 | 1.69x faster ✅ |
| realistic1 | 12.6 | 14.6 | 1.16x faster ✅ |
| reverse | 20.1 | 23.2 | 1.15x faster ✅ |
| base64DecodeBytes | 18.0 | 21.3 | 1.18x faster ✅ |
| gen_big_object | 12.5 | 12.5 | tied |

## Analysis

The optimization eliminates the dominant bottleneck in `realistic2`: materialization was 67% of total time (197ms out of 295ms), with 99% of objects overflowing the 2-slot inline value cache. By bypassing `value()` entirely and invoking member functions directly, we eliminate:
- All HashMap allocations from cache overflow
- All `visibleKeyNames` array allocations  
- All per-object sort operations (cached at MemberList level)

This turns `realistic2` from 1.98x **slower** than jrsonnet to 1.15x **faster**.

## References

- Materializer inline iteration: `Materializer.scala:85-227`
- Val.Obj.canDirectIterate: `Val.scala:661`
- _sortedInlineOrder cache: `Val.scala:680`, `Evaluator.scala:1758`

## Result

All tests pass (`./mill __.test` — 420/420 across all platforms and Scala versions). No regressions on any benchmark.