### PR TITLE
perf: cache renderDouble for small integers

### DIFF
--- a/sjsonnet/src/sjsonnet/Materializer.scala
+++ b/sjsonnet/src/sjsonnet/Materializer.scala
@@ -33,10 +33,7 @@ abstract class Materializer {
       case Val.False(_)  => "false"
       case Val.Null(_)   => "null"
       case Val.Num(_, _) =>
-        val d = v.asDouble
-        val l = d.toLong
-        if (l.toDouble == d) java.lang.Long.toString(l)
-        else RenderUtils.renderDouble(d)
+        RenderUtils.renderDouble(v.asDouble)
       case _ => apply0(v, new sjsonnet.Renderer()).toString
     }
   }

--- a/sjsonnet/src/sjsonnet/Renderer.scala
+++ b/sjsonnet/src/sjsonnet/Renderer.scala
@@ -268,12 +268,18 @@ final case class MaterializeJsonRenderer(
 
 object RenderUtils {
 
+  // Pre-cached string representations of small integers (0-255)
+  private val intStrCache: Array[String] = Array.tabulate(256)(_.toString)
+
   /**
    * Custom rendering of Doubles used in rendering
    */
   def renderDouble(d: Double): String = {
-    if (d.toLong == d) d.toLong.toString
-    else if (d % 1 == 0) {
+    val l = d.toLong
+    if (l.toDouble == d) {
+      if (l >= 0 && l < 256) intStrCache(l.toInt)
+      else l.toString
+    } else if (d % 1 == 0) {
       BigDecimal(d).setScale(0, BigDecimal.RoundingMode.HALF_EVEN).toBigInt.toString()
     } else d.toString
   }


### PR DESCRIPTION
Motivation:

Reduce allocation overhead in common numeric rendering paths.

Key Design Decision:

Keep this PR focused on the `renderDouble` optimization. The original `Builtin1.apply1` / `Builtin3.apply3` specialization has already landed in current `master` via #807, so it is intentionally no longer part of this PR diff after the rebase.

Modification:

- `Materializer` delegates number stringification to `RenderUtils.renderDouble`.
- `RenderUtils.renderDouble` reuses a small integer string cache for exact integer doubles in the range `0` to `255`.

Benchmark Results:

Rebased onto latest `upstream/master` at `8b67cb1e`.

JMH, JVM harness, lower is better. Normal/noise-only rows are intentionally omitted.

| Benchmark | master ms/op | PR ms/op | Delta |
| --- | ---: | ---: | ---: |
| `realistic2` | 47.484 | 41.848 | -11.9% |

Scala Native hyperfine against latest source-built jrsonnet master `5b43fa8` (`jrsonnet 0.5.0-pre98`), lower is better:

| Benchmark | master-native | PR-native | jrsonnet-source | Result |
| --- | ---: | ---: | ---: | --- |
| `realistic2` | 82.2 +/- 1.5 ms | 85.4 +/- 6.1 ms | 143.7 +/- 4.0 ms | Native neutral/noisy vs master; PR-native is 1.68x faster than latest jrsonnet |

Analysis:

The current-master refresh leaves one clear JVM signal: `realistic2` improves by about 12% through the shared numeric rendering path. Native CLI is not a standout improvement over master on this PR, but latest jrsonnet is substantially slower on the same `realistic2` case.

Verification:

- `./mill -i __.checkFormat`
- `./mill -i 'sjsonnet.jvm[3.3.7].test'`
- `./mill -i bench.runRegressions bench/resources/cpp_suite/large_string_join.jsonnet bench/resources/cpp_suite/large_string_template.jsonnet bench/resources/cpp_suite/realistic2.jsonnet bench/resources/go_suite/parseInt.jsonnet`
- `./mill -i 'sjsonnet.native[3.3.7].nativeLink'`
- `hyperfine --warmup 10 --min-runs 50`

References:

- PR branch: `perf/cached-render-double`
- Base: `upstream/master` at `8b67cb1eeffa764f2a7298658e5473d8402a8da1`
- Head: `b21352970b5f19e8f929a259739d88e69df31627`
- Source-built jrsonnet: `5b43fa88b8c43856dd5a2daa9c5c251153c5e14d`

Result:

Ready. The PR now contains only the cached `renderDouble` work; the Builtin1/3 apply override work is already covered by #807 on `master`.
