### PR TITLE
perf: add canDirectIterate fast path to fused ByteRenderer materializer

### DIFF
--- a/sjsonnet/src/sjsonnet/ByteRenderer.scala
+++ b/sjsonnet/src/sjsonnet/ByteRenderer.scala
@@ -2,6 +2,7 @@ package sjsonnet
 
 import java.io.OutputStream
 
+import scala.inline
 import upickle.core.{ArrVisitor, ObjVisitor}
 
 /**
@@ -255,52 +256,156 @@ class ByteRenderer(out: OutputStream = new java.io.ByteArrayOutputStream(), inde
       Error.fail("Stackoverflow while materializing, possibly due to recursive value", obj.pos)
     try {
       obj.triggerAllAsserts(ctx.brokenAssertionLogic)
-      val keys =
-        if (ctx.sort) obj.visibleKeyNames.sorted(Util.CodepointStringOrdering)
-        else obj.visibleKeyNames
+      if (obj.canDirectIterate) {
+        // Fast path: inline objects (no super chain, no excludedKeys).
+        // Bypasses visibleKeyNames allocation and value() HashMap lookup per key,
+        // invoking members directly by array index.
+        if (ctx.sort) materializeDirectSortedInlineObj(obj, matDepth, ctx)
+        else materializeDirectInlineObj(obj, matDepth, ctx)
+      } else {
+        materializeDirectGenericObj(obj, matDepth, ctx)
+      }
+    } finally {
+      ctx.exitObject(obj)
+    }
+  }
 
-      // Inline of visitObject — open brace
-      elemBuilder.append('{')
-      newlineBuffered = true
-      depth += 1
-      resetEmpty()
+  /** Open an object brace and initialize depth/empty state. */
+  @inline private def openObjBrace(): Unit = {
+    elemBuilder.append('{')
+    newlineBuffered = true
+    depth += 1
+    resetEmpty()
+  }
+
+  /** Close an object brace, handling empty vs non-empty formatting. */
+  @inline private def closeObjBrace(): Unit = {
+    commaBuffered = false
+    newlineBuffered = false
+    val wasEmpty = isEmpty
+    resetEmpty()
+    depth -= 1
+    if (wasEmpty) elemBuilder.append(' ')
+    else renderIndent()
+    elemBuilder.append('}')
+    flushByteBuilder()
+  }
+
+  /** Render a single key-value pair (comma buffering assumed by caller). */
+  @inline private def renderKeyValue(
+      key: String,
+      childVal: Val,
+      matDepth: Int,
+      ctx: Materializer.MaterializeContext)(implicit evaluator: EvalScope): Unit = {
+    markNonEmpty()
+    flushBuffer()
+    renderQuotedString(key)
+    elemBuilder.append(':')
+    elemBuilder.append(' ')
+    materializeChild(childVal, matDepth, ctx)
+  }
+
+  /** Fused inline object rendering — bypasses visibleKeyNames and value() lookup. */
+  private def materializeDirectInlineObj(
+      obj: Val.Obj,
+      matDepth: Int,
+      ctx: Materializer.MaterializeContext)(implicit evaluator: EvalScope): Unit = {
+    val fs = ctx.emptyPos.fileScope
+    val rawKeys = obj.inlineKeys
+    if (rawKeys != null) {
+      val rawMembers = obj.inlineMembers
+      val rawN = rawKeys.length
+
+      openObjBrace()
 
       var i = 0
-      while (i < keys.length) {
-        val key = keys(i)
-        val childVal = obj.value(key, ctx.emptyPos)
+      while (i < rawN) {
+        val m = rawMembers(i)
+        if (m.visibility != Expr.Member.Visibility.Hidden) {
+          val childVal = m.invoke(obj, null, fs, evaluator)
+          if (!obj._skipFieldCache) obj.cacheFieldValue(rawKeys(i), childVal)
+          renderKeyValue(rawKeys(i), childVal, matDepth, ctx)
+          commaBuffered = true
+        }
+        i += 1
+      }
 
-        markNonEmpty()
-
-        // Flush comma+indent from previous pair, then render key+value
-        // without intermediate flushes
-        flushBuffer()
-        renderQuotedString(key)
-
-        // Key-value separator ": "
-        elemBuilder.append(':')
+      closeObjBrace()
+    } else {
+      // Single-field object
+      val sfm = obj.singleMem
+      if (sfm.visibility != Expr.Member.Visibility.Hidden) {
+        openObjBrace()
+        val childVal = sfm.invoke(obj, null, fs, evaluator)
+        if (!obj._skipFieldCache) obj.cacheFieldValue(obj.singleKey, childVal)
+        renderKeyValue(obj.singleKey, childVal, matDepth, ctx)
+        closeObjBrace()
+      } else {
+        // Empty object (single hidden field)
+        elemBuilder.append('{')
         elemBuilder.append(' ')
+        elemBuilder.append('}')
+        flushByteBuilder()
+      }
+    }
+  }
 
-        // Render value directly — no flush overhead
-        materializeChild(childVal, matDepth, ctx)
+  /** Fused sorted inline object rendering — uses cached sorted field order. */
+  private def materializeDirectSortedInlineObj(
+      obj: Val.Obj,
+      matDepth: Int,
+      ctx: Materializer.MaterializeContext)(implicit evaluator: EvalScope): Unit = {
+    val fs = ctx.emptyPos.fileScope
+    val rawKeys = obj.inlineKeys
+    if (rawKeys != null) {
+      val rawMembers = obj.inlineMembers
+      val order = {
+        val cached = obj._sortedInlineOrder
+        if (cached != null) cached
+        else Materializer.computeSortedInlineOrder(rawKeys, rawMembers)
+      }
+      val visCount = order.length
 
+      openObjBrace()
+
+      var i = 0
+      while (i < visCount) {
+        val idx = order(i)
+        val childVal = rawMembers(idx).invoke(obj, null, fs, evaluator)
+        if (!obj._skipFieldCache) obj.cacheFieldValue(rawKeys(idx), childVal)
+        renderKeyValue(rawKeys(idx), childVal, matDepth, ctx)
         commaBuffered = true
         i += 1
       }
 
-      // Inline of visitEnd — close brace
-      commaBuffered = false
-      newlineBuffered = false
-      val wasEmpty = isEmpty
-      resetEmpty()
-      depth -= 1
-      if (wasEmpty) elemBuilder.append(' ')
-      else renderIndent()
-      elemBuilder.append('}')
-      flushByteBuilder()
-    } finally {
-      ctx.exitObject(obj)
+      closeObjBrace()
+    } else {
+      // Single-field: sorted = unsorted
+      materializeDirectInlineObj(obj, matDepth, ctx)
     }
+  }
+
+  /** Generic object rendering — uses visibleKeyNames + value() lookup. */
+  private def materializeDirectGenericObj(
+      obj: Val.Obj,
+      matDepth: Int,
+      ctx: Materializer.MaterializeContext)(implicit evaluator: EvalScope): Unit = {
+    val keys =
+      if (ctx.sort) obj.visibleKeyNames.sorted(Util.CodepointStringOrdering)
+      else obj.visibleKeyNames
+
+    openObjBrace()
+
+    var i = 0
+    while (i < keys.length) {
+      val key = keys(i)
+      val childVal = obj.value(key, ctx.emptyPos)
+      renderKeyValue(key, childVal, matDepth, ctx)
+      commaBuffered = true
+      i += 1
+    }
+
+    closeObjBrace()
   }
 
   private def materializeDirectArr(


### PR DESCRIPTION
## Motivation

The fused ByteRenderer (`materializeDirect`) path used by Scala Native bypasses the upickle Visitor interface for direct byte-level JSON rendering. However, it was missing the `canDirectIterate` optimization already present in `Materializer.materializeRecursiveObj` — meaning every object field went through `visibleKeyNames` allocation + `value()` HashMap lookup, even for simple inline objects.

Profiling showed **realistic2 spends 99% of its time in materialization** (155ms materialize vs 1.7ms eval), processing ~125K objects and producing 28MB JSON output. This makes materializer optimization the highest-leverage target.

## Key Design Decision

Mirror the `canDirectIterate` fast path from `Materializer.scala` into `ByteRenderer.scala`, splitting `materializeDirectObj` into three specialized methods that avoid HashMap lookup for the common case of inline objects.

## Modification

Split `ByteRenderer.materializeDirectObj` into:
- **`materializeDirectInlineObj`**: Iterates raw `inlineFieldKeys`/`inlineFieldMembers` arrays directly, invoking members by index. Handles both multi-field and single-field objects.
- **`materializeDirectSortedInlineObj`**: Uses `_sortedInlineOrder` cached sort order (shared across all objects from same MemberList) for sorted output.
- **`materializeDirectGenericObj`**: Fallback to `visibleKeyNames` + `value()` for complex objects with super chains or excludedKeys.

## Benchmark Results

### JMH (JVM, Scala 3.3.7)

Baseline: master @ `0d13274`

| Benchmark | Before (ms) | After (ms) | Change |
|-----------|-------------|-----------|--------|
| **realistic2** | **57.541** | **49.391** | **-14.2%** ✅ |
| comparison2 | 18.681 | 17.606 | -5.8% ✅ |
| base64Decode | 0.123 | 0.118 | -4.1% |
| bench.02 | 35.401 | 32.904 | -7.1% |
| reverse | 6.717 | 6.883 | +2.5% (noise) |

### Scala Native (hyperfine, 15 runs, 5 warmup)

| Binary | realistic2 (ms) | Relative |
|--------|----------------|----------|
| **sjsonnet (this PR)** | **96.1 ± 2.4** | **1.00x** ✅ |
| jrsonnet (Rust) | 112.8 ± 5.5 | 1.17x slower |
| sjsonnet (master) | 171.8 ± 5.6 | 1.79x slower |

**sjsonnet now beats jrsonnet by 17% on realistic2!**

## Analysis

The `canDirectIterate` fast path eliminates:
1. **`visibleKeyNames` allocation**: No more `ArrayBuffer` → `Array` creation per object
2. **`value()` HashMap lookup**: No more key-based cache lookup per field (replaced by direct index invocation)
3. **Validation checks**: Inline fields skip the `value()` validation path

For realistic2 with 125K objects, this removes ~125K HashMap lookups and ~125K array allocations from the hot materialization loop.

## References

- Mirrors `Materializer.materializeInlineObj` / `materializeSortedInlineObj` logic
- Related profiling: `sjsonnet --debug-stats bench/resources/cpp_suite/realistic2.jsonnet`

## Result

All 420 tests pass across JVM/JS/WASM/Native × Scala 2.12/2.13/3.3.7.