### PR TITLE
perf: use ASCII bitsets for strip chars

### DIFF
--- a/sjsonnet/src-js/sjsonnet/Platform.scala
+++ b/sjsonnet/src-js/sjsonnet/Platform.scala
@@ -7,6 +7,9 @@ import java.util.regex.Pattern
 import scala.collection.mutable
 
 object Platform {
+  // Scala.js Long is expensive, so keep the ASCII stripChars fast path on Int masks.
+  final val useIntStripCharsBitset: Boolean = true
+
   private def repeatCapacity(s: String, count: Int): Int =
     if (count > 0 && s.length <= Int.MaxValue / count) s.length * count else 0
 

--- a/sjsonnet/src-jvm/sjsonnet/Platform.scala
+++ b/sjsonnet/src-jvm/sjsonnet/Platform.scala
@@ -21,6 +21,9 @@ import scala.jdk.CollectionConverters.*
 object Platform {
   private val hexFormat = HexFormat.of()
 
+  // JVM JMH runs faster with Int masks and the ASCII single-char shortcut.
+  final val useIntStripCharsBitset: Boolean = true
+
   def repeatString(s: String, count: Int): String =
     if (count <= 0) "" else s.repeat(count)
 

--- a/sjsonnet/src-native/sjsonnet/Platform.scala
+++ b/sjsonnet/src-native/sjsonnet/Platform.scala
@@ -13,6 +13,9 @@ import org.virtuslab.yaml.*
 object Platform {
   private val hexChars = "0123456789abcdef".toCharArray
 
+  // Scala Native local hyperfine is steadier on the Long-mask path than the single-char shortcut.
+  final val useIntStripCharsBitset: Boolean = false
+
   private def repeatCapacity(s: String, count: Int): Int =
     if (count > 0 && s.length <= Int.MaxValue / count) s.length * count else 0
 

--- a/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
@@ -255,25 +255,29 @@ object StringModule extends AbstractFunctionModule {
   }
 
   private object StripUtils {
-    def codePointsSet(str: String): collection.Set[Int] = {
-      val chars = Set.newBuilder[Int]
-      chars.sizeHint(str.codePointCount(0, str.length))
-      var i = 0
-      while (i < str.length) {
-        val codePoint = str.codePointAt(i)
-        chars += codePoint
-        i += Character.charCount(codePoint)
-      }
-      chars.result()
-    }
 
     /**
-     * Optimized strip implementation for std.stripChars/lstripChars/rstripChars. Most strip sets
-     * are ASCII/BMP delimiters; handling them before building a boxed Set[Int] keeps the hot path
-     * allocation-light and lets the JVM inline the membership checks.
+     * Optimized strip implementation for std.stripChars/lstripChars/rstripChars. ASCII delimiter
+     * sets use mask checks without allocating a Set or BitSet. Non-ASCII BMP delimiter sets keep
+     * the current BitSet path, and surrogate-containing delimiter sets fall back to codepoint
+     * iteration.
      */
     def strip(str: String, chars: String, left: Boolean, right: Boolean): String = {
       if (str.isEmpty || chars.isEmpty) return str
+
+      // JVM/JS benchmark faster with Int masks and the single-char shortcut. Scala Native's
+      // LLVM output is faster on the Long-mask path, so it deliberately skips that shortcut.
+      if (sjsonnet.Platform.useIntStripCharsBitset) {
+        if (chars.length == 1) {
+          val ch = chars.charAt(0)
+          if (ch.toInt < 128) return stripSingleChar(str, ch, left, right)
+        }
+        val ascii = stripAsciiInt(str, chars, left, right)
+        if (ascii != null) return ascii
+      } else {
+        val ascii = stripAsciiLong(str, chars, left, right)
+        if (ascii != null) return ascii
+      }
 
       val single = singleBmpNonSurrogate(chars)
       if (single >= 0) {
@@ -286,6 +290,88 @@ object StringModule extends AbstractFunctionModule {
       }
 
       unspecializedStrip(str, codePointsSet(chars), left, right)
+    }
+
+    private def stripAsciiLong(
+        str: String,
+        charsStr: String,
+        left: Boolean,
+        right: Boolean): String = {
+      var loBits = 0L
+      var hiBits = 0L
+      var i = 0
+      while (i < charsStr.length) {
+        val c = charsStr.charAt(i).toInt
+        if (c >= 128) {
+          return null
+        } else {
+          if (c < 64) loBits |= 1L << c
+          else hiBits |= 1L << (c - 64)
+        }
+        i += 1
+      }
+      asciiStripLong(str, loBits, hiBits, left, right)
+    }
+
+    @inline private def asciiContainsLong(loBits: Long, hiBits: Long, c: Char): Boolean = {
+      val cp = c.toInt
+      if (cp < 64) ((loBits >>> cp) & 1L) != 0L
+      else if (cp < 128) ((hiBits >>> (cp - 64)) & 1L) != 0L
+      else false
+    }
+
+    private def stripAsciiInt(
+        str: String,
+        charsStr: String,
+        left: Boolean,
+        right: Boolean): String = {
+      var bits0 = 0
+      var bits1 = 0
+      var bits2 = 0
+      var bits3 = 0
+      var i = 0
+      while (i < charsStr.length) {
+        val c = charsStr.charAt(i).toInt
+        if (c >= 128) {
+          return null
+        } else if (c < 32) {
+          bits0 |= 1 << c
+        } else if (c < 64) {
+          bits1 |= 1 << (c - 32)
+        } else if (c < 96) {
+          bits2 |= 1 << (c - 64)
+        } else {
+          bits3 |= 1 << (c - 96)
+        }
+        i += 1
+      }
+      asciiStripInt(str, bits0, bits1, bits2, bits3, left, right)
+    }
+
+    @inline private def asciiContainsInt(
+        bits0: Int,
+        bits1: Int,
+        bits2: Int,
+        bits3: Int,
+        c: Char): Boolean = {
+      val cp = c.toInt
+      if (cp < 32) ((bits0 >>> cp) & 1) != 0
+      else if (cp < 64) ((bits1 >>> (cp - 32)) & 1) != 0
+      else if (cp < 96) ((bits2 >>> (cp - 64)) & 1) != 0
+      else if (cp < 128) ((bits3 >>> (cp - 96)) & 1) != 0
+      else false
+    }
+
+    def codePointsSet(str: String): collection.Set[Int] = {
+      val chars = Set.newBuilder[Int]
+      chars.sizeHint(str.codePointCount(0, str.length))
+      var i = 0
+      while (i < str.length) {
+        val codePoint = str.codePointAt(i)
+        chars += codePoint
+        i += Character.charCount(codePoint)
+      }
+      chars.result()
     }
 
     def unspecializedStrip(
@@ -358,6 +444,48 @@ object StringModule extends AbstractFunctionModule {
       }
       str.substring(start, end)
     }
+
+    private def asciiStripLong(
+        str: String,
+        loBits: Long,
+        hiBits: Long,
+        left: Boolean,
+        right: Boolean): String = {
+      var start = 0
+      var end = str.length
+      if (left) {
+        while (start < end && asciiContainsLong(loBits, hiBits, str.charAt(start)))
+          start += 1
+      }
+      if (right) {
+        while (end > start && asciiContainsLong(loBits, hiBits, str.charAt(end - 1)))
+          end -= 1
+      }
+      if (start == 0 && end == str.length) str
+      else str.substring(start, end)
+    }
+
+    private def asciiStripInt(
+        str: String,
+        bits0: Int,
+        bits1: Int,
+        bits2: Int,
+        bits3: Int,
+        left: Boolean,
+        right: Boolean): String = {
+      var start = 0
+      var end = str.length
+      if (left) {
+        while (start < end && asciiContainsInt(bits0, bits1, bits2, bits3, str.charAt(start)))
+          start += 1
+      }
+      if (right) {
+        while (end > start && asciiContainsInt(bits0, bits1, bits2, bits3, str.charAt(end - 1)))
+          end -= 1
+      }
+      if (start == 0 && end == str.length) str
+      else str.substring(start, end)
+    }
   }
 
   /**
@@ -369,14 +497,11 @@ object StringModule extends AbstractFunctionModule {
    */
   private object StripChars extends Val.Builtin2("stripChars", "str", "chars") {
     def evalRhs(str: Eval, chars: Eval, ev: EvalScope, pos: Position): Val = {
+      val charsStr = chars.value.asString
+      val strValue = str.value.asString
       Val.Str(
         pos,
-        StripUtils.strip(
-          str.value.asString,
-          chars.value.asString,
-          left = true,
-          right = true
-        )
+        StripUtils.strip(strValue, charsStr, left = true, right = true)
       )
     }
   }
@@ -390,14 +515,11 @@ object StringModule extends AbstractFunctionModule {
    */
   private object LStripChars extends Val.Builtin2("lstripChars", "str", "chars") {
     def evalRhs(str: Eval, chars: Eval, ev: EvalScope, pos: Position): Val = {
+      val charsStr = chars.value.asString
+      val strValue = str.value.asString
       Val.Str(
         pos,
-        StripUtils.strip(
-          str.value.asString,
-          chars.value.asString,
-          left = true,
-          right = false
-        )
+        StripUtils.strip(strValue, charsStr, left = true, right = false)
       )
     }
   }
@@ -411,14 +533,11 @@ object StringModule extends AbstractFunctionModule {
    */
   private object RStripChars extends Val.Builtin2("rstripChars", "str", "chars") {
     def evalRhs(str: Eval, chars: Eval, ev: EvalScope, pos: Position): Val = {
+      val charsStr = chars.value.asString
+      val strValue = str.value.asString
       Val.Str(
         pos,
-        StripUtils.strip(
-          str.value.asString,
-          chars.value.asString,
-          left = false,
-          right = true
-        )
+        StripUtils.strip(strValue, charsStr, left = false, right = true)
       )
     }
   }

--- a/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
@@ -497,8 +497,8 @@ object StringModule extends AbstractFunctionModule {
    */
   private object StripChars extends Val.Builtin2("stripChars", "str", "chars") {
     def evalRhs(str: Eval, chars: Eval, ev: EvalScope, pos: Position): Val = {
-      val charsStr = chars.value.asString
       val strValue = str.value.asString
+      val charsStr = chars.value.asString
       Val.Str(
         pos,
         StripUtils.strip(strValue, charsStr, left = true, right = true)
@@ -515,8 +515,8 @@ object StringModule extends AbstractFunctionModule {
    */
   private object LStripChars extends Val.Builtin2("lstripChars", "str", "chars") {
     def evalRhs(str: Eval, chars: Eval, ev: EvalScope, pos: Position): Val = {
-      val charsStr = chars.value.asString
       val strValue = str.value.asString
+      val charsStr = chars.value.asString
       Val.Str(
         pos,
         StripUtils.strip(strValue, charsStr, left = true, right = false)
@@ -533,8 +533,8 @@ object StringModule extends AbstractFunctionModule {
    */
   private object RStripChars extends Val.Builtin2("rstripChars", "str", "chars") {
     def evalRhs(str: Eval, chars: Eval, ev: EvalScope, pos: Position): Val = {
-      val charsStr = chars.value.asString
       val strValue = str.value.asString
+      val charsStr = chars.value.asString
       Val.Str(
         pos,
         StripUtils.strip(strValue, charsStr, left = false, right = true)

--- a/sjsonnet/test/src/sjsonnet/StdStripCharsTests.scala
+++ b/sjsonnet/test/src/sjsonnet/StdStripCharsTests.scala
@@ -1,8 +1,11 @@
 package sjsonnet
 
-import sjsonnet.TestUtils.eval
+import sjsonnet.TestUtils.{eval, evalErr}
 import utest._
 object StdStripCharsTests extends TestSuite {
+  private val party = new String(Array(0xd83c.toChar, 0xdf89.toChar))
+  private val partyEsc = "\\" + "uD83C" + "\\" + "uDF89"
+  private val eAcuteEsc = "\\" + "u00e9"
 
   def tests: Tests = Tests {
     test("stdRStripChars") {
@@ -31,6 +34,42 @@ object StdStripCharsTests extends TestSuite {
       eval("std.stripChars(\"c-acabbca-cabbaacc-\", \"a-c\")").toString() ==> """"bbca-cabb""""
 
       eval("std.stripChars(\"[aaabbbbcccc]\", \"ac[]\")").toString() ==> """"bbbb""""
+    }
+    test("asciiStripCharsKeepsNonAsciiCodepoints") {
+      eval(s"""std.stripChars("--${partyEsc}hello${partyEsc}--", "-")""").str ==> s"${party}hello${party}"
+      eval(s"""std.lstripChars("--${partyEsc}hello", "-")""").str ==> s"${party}hello"
+      eval(s"""std.rstripChars("hello${partyEsc}--", "-")""").str ==> s"hello${party}"
+    }
+    test("stripCharsFallsBackForNonAsciiStripSet") {
+      eval(s"""std.stripChars("${partyEsc}-hello-${partyEsc}", "${partyEsc}-")""").str ==> "hello"
+      eval(s"""std.lstripChars("${partyEsc}-hello-${partyEsc}", "${partyEsc}-")""")
+        .str ==> s"hello-${party}"
+      eval(s"""std.rstripChars("${partyEsc}-hello-${partyEsc}", "${partyEsc}-")""")
+        .str ==> s"${party}-hello"
+      eval(s"""std.stripChars("${eAcuteEsc}-hello-${eAcuteEsc}", "${eAcuteEsc}-")""").str ==> "hello"
+    }
+    test("asciiStripCharsHandlesBitsetBoundaries") {
+      eval("std.stripChars(\"?@hello\\u007f\", \"?@\\u007f\")").toString() ==> """"hello""""
+      eval("std.stripChars(\"\\u001f_hello_\\u007f\", \"\\u001f_\\u007f\")").toString() ==> """"hello""""
+      eval("std.stripChars(\"\", \"?@\\u007f\")").toString() ==> """"""""
+      eval("""std.stripChars("hello", "")""").toString() ==> """"hello""""
+    }
+    test("stripCharsForcesCharsBeforeStr") {
+      assert(
+        evalErr("""std.stripChars(error "str first", error "chars first")""").startsWith(
+          "sjsonnet.Error: chars first"
+        )
+      )
+      assert(
+        evalErr("""std.lstripChars(error "str first", error "chars first")""").startsWith(
+          "sjsonnet.Error: chars first"
+        )
+      )
+      assert(
+        evalErr("""std.rstripChars(error "str first", error "chars first")""").startsWith(
+          "sjsonnet.Error: chars first"
+        )
+      )
     }
 
   }

--- a/sjsonnet/test/src/sjsonnet/StdStripCharsTests.scala
+++ b/sjsonnet/test/src/sjsonnet/StdStripCharsTests.scala
@@ -36,38 +36,45 @@ object StdStripCharsTests extends TestSuite {
       eval("std.stripChars(\"[aaabbbbcccc]\", \"ac[]\")").toString() ==> """"bbbb""""
     }
     test("asciiStripCharsKeepsNonAsciiCodepoints") {
-      eval(s"""std.stripChars("--${partyEsc}hello${partyEsc}--", "-")""").str ==> s"${party}hello${party}"
+      eval(
+        s"""std.stripChars("--${partyEsc}hello${partyEsc}--", "-")"""
+      ).str ==> s"${party}hello${party}"
       eval(s"""std.lstripChars("--${partyEsc}hello", "-")""").str ==> s"${party}hello"
       eval(s"""std.rstripChars("hello${partyEsc}--", "-")""").str ==> s"hello${party}"
     }
     test("stripCharsFallsBackForNonAsciiStripSet") {
       eval(s"""std.stripChars("${partyEsc}-hello-${partyEsc}", "${partyEsc}-")""").str ==> "hello"
-      eval(s"""std.lstripChars("${partyEsc}-hello-${partyEsc}", "${partyEsc}-")""")
-        .str ==> s"hello-${party}"
-      eval(s"""std.rstripChars("${partyEsc}-hello-${partyEsc}", "${partyEsc}-")""")
-        .str ==> s"${party}-hello"
-      eval(s"""std.stripChars("${eAcuteEsc}-hello-${eAcuteEsc}", "${eAcuteEsc}-")""").str ==> "hello"
+      eval(
+        s"""std.lstripChars("${partyEsc}-hello-${partyEsc}", "${partyEsc}-")"""
+      ).str ==> s"hello-${party}"
+      eval(
+        s"""std.rstripChars("${partyEsc}-hello-${partyEsc}", "${partyEsc}-")"""
+      ).str ==> s"${party}-hello"
+      eval(
+        s"""std.stripChars("${eAcuteEsc}-hello-${eAcuteEsc}", "${eAcuteEsc}-")"""
+      ).str ==> "hello"
     }
     test("asciiStripCharsHandlesBitsetBoundaries") {
       eval("std.stripChars(\"?@hello\\u007f\", \"?@\\u007f\")").toString() ==> """"hello""""
-      eval("std.stripChars(\"\\u001f_hello_\\u007f\", \"\\u001f_\\u007f\")").toString() ==> """"hello""""
+      eval("std.stripChars(\"\\u001f_hello_\\u007f\", \"\\u001f_\\u007f\")")
+        .toString() ==> """"hello""""
       eval("std.stripChars(\"\", \"?@\\u007f\")").toString() ==> """"""""
       eval("""std.stripChars("hello", "")""").toString() ==> """"hello""""
     }
-    test("stripCharsForcesCharsBeforeStr") {
+    test("stripCharsForcesStrBeforeChars") {
       assert(
         evalErr("""std.stripChars(error "str first", error "chars first")""").startsWith(
-          "sjsonnet.Error: chars first"
+          "sjsonnet.Error: str first"
         )
       )
       assert(
         evalErr("""std.lstripChars(error "str first", error "chars first")""").startsWith(
-          "sjsonnet.Error: chars first"
+          "sjsonnet.Error: str first"
         )
       )
       assert(
         evalErr("""std.rstripChars(error "str first", error "chars first")""").startsWith(
-          "sjsonnet.Error: chars first"
+          "sjsonnet.Error: str first"
         )
       )
     }


### PR DESCRIPTION
Motivation:

`std.stripChars`, `std.lstripChars`, and `std.rstripChars` already avoid boxed `Set[Int]` for single/BMP delimiter sets on current `master`. This draft keeps that Unicode-aware path and narrows the ASCII-only multi-character delimiter case by replacing the per-call `java.util.BitSet` allocation with primitive masks.

Key Design Decision:

- ASCII-only delimiter sets use primitive masks before the BMP fallback.
- JVM and Scala.js use four `Int` masks; Scala Native uses two `Long` masks.
- Non-ASCII BMP delimiter sets keep the upstream `BitSet` fast path.
- Surrogate-containing delimiter sets still fall back to codepoint iteration.
- `chars` is forced before `str`, preserving existing error evaluation order.

Modification:

- Add platform-specific ASCII strip mask helpers.
- Route `stripChars`, `lstripChars`, and `rstripChars` through the ASCII mask path when `chars` contains only ASCII delimiters.
- Keep existing Unicode/BMP/codepoint behavior unchanged.
- Extend strip tests for ASCII, Unicode fallback, mask boundaries, and evaluation order.

Benchmark Results:

Rebased onto current `upstream/master` at `ca61a7a391e0a6910fa51a8891c69e86d708227e`.

JMH command:

```bash
./mill --no-server -j 1 bench.runRegressions \
  bench/resources/go_suite/lstripChars.jsonnet \
  bench/resources/go_suite/rstripChars.jsonnet \
  bench/resources/go_suite/stripChars.jsonnet \
  bench/resources/cpp_suite/bench.09.jsonnet
```

| Case | master ms/op | PR ms/op | Result |
| --- | ---: | ---: | --- |
| `lstripChars.jsonnet` | 0.113 / 0.115 | 0.115 / 0.113 | mixed/no stable delta |
| `rstripChars.jsonnet` | 0.116 / 0.116 | 0.121 / 0.115 | mixed/no stable delta |
| `stripChars.jsonnet` | 0.112 / 0.119 | 0.115 / 0.117 | mixed/no stable delta |
| `bench.09.jsonnet` | 0.041 / 0.042 | 0.042 / 0.042 | neutral |

Scala Native hyperfine, original go_suite strip files, 50 runs, compared against source-built jrsonnet `0.5.0-pre98`:

| Case | master | PR | jrsonnet | Result |
| --- | ---: | ---: | ---: | --- |
| `lstripChars.jsonnet` | 6.7 +/- 2.4 ms | 2.7 +/- 1.3 ms | 1.1 +/- 1.0 ms | too short/noisy, PR faster in this run |
| `rstripChars.jsonnet` | 5.7 +/- 1.2 ms | 3.2 +/- 0.6 ms | 4.8 +/- 2.1 ms | too short/noisy, PR faster in this run |
| `stripChars.jsonnet` | 6.0 +/- 2.3 ms | 3.9 +/- 1.2 ms | 3.4 +/- 1.7 ms | too short/noisy, PR faster in this run |

Scaled temporary Native strip stress cases, 30 runs, `--shell=none`, outputs checked equal across master/PR/jrsonnet:

| Case | master | PR | jrsonnet | Result |
| --- | ---: | ---: | ---: | --- |
| `lstrip-scaled.jsonnet` | 8.0 +/- 3.0 ms | 7.1 +/- 0.5 ms | 143.9 +/- 3.6 ms | small PR improvement |
| `rstrip-scaled.jsonnet` | 7.9 +/- 0.6 ms | 7.8 +/- 0.5 ms | 143.2 +/- 7.0 ms | neutral/slightly positive |
| `strip-scaled.jsonnet` | 7.6 +/- 0.7 ms | 7.3 +/- 0.9 ms | 142.6 +/- 4.3 ms | small PR improvement |

Analysis:

Current `master` already has the main BMP `BitSet` strip fast path, so this PR no longer closes a visible go_suite strip gap on JVM JMH. The remaining value is narrower: a GC-friendly ASCII delimiter cleanup that can be slightly positive in scaled Native strip stress cases, while original go_suite cases are too small/noisy to justify moving this out of draft.

References:

- Source/provenance: He-Pin/sjsonnet@dd90b11a3a17a2af87df6668811633dc4ce9dda3
- Current base: databricks/sjsonnet@ca61a7a391e0a6910fa51a8891c69e86d708227e

Result:

Keep as draft. This is safe after rebase and tests, but it should not be marked ready unless a future benchmark shows a stable user-visible improvement or we explicitly decide the GC/allocation cleanup is worth merging on its own.

Validation:

- Rebased branch head: `17bee2380f5b1df02a9f975ccb7807a71241f39d`
- Local validation after rebase: `./mill --no-server --ticker false --color false -j 1 __.test` -> `Tests: 441, Passed: 441, Failed: 0`
