### PR TITLE
perf: O(1) sort and equality for range arrays

### DIFF
--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -2058,8 +2058,10 @@ class Evaluator(
     case x: Val.Arr =>
       y match {
         case y: Val.Arr =>
+          if (x eq y) return true
           val xlen = x.length
           if (xlen != y.length) return false
+          if (x.rangeEquals(y)) return true
           // Skip shared ConcatView prefix — elements are reference-identical
           var i = x.sharedConcatPrefixLength(y)
           while (i < xlen) {

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -652,20 +652,21 @@ object Val {
      * it directly. If it is a reversed range, return the equivalent forward range in O(1). Returns
      * null if sort order is unknown and a full sort is needed.
      */
-    private[sjsonnet] def asSortedIfKnown(newPos: Position): Arr = {
-      if (isRange) {
-        if (_reversed) reversed(newPos) else this
-      } else null
+    private[sjsonnet] def asSortedIfKnown(newPos: Position): Arr = this match {
+      case _: RangeArr => if (_reversed) reversed(newPos) else this
+      case _           => null
     }
 
     /**
      * O(1) equality check for range arrays. Two ranges are equal if they describe the same integer
      * sequence (same start, length, and direction). Returns false if either array is not a range.
      */
-    private[sjsonnet] def rangeEquals(other: Arr): Boolean = {
-      isRange && other.isRange && _length == other._length &&
-      _reversed == other._reversed && _rangeFrom == other._rangeFrom
-    }
+    private[sjsonnet] def rangeEquals(other: Arr): Boolean =
+      (this, other) match {
+        case (r1: RangeArr, r2: RangeArr) =>
+          r1._length == r2._length && r1._reversed == r2._reversed && r1.rangeFrom == r2.rangeFrom
+        case _ => false
+      }
 
     /**
      * Create a reversed view of this array without copying. The returned Arr shares the same
@@ -691,7 +692,7 @@ object Val {
    *
    * Inspired by jrsonnet's RangeArray (arr/spec.rs).
    */
-  final class RangeArr(pos0: Position, private val rangeFrom: Int, size: Int)
+  final class RangeArr(pos0: Position, private[sjsonnet] val rangeFrom: Int, size: Int)
       extends Arr(pos0, null) {
     _length = size
 

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -648,6 +648,26 @@ object Val {
     }
 
     /**
+     * If this array is known to be sorted in ascending numeric order (e.g. a forward range), return
+     * it directly. If it is a reversed range, return the equivalent forward range in O(1). Returns
+     * null if sort order is unknown and a full sort is needed.
+     */
+    private[sjsonnet] def asSortedIfKnown(newPos: Position): Arr = {
+      if (isRange) {
+        if (_reversed) reversed(newPos) else this
+      } else null
+    }
+
+    /**
+     * O(1) equality check for range arrays. Two ranges are equal if they describe the same integer
+     * sequence (same start, length, and direction). Returns false if either array is not a range.
+     */
+    private[sjsonnet] def rangeEquals(other: Arr): Boolean = {
+      isRange && other.isRange && _length == other._length &&
+      _reversed == other._reversed && _rangeFrom == other._rangeFrom
+    }
+
+    /**
      * Create a reversed view of this array without copying. The returned Arr shares the same
      * backing array but flips the reversed flag, so element access is O(1) with zero allocation.
      * Double-reversal cancels out.

--- a/sjsonnet/src/sjsonnet/stdlib/SetModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/SetModule.scala
@@ -82,7 +82,21 @@ object SetModule extends AbstractFunctionModule {
     Val.Arr(pos, out.result())
   }
 
-  private def sortArr(pos: Position, ev: EvalScope, arr: Val, keyF: Val) = {
+  private def sortArr(pos: Position, ev: EvalScope, arr: Val, keyF: Val): Val = {
+    // Fast path: range arrays are already sorted ascending by construction.
+    // Avoids O(n) materialization + O(n log n) sort for already-sorted data.
+    if (keyF == null || keyF.isInstanceOf[Val.False]) {
+      arr match {
+        case a: Val.Arr =>
+          val sorted = a.asSortedIfKnown(pos)
+          if (sorted != null) return sorted
+        case _ =>
+      }
+    }
+    sortArrSlow(pos, ev, arr, keyF)
+  }
+
+  private def sortArrSlow(pos: Position, ev: EvalScope, arr: Val, keyF: Val) = {
     val vs = toArrOrString(arr, pos, ev)
     if (vs.length <= 1) {
       arr


### PR DESCRIPTION
Motivation:

Avoid materializing and sorting arrays when the evaluator already knows an array is a numeric range with deterministic order.

Key Design Decision:

Use the post-#778 `RangeArr` representation directly rather than adding a separate range flag. This keeps the optimization aligned with the current array model.

Modification:

- Add `Arr.asSortedIfKnown` for O(1) sorted range detection.
- Add `Arr.rangeEquals` for O(1) equality on range arrays.
- Fast-path `std.set` sorting when the input range is already known sorted or can be reversed to sorted order.
- Add a direct `eq` check before array structural comparison.

Benchmark Results:

JMH throughput, normalized from `ms/op` to `ops/ms` (`ops/ms = 1 / ms_per_op`; higher is better):

| Benchmark | master ms/op | PR ms/op | master ops/ms | PR ops/ms | Delta ops/ms |
| --- | ---: | ---: | ---: | ---: | ---: |
| `bench.06` | 0.216 | 0.189 | 4.63 | 5.29 | +14.3% |
| `setUnion` | 0.608 | 0.581 | 1.64 | 1.72 | +4.7% |
| `comparison` | 0.028 | 0.029 | 35.71 | 34.48 | -3.4% |

Scala Native hyperfine against source-built jrsonnet (`git@github.com:CertainLach/jrsonnet.git`, origin/master `80cd36a`; lower is better):

| Benchmark | master-native | PR-native | jrsonnet-source | Result |
| --- | ---: | ---: | ---: | --- |
| `bench.06` | 6.16 +/- 0.50 ms | 5.80 +/- 1.33 ms | 4.30 +/- 0.34 ms | PR faster than master; jrsonnet faster |
| `setUnion` | 6.07 +/- 0.52 ms | 5.94 +/- 0.86 ms | 4.18 +/- 0.39 ms | PR slightly faster than master; jrsonnet faster |

Analysis:

The core change is semantics-preserving because it only skips work for arrays whose sorted order is known from their `RangeArr` representation. JMH is positive on the intended range/set workloads, and Native hyperfine is also directionally positive though jrsonnet still has a lower startup/runtime cost on these small cases.

References:

- PR branch: `perf/jrsonnet-optimizations`
- Head: `e950edb0c362f46c8c3967f1b209e3a3d395040e`
- Inspired by jrsonnet range-array representation.
- Benchmark toolchain: `./mill --no-server bench.runRegressions`; `hyperfine --warmup 10 --min-runs 50 -N`; source-built `jrsonnet 0.5.0-pre98`

Result:

Ready. JMH is positive and Native hyperfine is non-negative on the targeted cases.
