### PR TITLE
perf: add reference equality fast path to compareStringsByCodepoint

### DIFF
--- a/sjsonnet/src/sjsonnet/Util.scala
+++ b/sjsonnet/src/sjsonnet/Util.scala
@@ -135,6 +135,8 @@ object Util {
    * compared correctly according to their Unicode codepoint values.
    */
   def compareStringsByCodepoint(s1: String, s2: String): Int = {
+    // Fast path: same reference (e.g. interned strings, or self-comparison)
+    if (s1 eq s2) return 0
     val n1 = s1.length
     val n2 = s2.length
     var i1 = 0


### PR DESCRIPTION
When two strings are the same reference (e.g. interned strings from the Parser pool, or self-comparison in array equality checks), return 0 immediately without doing the O(n) codepoint-by-codepoint comparison.

