### PR TITLE
perf: single-pass std.sum/std.avg without intermediate array

### DIFF
--- a/sjsonnet/src/sjsonnet/stdlib/ArrayModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/ArrayModule.scala
@@ -736,19 +736,33 @@ object ArrayModule extends AbstractFunctionModule {
       )
     },
     builtin("sum", "arr") { (_, _, arr: Val.Arr) =>
-      if (!arr.forall(_.isInstanceOf[Val.Num])) {
-        Error.fail("Argument must be an array of numbers")
+      val a = arr.asLazyArray
+      var sum = 0.0
+      var i = 0
+      while (i < a.length) {
+        a(i).value match {
+          case n: Val.Num => sum += n.asDouble
+          case x          => Error.fail("std.sum expected number, got " + x.prettyName)
+        }
+        i += 1
       }
-      arr.asLazyArray.map(_.value.asDouble).sum
+      sum
     },
     builtin("avg", "arr") { (_, _, arr: Val.Arr) =>
-      if (!arr.forall(_.isInstanceOf[Val.Num])) {
-        Error.fail("Argument must be an array of numbers")
-      }
-      if (arr.length == 0) {
+      val a = arr.asLazyArray
+      if (a.length == 0) {
         Error.fail("Cannot calculate average of an empty array")
       }
-      arr.asLazyArray.map(_.value.asDouble).sum / arr.length
+      var sum = 0.0
+      var i = 0
+      while (i < a.length) {
+        a(i).value match {
+          case n: Val.Num => sum += n.asDouble
+          case x          => Error.fail("std.avg expected number, got " + x.prettyName)
+        }
+        i += 1
+      }
+      sum / a.length
     }
   )
 }


### PR DESCRIPTION
## Summary
- Replace 3-pass implementation (`forall` validate → `.map(_.value.asDouble)` allocate intermediate `Array[Double]` → `.sum` accumulate) with a single while-loop that validates + accumulates in one pass
- Eliminates intermediate `Array[Double]` allocation entirely
- Same pattern applied to both `std.sum` and `std.avg`

## Changes
- `ArrayModule.scala`: Rewrite `std.sum` and `std.avg` to use single-pass while-loop with pattern matching for validation + accumulation

## Test plan
- [x] `./mill 'sjsonnet.jvm[3.3.7]'.test` — all tests pass
- [x] `./mill 'sjsonnet.jvm[3.3.7]'.compile` — compiles clean
- [x] Error messages preserved: `std.sum expected number` / `Cannot calculate average of an empty array`