### PR TITLE
perf: Long fast path for formatOctal and formatHexadecimal

### DIFF
--- a/sjsonnet/src/sjsonnet/Format.scala
+++ b/sjsonnet/src/sjsonnet/Format.scala
@@ -488,14 +488,6 @@ object Format {
     output.toString()
   }
 
-  // Use Long as a fast path for integer formatting to avoid BigInt allocation.
-  // Most Jsonnet integers fit in a Long; only fall back to BigDecimal for very large values.
-  private def truncateToInteger(s: Double): BigInt = {
-    val sl = s.toLong
-    if (sl.toDouble == s) BigInt(sl)
-    else BigDecimal(s).toBigInt
-  }
-
   private def formatInteger(formatted: FormatSpec, s: Double): String = {
     // Fast path: if the value fits in a Long (and isn't Long.MinValue where
     // negation overflows), avoid BigInt allocation entirely
@@ -537,35 +529,69 @@ object Format {
   }
 
   private def formatOctal(formatted: FormatSpec, s: Double): String = {
-    val i = truncateToInteger(s)
-    val negative = i.signum < 0
-    val lhs = if (negative) "-" else ""
-    val rhs = i.abs.toString(8)
-    val rhs2 = precisionPad(lhs, rhs, formatted.precision)
-    widen(
-      formatted,
-      lhs,
-      if (!formatted.alternate || rhs2(0) == '0') "" else "0",
-      rhs2,
-      numeric = true,
-      signedConversion = !negative
-    )
+    // Fast path: if the value fits in a Long, avoid BigInt allocation
+    val sl = s.toLong
+    if (sl.toDouble == s && sl != Long.MinValue) {
+      val negative = sl < 0
+      val lhs = if (negative) "-" else ""
+      val rhs = java.lang.Long.toString(if (negative) -sl else sl, 8)
+      val rhs2 = precisionPad(lhs, rhs, formatted.precision)
+      widen(
+        formatted,
+        lhs,
+        if (!formatted.alternate || rhs2.charAt(0) == '0') "" else "0",
+        rhs2,
+        numeric = true,
+        signedConversion = !negative
+      )
+    } else {
+      val i = BigDecimal(s).toBigInt
+      val negative = i.signum < 0
+      val lhs = if (negative) "-" else ""
+      val rhs = i.abs.toString(8)
+      val rhs2 = precisionPad(lhs, rhs, formatted.precision)
+      widen(
+        formatted,
+        lhs,
+        if (!formatted.alternate || rhs2.charAt(0) == '0') "" else "0",
+        rhs2,
+        numeric = true,
+        signedConversion = !negative
+      )
+    }
   }
 
   private def formatHexadecimal(formatted: FormatSpec, s: Double): String = {
-    val i = truncateToInteger(s)
-    val negative = i.signum < 0
-    val lhs = if (negative) "-" else ""
-    val rhs = i.abs.toString(16)
-    val rhs2 = precisionPad(lhs, rhs, formatted.precision)
-    widen(
-      formatted,
-      lhs,
-      if (!formatted.alternate) "" else "0x",
-      rhs2,
-      numeric = true,
-      signedConversion = !negative
-    )
+    // Fast path: if the value fits in a Long, avoid BigInt allocation
+    val sl = s.toLong
+    if (sl.toDouble == s && sl != Long.MinValue) {
+      val negative = sl < 0
+      val lhs = if (negative) "-" else ""
+      val rhs = java.lang.Long.toString(if (negative) -sl else sl, 16)
+      val rhs2 = precisionPad(lhs, rhs, formatted.precision)
+      widen(
+        formatted,
+        lhs,
+        if (!formatted.alternate) "" else "0x",
+        rhs2,
+        numeric = true,
+        signedConversion = !negative
+      )
+    } else {
+      val i = BigDecimal(s).toBigInt
+      val negative = i.signum < 0
+      val lhs = if (negative) "-" else ""
+      val rhs = i.abs.toString(16)
+      val rhs2 = precisionPad(lhs, rhs, formatted.precision)
+      widen(
+        formatted,
+        lhs,
+        if (!formatted.alternate) "" else "0x",
+        rhs2,
+        numeric = true,
+        signedConversion = !negative
+      )
+    }
   }
 
   private def precisionPad(lhs: String, rhs: String, precision: Option[Int]): String = {


### PR DESCRIPTION
## Motivation

`formatOctal` and `formatHexadecimal` always allocate `BigInt` via `truncateToInteger`, even when the value fits in a `Long`. The existing `formatInteger` already has a `Long` fast path that avoids this allocation — extending the same pattern to octal and hex formatting.

## Key Design Decision

Inline the Long-fits check (`sl.toDouble == s && sl != Long.MinValue`) directly into `formatOctal` and `formatHexadecimal`, using `java.lang.Long.toString(value, radix)` for the fast path. Fall back to `BigDecimal.toBigInt` only for values exceeding Long range.

## Modification

- `Format.scala`: Add Long fast path to `formatOctal` and `formatHexadecimal`
- `Format.scala`: Remove now-unused `truncateToInteger` helper method
- Use `rhs2.charAt(0)` instead of `rhs2(0)` for consistency (avoids Scala implicit conversion)

## Benchmark Results

### JMH (single fork, 1 iteration — directional only)

Format-heavy benchmarks are the primary beneficiaries:

| Benchmark | Master (ms/op) | This PR (ms/op) | Change |
|-----------|---------------|-----------------|--------|
| large_string_template | 1.610 | 1.646 | +2.2% (noise) |
| bench.03 | 9.809 | 9.652 | -1.6% |

The `%o` and `%x` format specifiers are less common than `%d` in typical Jsonnet, so the impact is modest but still beneficial when these paths are hit.

### Scala Native vs jrsonnet (hyperfine)

| Benchmark | sjsonnet Native (ms) | jrsonnet (ms) | Ratio |
|-----------|---------------------|---------------|-------|
| large_string_template | 17.3 | 8.0 | 2.15x (jrsonnet wins) |

Gap is primarily due to process startup overhead and overall eval speed, not format-specific.

## Analysis

This is a correctness-neutral optimization that extends an established pattern (Long fast path in `formatInteger`) to two more methods. No new code paths — the fallback to `BigDecimal.toBigInt` handles edge cases identically to the original `truncateToInteger`.

## References

- Upstream: jit branch commit [`6524d77d`](https://github.com/He-Pin/sjsonnet/commit/6524d77d)

## Result

All 420 tests pass across JVM/JS/Native × Scala 3.3.7, 2.13.18, 2.12.21.
