### PR TITLE
perf: extend comprehension scope reuse to builtins, select, lookup

### DIFF
--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -460,6 +460,24 @@ class Evaluator(
       isNonCapturingBody(ie.cond) && isNonCapturingBody(ie.`then`) && isNonCapturingBody(
         ie.`else`
       )
+    case ExprTags.ApplyBuiltin0 => true
+    case ExprTags.ApplyBuiltin1 =>
+      isNonCapturingBody(e.asInstanceOf[ApplyBuiltin1].a1)
+    case ExprTags.ApplyBuiltin2 =>
+      val ab = e.asInstanceOf[ApplyBuiltin2]
+      isNonCapturingBody(ab.a1) && isNonCapturingBody(ab.a2)
+    case ExprTags.ApplyBuiltin3 =>
+      val ab = e.asInstanceOf[ApplyBuiltin3]
+      isNonCapturingBody(ab.a1) && isNonCapturingBody(ab.a2) && isNonCapturingBody(ab.a3)
+    case ExprTags.ApplyBuiltin4 =>
+      val ab = e.asInstanceOf[ApplyBuiltin4]
+      isNonCapturingBody(ab.a1) && isNonCapturingBody(ab.a2) &&
+      isNonCapturingBody(ab.a3) && isNonCapturingBody(ab.a4)
+    case ExprTags.Select =>
+      isNonCapturingBody(e.asInstanceOf[Select].value)
+    case ExprTags.Lookup =>
+      val l = e.asInstanceOf[Lookup]
+      isNonCapturingBody(l.value) && isNonCapturingBody(l.index)
     case _ =>
       e.isInstanceOf[Val.Literal]
   }


### PR DESCRIPTION
## Summary
- Extend `isNonCapturingBody` to recognize more expression types that produce eager values without capturing the comprehension `ValScope`
- This allows the mutable scope reuse fast path to activate for common comprehension patterns like `[std.length(x) for x in arr]` or `[x.field for x in arr]`, avoiding per-iteration `ValScope` allocation via `scope.extendSimple()` + `Arrays.copyOf`

## New expression types covered
| Expression | Check |
|------------|-------|
| `ApplyBuiltin0` | always true (no args) |
| `ApplyBuiltin1` | `isNonCapturingBody(a1)` |
| `ApplyBuiltin2` | both args non-capturing |
| `ApplyBuiltin3` | all 3 args non-capturing |
| `ApplyBuiltin4` | all 4 args non-capturing |
| `Select` | `isNonCapturingBody(value)` |
| `Lookup` | both value and index non-capturing |

## Safety argument
The mutable scope reuse path evaluates the body with `visitExpr` (eager). The returned `Val` doesn't capture the comprehension scope. Internal `visitAsLazy` calls within builtins receive non-capturing sub-expressions, so `visitAsLazy` returns eagerly via `tryEagerEval` or direct binding lookup — no `LazyExpr` creation, no stale scope capture.

**NOT extended to:** `Apply0-3` (user-defined function calls may create closures that capture scope), `Function` (creates `Val.Func` capturing scope), `ObjBody.MemberList` (creates `Val.Obj` with lazy fields capturing scope).

## Test plan
- [x] `./mill 'sjsonnet.jvm[3.3.7]'.test` — all tests pass
- [x] `./mill 'sjsonnet.jvm[3.3.7]'.compile` — compiles clean
- [x] `isInvariantExpr` (line 478+) already covers the same expression types, confirming this pattern is established