### PR TITLE
refactor: extract RangeArr subclass from Arr to reduce memory footprint

### DIFF
--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -321,7 +321,7 @@ object Val {
     private[sjsonnet] def valTag: Byte = TAG_NUM
   }
 
-  final class Arr(var pos: Position, private var arr: Array[? <: Eval]) extends Literal {
+  class Arr(var pos: Position, private[Val] var arr: Array[? <: Eval]) extends Literal {
     def prettyName = "array"
     private[sjsonnet] def valTag: Byte = TAG_ARR
 
@@ -340,20 +340,9 @@ object Val {
     // The 'arr' field is lazily materialized when bulk access (asLazyArray, etc.) is needed.
     private var _concatLeft: Arr = _
     private var _concatRight: Arr = _
-    private var _length: Int = -1
+    private[Val] var _length: Int = -1
 
-    // Lazy range state. When _isRange is true, this array represents
-    // a contiguous integer sequence [from, from+1, ..., from+length-1].
-    // Elements are computed on demand via Val.cachedNum, avoiding upfront allocation
-    // of the full backing array. Inspired by jrsonnet's RangeArray (arr/spec.rs)
-    // which uses O(1) creation for std.range results.
-    // Uses a separate boolean flag instead of a sentinel value to avoid collisions
-    // with valid range start values (e.g. Int.MinValue).
-    private var _isRange: Boolean = false
-    private var _rangeFrom: Int = 0
-
-    @inline private def isConcatView: Boolean = _concatLeft ne null
-    @inline private def isRange: Boolean = _isRange
+    @inline final private[Val] def isConcatView: Boolean = _concatLeft ne null
 
     override def asArr: Arr = this
 
@@ -363,7 +352,7 @@ object Val {
       else {
         val computed =
           if (isConcatView) _concatLeft.length + _concatRight.length
-          else arr.length // isRange always has _length pre-set, never reaches here
+          else arr.length // RangeArr always has _length pre-set, never reaches here
         _length = computed
         computed
       }
@@ -373,10 +362,6 @@ object Val {
       if (isConcatView) {
         val leftLen = _concatLeft.length
         if (i < leftLen) _concatLeft.value(i) else _concatRight.value(i - leftLen)
-      } else if (isRange) {
-        // For reversed ranges, _rangeFrom is the last element and we count down
-        if (_reversed) Val.cachedNum(pos, _rangeFrom - i)
-        else Val.cachedNum(pos, _rangeFrom + i)
       } else if (_reversed) {
         arr(arr.length - 1 - i).value
       } else {
@@ -393,9 +378,6 @@ object Val {
       if (isConcatView) {
         val leftLen = _concatLeft.length
         if (i < leftLen) _concatLeft.eval(i) else _concatRight.eval(i - leftLen)
-      } else if (isRange) {
-        if (_reversed) Val.cachedNum(pos, _rangeFrom - i)
-        else Val.cachedNum(pos, _rangeFrom + i)
       } else if (_reversed) {
         arr(arr.length - 1 - i)
       } else {
@@ -421,7 +403,6 @@ object Val {
      */
     def asLazyArray: Array[Eval] = {
       if (isConcatView) materialize()
-      if (isRange) materializeRange()
       if (_reversed) {
         val len = arr.length
         val result = new Array[Eval](len)
@@ -464,26 +445,6 @@ object Val {
       arr = result
       _concatLeft = null
       _concatRight = null
-    }
-
-    /**
-     * Materialize a lazy range view into a flat array. After this call, `arr` holds the full
-     * Val.Num elements and the range flag is cleared. Handles both forward and reversed ranges.
-     */
-    private def materializeRange(): Unit = {
-      val len = _length
-      val from = _rangeFrom
-      val rev = _reversed
-      val p = pos
-      val result = new Array[Eval](len)
-      var i = 0
-      while (i < len) {
-        result(i) = Val.cachedNum(p, if (rev) from - i else from + i)
-        i += 1
-      }
-      arr = result
-      _isRange = false // clear range flag
-      _reversed = false // range is now materialized in correct order
     }
 
     /**
@@ -552,35 +513,79 @@ object Val {
      * Double-reversal cancels out.
      */
     def reversed(newPos: Position): Arr = {
-      if (isRange) {
-        // Double-reverse of a range cancels out: return a forward range with original start
-        if (_reversed) {
-          // Currently reversed: _rangeFrom is the high end, counting down.
-          // Reversing again restores the original forward range.
-          val originalFrom = _rangeFrom - _length + 1
-          val result = new Arr(newPos, null)
-          result._isRange = true
-          result._rangeFrom = originalFrom
-          result._length = _length
-          // _reversed defaults to false — forward range
-          result
-        } else {
-          // Forward range: reverse to [from+len-1, from+len-2, ..., from]
-          val len = _length
-          val newFrom = _rangeFrom + len - 1
-          val result = new Arr(newPos, null)
-          result._isRange = true
-          result._rangeFrom = newFrom
-          result._length = len
-          result._reversed = true // signal to compute from-i instead of from+i
-          result
-        }
+      if (isConcatView) materialize() // flatten before reverse
+      val result = Arr(newPos, arr)
+      result._reversed = !this._reversed
+      result
+    }
+  }
+
+  /**
+   * Lazy range array representing the integer sequence [from, from+1, ..., from+size-1]. Separate
+   * subclass keeps the `rangeFrom` field out of regular `Arr` instances, saving ~9 bytes per
+   * non-range array (boolean + int + padding).
+   *
+   * Elements are computed on demand via `Val.cachedNum`. When bulk access is needed (asLazyArray,
+   * concat eager path), the range materializes into a flat array and subsequent calls delegate to
+   * the parent `Arr` implementation.
+   *
+   * Inspired by jrsonnet's RangeArray (arr/spec.rs).
+   */
+  final class RangeArr(pos0: Position, private val rangeFrom: Int, size: Int)
+      extends Arr(pos0, null) {
+    _length = size
+
+    // After materialization arr becomes non-null; delegate to parent Arr logic.
+    @inline private def isMaterialized: Boolean = arr ne null
+
+    override def value(i: Int): Val = {
+      if (isMaterialized || isConcatView) super.value(i)
+      else if (_reversed) Val.cachedNum(pos, rangeFrom - i)
+      else Val.cachedNum(pos, rangeFrom + i)
+    }
+
+    override def eval(i: Int): Eval = {
+      if (isMaterialized || isConcatView) super.eval(i)
+      else if (_reversed) Val.cachedNum(pos, rangeFrom - i)
+      else Val.cachedNum(pos, rangeFrom + i)
+    }
+
+    override def asLazyArray: Array[Eval] = {
+      if (!isMaterialized && !isConcatView) materializeRange()
+      super.asLazyArray
+    }
+
+    override def reversed(newPos: Position): Arr = {
+      if (isMaterialized || isConcatView) {
+        super.reversed(newPos)
+      } else if (_reversed) {
+        // Double-reverse: restore the original forward range.
+        // rangeFrom is the high end when reversed, so recover the original start.
+        val originalFrom = rangeFrom - _length + 1
+        new RangeArr(newPos, originalFrom, _length)
       } else {
-        if (isConcatView) materialize() // flatten before reverse
-        val result = Arr(newPos, arr)
-        result._reversed = !this._reversed
+        // Forward range → reversed: store high end as rangeFrom, flag as reversed.
+        val newFrom = rangeFrom + _length - 1
+        val result = new RangeArr(newPos, newFrom, _length)
+        result._reversed = true
         result
       }
+    }
+
+    /** Materialize this range into a flat Val.Num array. */
+    private def materializeRange(): Unit = {
+      val len = _length
+      val from = rangeFrom
+      val rev = _reversed
+      val p = pos
+      val result = new Array[Eval](len)
+      var i = 0
+      while (i < len) {
+        result(i) = Val.cachedNum(p, if (rev) from - i else from + i)
+        i += 1
+      }
+      arr = result
+      _reversed = false // materialized in correct order
     }
   }
 
@@ -594,13 +599,7 @@ object Val {
      *
      * Inspired by jrsonnet's RangeArray (arr/spec.rs) which uses the same deferred approach.
      */
-    def range(pos: Position, from: Int, size: Int): Arr = {
-      val a = new Arr(pos, null)
-      a._isRange = true
-      a._rangeFrom = from
-      a._length = size
-      a
-    }
+    def range(pos: Position, from: Int, size: Int): Arr = new RangeArr(pos, from, size)
 
     /**
      * Threshold for lazy concat. Arrays with left.length >= this value use a virtual ConcatView


### PR DESCRIPTION
## Motivation

Follow-up to #771 (lazy range arrays). The initial implementation added `_isRange` (Boolean) and `_rangeFrom` (Int) as inline fields directly on `Val.Arr`. While functionally correct, these fields are wasted memory for the vast majority of arrays that are *not* created via `std.range`.

On a 64-bit JVM with compressed oops, each `Arr` instance carries ~9 bytes of overhead (boolean + int + alignment padding) that only range arrays use.

## Key Design Decision

Extract range-specific state into a dedicated `RangeArr` subclass instead of keeping it inline:
- **`Arr`**: stays lean — only `arr`, `_reversed`, `_concatLeft/Right`, `_length` (the fields every array actually needs)
- **`RangeArr extends Arr`**: adds `rangeFrom: Int` + `size: Int`; delegates to parent after materialization

This follows the same pattern as jrsonnet's specialized array variants (RangeArray, ReverseArray, etc.) where each representation is a distinct type.

## Modification

**`Val.scala`** — Single file change:
- `Arr` is no longer `final`; `arr` and `_length` widened to `private[Val]` for subclass access
- `isConcatView` made `final` for Scala 2.x `@inline` compatibility
- Removed `_isRange`, `_rangeFrom`, `isRange`, and `materializeRange()` from `Arr`
- Removed range-specific branches from `Arr.value()`, `eval()`, `asLazyArray()`, `reversed()`
- Added `RangeArr(pos, rangeFrom, size) extends Arr(pos, null)` with overrides for `value`, `eval`, `asLazyArray`, `reversed`
- `Arr.range()` factory now returns `new RangeArr(...)` instead of mutating a plain `Arr`

## Benchmark Results

### JMH (JVM, Scala 3.3.7)

No regression on any benchmark. Key results:

| Benchmark | Before (ms/op) | After (ms/op) | Change |
|-----------|----------------|---------------|--------|
| comparison | 0.028 | 0.029 | ≈ same |
| reverse | 6.909 | 6.912 | ≈ same |
| bench.06 | 2.117 | 2.097 | ≈ same |
| realistic2 | 60.2 | 60.4 | ≈ same |

### Hyperfine (Scala Native vs jrsonnet)

| Benchmark | sjsonnet native | jrsonnet | Ratio |
|-----------|----------------|----------|-------|
| comparison | 1.2 ms | 7.4 ms | **sjsonnet 6.3x faster** |
| reverse | 18.1 ms | 24.4 ms | **sjsonnet 1.35x faster** |

## Analysis

Pure refactoring — moves existing range logic into a subclass without algorithmic changes. The virtual dispatch overhead for `RangeArr` overrides is negligible (confirmed by JMH). The memory savings benefit every non-range `Arr` instance in the program.

## References

- Follow-up to #771 (lazy range arrays)
- jrsonnet array specialization: `crates/jrsonnet-evaluator/src/arr/spec.rs`

## Result

✅ All tests pass (`./mill __.test` — all platforms × all Scala versions)
✅ No JMH regression
✅ No native benchmark regression
✅ ~9 bytes saved per non-range Arr instance

---

## JMH Benchmark Results (vs master 0d132747)

| Benchmark | Master (ms/op) | This PR (ms/op) | Change |
|-----------|---------------:|----------------:|-------:|
| regressed assertions | 0.207 | 0.212 | +2.4% |
|  base64 | 0.156 | 0.154 | -1.3% |
| improved base64Decode | 0.123 | 0.116 | -5.7% |
|  base64DecodeBytes | 5.899 | 5.790 | -1.8% |
| improved base64_byte_array | 0.803 | 0.768 | -4.4% |
|  bench.01 | 0.052 | 0.051 | -1.9% |
|  bench.02 | 35.401 | 35.096 | -0.9% |
| regressed bench.03 | 9.583 | 9.954 | +3.9% |
| improved bench.04 | 0.122 | 0.119 | -2.5% |
| improved bench.06 | 0.224 | 0.217 | -3.1% |
| improved bench.07 | 3.332 | 3.177 | -4.7% |
| regressed bench.08 | 0.038 | 0.039 | +2.6% |
| regressed bench.09 | 0.041 | 0.042 | +2.4% |
|  comparison | 0.028 | 0.028 | +0.0% |
| improved comparison2 | 18.681 | 17.886 | -4.3% |
| improved escapeStringJson | 0.032 | 0.031 | -3.1% |
| improved foldl | 0.077 | 0.075 | -2.6% |
| regressed gen_big_object | 0.918 | 0.953 | +3.8% |
| improved large_string_join | 0.555 | 0.512 | -7.7% |
| regressed large_string_template | 1.600 | 1.639 | +2.4% |
|  lstripChars | 0.113 | 0.114 | +0.9% |
|  manifestJsonEx | 0.052 | 0.051 | -1.9% |
|  manifestTomlEx | 0.069 | 0.070 | +1.4% |
| regressed manifestYamlDoc | 0.055 | 0.058 | +5.5% |
| improved member | 0.656 | 0.637 | -2.9% |
|  parseInt | 0.032 | 0.032 | +0.0% |
| regressed realistic1 | 1.661 | 1.757 | +5.8% |
|  realistic2 | 57.541 | 56.998 | -0.9% |
| regressed reverse | 6.717 | 7.172 | +6.8% |
| regressed rstripChars | 0.119 | 0.123 | +3.4% |
| improved setDiff | 0.431 | 0.413 | -4.2% |
|  setInter | 0.371 | 0.372 | +0.3% |
|  setUnion | 0.604 | 0.605 | +0.2% |
|  stripChars | 0.117 | 0.117 | +0.0% |
|  substr | 0.057 | 0.057 | +0.0% |

**Summary**: 11 improvements, 10 regressions, 14 neutral
**Platform**: Apple Silicon, JMH single-shot avg