### PR TITLE
docs: Add official stdlib comments

### DIFF
--- a/sjsonnet/src/sjsonnet/stdlib/ArrayModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/ArrayModule.scala
@@ -5,6 +5,37 @@ import sjsonnet.functions.AbstractFunctionModule
 
 import scala.collection.mutable
 
+/**
+ * Native implementations for Jsonnet standard-library entries in this module.
+ *
+ * Official Jsonnet stdlib documentation links for this module:
+ *
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-minArray std.minArray(arr, keyF, onEmpty)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-maxArray std.maxArray(arr, keyF, onEmpty)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-all std.all(arr)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-any std.any(arr)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-count std.count(arr, x)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-filter std.filter(func, arr)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-map std.map(func, arr)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-mapWithIndex std.mapWithIndex(func, arr)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-find std.find(value, arr)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-flattenArrays std.flattenArrays(arr)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-flattenDeepArray std.flattenDeepArray(value)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-reverse std.reverse(arrs)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-member std.member(arr, x)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-range std.range(from, to)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-foldl std.foldl(func, arr, init)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-foldr std.foldr(func, arr, init)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-flatMap std.flatMap(func, arr)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-filterMap std.filterMap(filter_func, map_func, arr)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-repeat std.repeat(what, count)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-makeArray std.makeArray(sz, func)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-contains std.contains(arr, elem)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-remove std.remove(arr, elem)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-removeAt std.removeAt(arr, idx)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-sum std.sum(arr)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-avg std.avg(arr)]]
+ */
 object ArrayModule extends AbstractFunctionModule {
   def name = "array"
 
@@ -19,6 +50,17 @@ object ArrayModule extends AbstractFunctionModule {
     if (isDefaultKeyF(keyF)) elem
     else keyF.asFunc.apply1(elem, pos.noOffset)(ev, TailstrictModeDisabled)
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-minArray std.minArray(arr, keyF, onEmpty)]].
+   *
+   * Since: 0.21.0. Group: Arrays.
+   *
+   * Return the minimum of all elements in arr. If keyF is provided, it is called on each element of
+   * the array and should return a comparator value, and in this case minArray will return an
+   * element with the minimum comparator value. If onEmpty is provided, and arr is empty, then
+   * minArray will return the provided onEmpty value. If onEmpty is not provided, then an empty arr
+   * will raise an error.
+   */
   private object MinArray
       extends Val.Builtin(
         "minArray",
@@ -54,6 +96,17 @@ object ArrayModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-maxArray std.maxArray(arr, keyF, onEmpty)]].
+   *
+   * Since: 0.21.0. Group: Arrays.
+   *
+   * Return the maximum of all elements in arr. If keyF is provided, it is called on each element of
+   * the array and should return a comparator value, and in this case maxArray will return an
+   * element with the maximum comparator value. If onEmpty is provided, and arr is empty, then
+   * maxArray will return the provided onEmpty value. If onEmpty is not provided, then an empty arr
+   * will raise an error.
+   */
   private object MaxArray
       extends Val.Builtin(
         "maxArray",
@@ -89,6 +142,15 @@ object ArrayModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-all std.all(arr)]].
+   *
+   * Since: 0.19.0. Group: Arrays.
+   *
+   * Return true if all elements of arr is true, false otherwise. all([]) evaluates to true.
+   *
+   * It's an error if 1) arr is not an array, or 2) arr contains non-boolean values.
+   */
   private object All extends Val.Builtin1("all", "arr") {
     def evalRhs(arr: Eval, ev: EvalScope, pos: Position): Val = {
       val a = arr.value.asArr
@@ -101,6 +163,15 @@ object ArrayModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-any std.any(arr)]].
+   *
+   * Since: 0.19.0. Group: Arrays.
+   *
+   * Return true if any element of arr is true, false otherwise. any([]) evaluates to false.
+   *
+   * It's an error if 1) arr is not an array, or 2) arr contains non-boolean values.
+   */
   private object Any extends Val.Builtin1("any", "arr") {
     def evalRhs(arr: Eval, ev: EvalScope, pos: Position): Val = {
       val a = arr.value.asArr
@@ -113,6 +184,13 @@ object ArrayModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-count std.count(arr, x)]].
+   *
+   * Since: 0.10.0. Group: Arrays.
+   *
+   * Return the number of times that x occurs in arr.
+   */
   private object Count extends Val.Builtin2("count", "arr", "x") {
     def evalRhs(arr: Eval, x: Eval, ev: EvalScope, pos: Position): Val = {
       var count = 0
@@ -121,6 +199,13 @@ object ArrayModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-filter std.filter(func, arr)]].
+   *
+   * Since: 0.10.0. Group: Arrays.
+   *
+   * Return a new array containing all the elements of arr for which the func function returns true.
+   */
   private object Filter extends Val.Builtin2("filter", "func", "arr") {
     def evalRhs(_func: Eval, arr: Eval, ev: EvalScope, pos: Position): Val = {
       val p = pos.noOffset
@@ -178,6 +263,13 @@ object ArrayModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-map std.map(func, arr)]].
+   *
+   * Since: 0.10.0. Group: Arrays.
+   *
+   * Apply the given function to every element of the array to form a new array.
+   */
   private object Map_ extends Val.Builtin2("map", "func", "arr") {
     def evalRhs(_func: Eval, arr: Eval, ev: EvalScope, pos: Position): Val = {
       val func = _func.value.asFunc
@@ -209,6 +301,15 @@ object ArrayModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-mapWithIndex std.mapWithIndex(func, arr)]].
+   *
+   * Since: 0.10.0. Group: Arrays.
+   *
+   * Similar to map above, but it also passes to the function the element's index in the array. The
+   * function func is expected to take the index as the first parameter and the element as the
+   * second.
+   */
   private object MapWithIndex extends Val.Builtin2("mapWithIndex", "func", "arr") {
     def evalRhs(_func: Eval, _arr: Eval, ev: EvalScope, pos: Position): Val = {
       val func = _func.value.asFunc
@@ -229,6 +330,13 @@ object ArrayModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-find std.find(value, arr)]].
+   *
+   * Since: 0.10.0. Group: Arrays.
+   *
+   * Returns an array that contains the indexes of all occurrences of value in arr.
+   */
   private object Find extends Val.Builtin2("find", "value", "arr") {
     def evalRhs(value: Eval, _arr: Eval, ev: EvalScope, pos: Position): Val = {
       val arr = _arr.value.asArr
@@ -246,6 +354,13 @@ object ArrayModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-flattenArrays std.flattenArrays(arr)]].
+   *
+   * Since: 0.10.0. Group: Arrays.
+   *
+   * Concatenate an array of arrays into a single array.
+   */
   private object FlattenArrays extends Val.Builtin1("flattenArrays", "arrs") {
     def evalRhs(arrs: Eval, ev: EvalScope, pos: Position): Val = {
       val out = new mutable.ArrayBuilder.ofRef[Eval]
@@ -262,6 +377,13 @@ object ArrayModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-flattenDeepArray std.flattenDeepArray(value)]].
+   *
+   * Since: 0.21.0. Group: Arrays.
+   *
+   * Concatenate an array containing values and arrays into a single flattened array.
+   */
   private object FlattenDeepArrays extends Val.Builtin1("flattenDeepArray", "value") {
     def evalRhs(value: Eval, ev: EvalScope, pos: Position): Val = {
       val value0 = value.value
@@ -286,6 +408,13 @@ object ArrayModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-reverse std.reverse(arrs)]].
+   *
+   * Since: 0.13.0. Group: Arrays.
+   *
+   * Reverses an array.
+   */
   private object Reverse extends Val.Builtin1("reverse", "arrs") {
     def evalRhs(arrs: Eval, ev: EvalScope, pos: Position): Val = {
       // Zero-copy reverse: create a reversed view sharing the same backing array.
@@ -294,6 +423,13 @@ object ArrayModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-member std.member(arr, x)]].
+   *
+   * Since: 0.15.0. Group: Arrays.
+   *
+   * Returns whether x occurs in arr. Argument arr may be an array or a string.
+   */
   private object Member extends Val.Builtin2("member", "arr", "x") {
     def evalRhs(arr: Eval, x: Eval, ev: EvalScope, pos: Position): Val = {
       Val.bool(
@@ -324,6 +460,13 @@ object ArrayModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-range std.range(from, to)]].
+   *
+   * Since: 0.10.0. Group: Arrays.
+   *
+   * Return an array of ascending numbers between the two limits, inclusively.
+   */
   private object Range extends Val.Builtin2("range", "from", "to") {
     def evalRhs(from: Eval, to: Eval, ev: EvalScope, pos: Position): Val = {
       val fromInt = from.value.asInt
@@ -473,6 +616,17 @@ object ArrayModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-foldl std.foldl(func, arr, init)]].
+   *
+   * Since: 0.10.0. Group: Arrays.
+   *
+   * Classic foldl function. Calls the function for each array element, passing the result from the
+   * previous call (or init for the first call), and the array element. Traverses the array from
+   * left to right.
+   *
+   * For example: foldl(f, [1,2,3], 0) is equivalent to f(f(f(0, 1), 2), 3).
+   */
   private object Foldl extends Val.Builtin3("foldl", "func", "arr", "init") {
     def evalRhs(_func: Eval, arr: Eval, init: Eval, ev: EvalScope, pos: Position): Val = {
       val func = _func.value.asFunc
@@ -519,6 +673,17 @@ object ArrayModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-foldr std.foldr(func, arr, init)]].
+   *
+   * Since: 0.10.0. Group: Arrays.
+   *
+   * Classic foldr function. Calls the function for each array element, passing the array element
+   * and the result from the previous call (or init for the first call). Traverses the array from
+   * right to left.
+   *
+   * For example: foldr(f, [1,2,3], 0) is equivalent to f(1, f(2, f(3, 0))).
+   */
   private object Foldr extends Val.Builtin3("foldr", "func", "arr", "init") {
     def evalRhs(_func: Eval, arr: Eval, init: Eval, ev: EvalScope, pos: Position): Val = {
       val func = _func.value.asFunc
@@ -582,6 +747,18 @@ object ArrayModule extends AbstractFunctionModule {
     builtin(Range),
     builtin(Foldl),
     builtin(Foldr),
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-flatMap std.flatMap(func, arr)]].
+     *
+     * Since: 0.10.0. Group: Arrays.
+     *
+     * Apply the given function to every element of arr to form a new array then flatten the result.
+     * The argument arr must be an array or a string. If arr is an array, function func must return
+     * an array. If arr is a string, function func must return an string.
+     *
+     * The std.flatMap function can be thought of as a generalized std.map, with each element mapped
+     * to 0, 1 or more elements.
+     */
     builtin("flatMap", "func", "arr") { (pos, ev, func: Val.Func, arr: Val) =>
       val res: Val = arr match {
         case a: Val.Arr =>
@@ -648,6 +825,13 @@ object ArrayModule extends AbstractFunctionModule {
       }
       res
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-filterMap std.filterMap(filter_func, map_func, arr)]].
+     *
+     * Since: 0.10.0. Group: Arrays.
+     *
+     * It first filters, then maps the given array, using the two functions provided.
+     */
     builtin("filterMap", "filter_func", "map_func", "arr") {
       (pos, ev, filter_func: Val.Func, map_func: Val.Func, arr: Val.Arr) =>
         val noOff = pos.noOffset
@@ -665,6 +849,13 @@ object ArrayModule extends AbstractFunctionModule {
         }
         Val.Arr(pos, b.result())
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-repeat std.repeat(what, count)]].
+     *
+     * Since: 0.15.0. Group: Arrays.
+     *
+     * Repeats an array or a string what a number of times specified by an integer count.
+     */
     builtin("repeat", "what", "count") { (pos, ev, what: Val, count: Int) =>
       if (count < 0) {
         Error.fail("makeArray requires size >= 0, got " + count)
@@ -692,6 +883,15 @@ object ArrayModule extends AbstractFunctionModule {
       }
       res
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-makeArray std.makeArray(sz, func)]].
+     *
+     * Since: 0.10.0. Group: Arrays.
+     *
+     * Create a new array of sz elements by calling func(i) to initialize each element. Func is
+     * expected to be a function that takes a single parameter, the index of the element it should
+     * initialize.
+     */
     builtin("makeArray", "sz", "func") { (pos, ev, size: Val, func: Val.Func) =>
       Val.Arr(
         pos, {
@@ -715,6 +915,13 @@ object ArrayModule extends AbstractFunctionModule {
         }
       )
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-contains std.contains(arr, elem)]].
+     *
+     * Since: 0.21.0. Group: Arrays.
+     *
+     * Return true if given elem is present in arr, false otherwise.
+     */
     builtin("contains", "arr", "elem") { (_, ev, arr: Val.Arr, elem: Val) =>
       val la = arr.asLazyArray
       var i = 0
@@ -725,6 +932,13 @@ object ArrayModule extends AbstractFunctionModule {
       }
       found
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-remove std.remove(arr, elem)]].
+     *
+     * Since: 0.21.0. Group: Arrays.
+     *
+     * Remove first occurrence of elem from arr.
+     */
     builtin("remove", "arr", "elem") { (_, ev, arr: Val.Arr, elem: Val) =>
       val la = arr.asLazyArray
       var idx = -1
@@ -742,6 +956,13 @@ object ArrayModule extends AbstractFunctionModule {
         )
       }
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-removeAt std.removeAt(arr, idx)]].
+     *
+     * Since: 0.21.0. Group: Arrays.
+     *
+     * Remove element at idx index from arr.
+     */
     builtin("removeAt", "arr", "idx") { (_, _, arr: Val.Arr, idx: Val) =>
       val removeIdx = idx match {
         case n: Val.Num =>
@@ -757,6 +978,13 @@ object ArrayModule extends AbstractFunctionModule {
         )
       }
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-sum std.sum(arr)]].
+     *
+     * Since: 0.20.0. Group: Arrays.
+     *
+     * Return sum of all element in arr.
+     */
     builtin("sum", "arr") { (_, _, arr: Val.Arr) =>
       val a = arr.asLazyArray
       var sum = 0.0
@@ -770,6 +998,13 @@ object ArrayModule extends AbstractFunctionModule {
       }
       sum
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-avg std.avg(arr)]].
+     *
+     * Since: 0.21.0. Group: Arrays.
+     *
+     * Return average of all element in arr.
+     */
     builtin("avg", "arr") { (_, _, arr: Val.Arr) =>
       val a = arr.asLazyArray
       if (a.length == 0) {

--- a/sjsonnet/src/sjsonnet/stdlib/EncodingModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/EncodingModule.scala
@@ -3,9 +3,30 @@ package sjsonnet.stdlib
 import sjsonnet._
 import sjsonnet.functions.AbstractFunctionModule
 
+/**
+ * Native implementations for Jsonnet standard-library entries in this module.
+ *
+ * Official Jsonnet stdlib documentation links for this module:
+ *
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-md5 std.md5(s)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-base64 std.base64(input)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-base64Decode std.base64Decode(str)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-base64DecodeBytes std.base64DecodeBytes(str)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-sha1 std.sha1(s)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-sha256 std.sha256(s)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-sha512 std.sha512(s)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-sha3 std.sha3(s)]]
+ */
 object EncodingModule extends AbstractFunctionModule {
   def name = "encoding"
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-md5 std.md5(s)]].
+   *
+   * Since: 0.10.0. Group: Encoding.
+   *
+   * Encodes the given value into an MD5 string.
+   */
   private object MD5 extends Val.Builtin1("md5", "s") {
     def evalRhs(s: Eval, ev: EvalScope, pos: Position): Val =
       Val.Str(pos, Platform.md5(s.value.asString))
@@ -13,6 +34,16 @@ object EncodingModule extends AbstractFunctionModule {
 
   val functions: Seq[(String, Val.Func)] = Seq(
     builtin(MD5),
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-base64 std.base64(input)]].
+     *
+     * Since: 0.10.0. Group: Encoding.
+     *
+     * Encodes the given value into a base64 string. The encoding sequence is A-Za-z0-9+/ with = to
+     * pad the output to a multiple of 4 characters. The value can be a string or an array of
+     * numbers, but the codepoints / numbers must be in the 0 to 255 range. The resulting string has
+     * no line breaks.
+     */
     builtin("base64", "input") { (pos, _, input: Val) =>
       (input match {
         case Val.Str(_, value) =>
@@ -42,6 +73,17 @@ object EncodingModule extends AbstractFunctionModule {
         case x => Error.fail("Cannot base64 encode " + x.prettyName)
       }): Val
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-base64Decode std.base64Decode(str)]].
+     *
+     * Since: 0.10.0. Group: Encoding.
+     *
+     * Deprecated, use std.base64DecodeBytes and decode the string explicitly (e.g. with
+     * std.decodeUTF8) instead.
+     *
+     * Behaves like std.base64DecodeBytes() except returns a naively encoded string instead of an
+     * array of bytes.
+     */
     builtin("base64Decode", "str") { (_, _, str: String) =>
       try {
         new String(PlatformBase64.decode(str), "UTF-8")
@@ -50,6 +92,15 @@ object EncodingModule extends AbstractFunctionModule {
           Error.fail("Invalid base64 string: " + e.getMessage)
       }
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-base64DecodeBytes std.base64DecodeBytes(str)]].
+     *
+     * Since: 0.10.0. Group: Encoding.
+     *
+     * Decodes the given base64 string into an array of bytes (number values). Currently assumes the
+     * input string has no linebreaks and is padded to a multiple of 4 (with the = character). In
+     * other words, it consumes the output of std.base64().
+     */
     builtin("base64DecodeBytes", "str") { (pos, _, str: String) =>
       try {
         Val.Arr.fromBytes(pos, PlatformBase64.decode(str))
@@ -58,15 +109,51 @@ object EncodingModule extends AbstractFunctionModule {
           Error.fail("Invalid base64 string: " + e.getMessage)
       }
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-sha1 std.sha1(s)]].
+     *
+     * Since: 0.21.0. Group: Encoding.
+     *
+     * Encodes the given value into an SHA1 string.
+     *
+     * This function is only available in Go version of jsonnet.
+     */
     builtin("sha1", "str") { (_, _, str: String) =>
       Platform.sha1(str)
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-sha256 std.sha256(s)]].
+     *
+     * Since: 0.21.0. Group: Encoding.
+     *
+     * Encodes the given value into an SHA256 string.
+     *
+     * This function is only available in Go version of jsonnet.
+     */
     builtin("sha256", "str") { (_, _, str: String) =>
       Platform.sha256(str)
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-sha512 std.sha512(s)]].
+     *
+     * Since: 0.21.0. Group: Encoding.
+     *
+     * Encodes the given value into an SHA512 string.
+     *
+     * This function is only available in Go version of jsonnet.
+     */
     builtin("sha512", "str") { (_, _, str: String) =>
       Platform.sha512(str)
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-sha3 std.sha3(s)]].
+     *
+     * Since: 0.21.0. Group: Encoding.
+     *
+     * Encodes the given value into an SHA3 string.
+     *
+     * This function is only available in Go version of jsonnet.
+     */
     builtin("sha3", "str") { (_, _, str: String) =>
       Platform.sha3(str)
     }

--- a/sjsonnet/src/sjsonnet/stdlib/ManifestModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/ManifestModule.scala
@@ -6,14 +6,50 @@ import sjsonnet.functions.AbstractFunctionModule
 import java.io.StringWriter
 import scala.collection.mutable
 
+/**
+ * Native implementations for Jsonnet standard-library entries in this module.
+ *
+ * Official Jsonnet stdlib documentation links for this module:
+ *
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-manifestJson std.manifestJson(value)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-manifestJsonMinified std.manifestJsonMinified(value)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-manifestJsonEx std.manifestJsonEx(value, indent, newline, key_val_sep)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-parseJson std.parseJson(str)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-parseYaml std.parseYaml(str)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-manifestTomlEx std.manifestTomlEx(value, indent)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-lines std.lines(arr)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-deepJoin std.deepJoin(arr)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-manifestYamlDoc std.manifestYamlDoc(value, indent_array_in_object=false, quote_keys=true)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-manifestYamlStream std.manifestYamlStream(value, indent_array_in_object=false, c_document_end=false, quote_keys=true)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-manifestIni std.manifestIni(ini)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-manifestPython std.manifestPython(v)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-manifestPythonVars std.manifestPythonVars(conf)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-manifestXmlJsonml std.manifestXmlJsonml(value)]]
+ */
 object ManifestModule extends AbstractFunctionModule {
   def name = "manifest"
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-manifestJson std.manifestJson(value)]].
+   *
+   * Since: 0.10.0. Group: Manifestation.
+   *
+   * Convert the given object to a JSON form. Under the covers, it calls std.manifestJsonEx with a
+   * 4-space indent.
+   */
   private object ManifestJson extends Val.Builtin1("manifestJson", "v") {
     def evalRhs(v: Eval, ev: EvalScope, pos: Position): Val =
       Val.Str(pos, Materializer.apply0(v.value, MaterializeJsonRenderer())(ev).toString)
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-manifestJsonMinified std.manifestJsonMinified(value)]].
+   *
+   * Since: 0.18.0. Group: Manifestation.
+   *
+   * Convert the given object to a minified JSON form. Under the covers, it calls
+   * std.manifestJsonEx.
+   */
   private object ManifestJsonMinified extends Val.Builtin1("manifestJsonMinified", "value") {
     def evalRhs(v: Eval, ev: EvalScope, pos: Position): Val =
       Val.Str(
@@ -27,6 +63,16 @@ object ManifestModule extends AbstractFunctionModule {
       )
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-manifestJsonEx std.manifestJsonEx(value, indent, newline, key_val_sep)]].
+   *
+   * Since: 0.10.0. Group: Manifestation.
+   *
+   * Convert the given object to a JSON form. indent is a string containing one or more whitespaces
+   * that are used for indentation. newline is by default \n and is inserted where a newline would
+   * normally be used to break long lines. key_val_sep is used to separate the key and value of an
+   * object field.
+   */
   private object ManifestJsonEx
       extends Val.Builtin4(
         "manifestJsonEx",
@@ -58,6 +104,13 @@ object ManifestModule extends AbstractFunctionModule {
       )
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-parseJson std.parseJson(str)]].
+   *
+   * Since: 0.13.0. Group: Parsing.
+   *
+   * Parses a JSON string.
+   */
   private object ParseJson extends Val.Builtin1("parseJson", "str") {
     def evalRhs(str: Eval, ev: EvalScope, pos: Position): Val = {
       try {
@@ -69,6 +122,18 @@ object ManifestModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-parseYaml std.parseYaml(str)]].
+   *
+   * Since: 0.18.0. Group: Parsing.
+   *
+   * Parses a YAML string. This is provided as a "best-effort" mechanism and should not be relied on
+   * to provide a fully standards compliant YAML parser. YAML is a superset of JSON, consequently
+   * "downcasting" or manifestation of YAML into JSON or Jsonnet values will only succeed when using
+   * the subset of YAML that is compatible with JSON. The parser does not support YAML documents
+   * with scalar values at the root. The root node of a YAML document must start with either a YAML
+   * sequence or map to be successfully parsed.
+   */
   private object ParseYaml extends Val.Builtin1("parseYaml", "str") {
     def evalRhs(str: Eval, ev: EvalScope, pos: Position): Val = {
       val input = str.value.asString
@@ -79,6 +144,14 @@ object ManifestModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-manifestTomlEx std.manifestTomlEx(value, indent)]].
+   *
+   * Since: 0.18.0. Group: Manifestation.
+   *
+   * Convert the given object to a TOML form. indent is a string containing one or more whitespaces
+   * that are used for indentation.
+   */
   private object ManifestTomlEx extends Val.Builtin2("manifestTomlEx", "value", "indent") {
     private def isTableArray(v: Val) = v.value match {
       case s: Val.Arr => s.length > 0 && s.asLazyArray.forall(_.isInstanceOf[Val.Obj])
@@ -167,6 +240,14 @@ object ManifestModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-lines std.lines(arr)]].
+   *
+   * Since: 0.10.0. Group: Arrays.
+   *
+   * Concatenate an array of strings into a text file with newline characters after each string.
+   * This is suitable for constructing bash scripts and the like.
+   */
   private object Lines extends Val.Builtin1("lines", "arr") {
     def evalRhs(v1: Eval, ev: EvalScope, pos: Position): Val = {
       v1.value.asArr.foreach {
@@ -190,6 +271,15 @@ object ManifestModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-deepJoin std.deepJoin(arr)]].
+   *
+   * Since: 0.10.0. Group: Arrays.
+   *
+   * Concatenate an array containing strings and arrays to form a single string. If arr is a string,
+   * it is returned unchanged. If it is an array, it is flattened and the string elements are
+   * concatenated together with no separator.
+   */
   private object DeepJoin extends Val.Builtin1("deepJoin", "arr") {
     def evalRhs(value: Eval, ev: EvalScope, pos: Position): Val = {
       val out = new StringWriter()
@@ -221,6 +311,21 @@ object ManifestModule extends AbstractFunctionModule {
     builtin("manifestToml", "value") { (pos, ev, value: Val) =>
       ManifestTomlEx.evalRhs(value, Val.Str(pos, ""), ev, pos)
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-manifestYamlDoc std.manifestYamlDoc(value, indent_array_in_object=false, quote_keys=true)]].
+     *
+     * Since: 0.10.0. Group: Manifestation.
+     *
+     * Convert the given value to a YAML form. Note that std.manifestJson could also be used for
+     * this purpose, because any JSON is also valid YAML. But this function will produce more
+     * canonical-looking YAML.
+     *
+     * The indent_array_in_object param adds additional indentation which some people may find
+     * easier to read.
+     *
+     * The quote_keys parameter controls whether YAML identifiers are always quoted or only when
+     * necessary.
+     */
     builtinWithDefaults(
       "manifestYamlDoc",
       "value" -> null,
@@ -245,6 +350,18 @@ object ManifestModule extends AbstractFunctionModule {
         )(ev)
         .toString
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-manifestYamlStream std.manifestYamlStream(value, indent_array_in_object=false, c_document_end=false, quote_keys=true)]].
+     *
+     * Since: 0.10.0. Group: Manifestation.
+     *
+     * Given an array of values, emit a YAML "stream", which is a sequence of documents separated by
+     * --- and ending with ....
+     *
+     * The indent_array_in_object and quote_keys params are the same as in manifestYamlDoc.
+     *
+     * The c_document_end param adds the optional terminating ....
+     */
     builtinWithDefaults(
       "manifestYamlStream",
       "value" -> null,
@@ -291,6 +408,15 @@ object ManifestModule extends AbstractFunctionModule {
         case _ => Error.fail("manifestYamlStream only takes arrays, got " + v.getClass)
       }
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-manifestIni std.manifestIni(ini)]].
+     *
+     * Since: 0.10.0. Group: Manifestation.
+     *
+     * Convert the given structure to a string in INI format. This allows using Jsonnet's object
+     * model to build a configuration to be consumed by an application expecting an INI file. The
+     * data is in the form of a set of sections, each containing a key/value mapping.
+     */
     builtin("manifestIni", "ini") { (pos, ev, v: Val) =>
       val materialized = Materializer(v)(ev)
       def render(x: ujson.Value) = x match {
@@ -320,15 +446,44 @@ object ManifestModule extends AbstractFunctionModule {
           )
       lines.flatMap(Seq(_, "\n")).mkString
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-manifestPython std.manifestPython(v)]].
+     *
+     * Since: 0.10.0. Group: Manifestation.
+     *
+     * Convert the given value to a JSON-like form that is compatible with Python. The chief
+     * differences are True / False / None instead of true / false / null.
+     */
     builtin("manifestPython", "v") { (pos, ev, v: Val) =>
       Materializer.apply0(v, new PythonRenderer())(ev).toString
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-manifestPythonVars std.manifestPythonVars(conf)]].
+     *
+     * Since: 0.10.0. Group: Manifestation.
+     *
+     * Convert the given object to a JSON-like form that is compatible with Python. The key
+     * difference to std.manifestPython is that the top level is represented as a list of Python
+     * global variables.
+     */
     builtin("manifestPythonVars", "conf") { (pos, ev, v: Val.Obj) =>
       // TODO remove the `toSeq` once this is fixed in scala3
       Materializer(v)(ev).obj.toSeq.map { case (k, v) =>
         k + " = " + v.transform(new PythonRenderer()).toString + "\n"
       }.mkString
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-manifestXmlJsonml std.manifestXmlJsonml(value)]].
+     *
+     * Since: 0.10.0. Group: Manifestation.
+     *
+     * Convert the given JsonML-encoded value to a string containing the XML.
+     *
+     * JsonML is designed to preserve "mixed-mode content" (i.e., textual data outside of or next to
+     * elements). This includes the whitespace needed to avoid having all the XML on one line, which
+     * is meaningful in XML. In order to have whitespace in the XML output, it must be present in
+     * the JsonML input.
+     */
     builtin("manifestXmlJsonml", "value") { (pos, ev, value: Val) =>
       import scalatags.Text.all.{value => _, _}
       def rec(v: ujson.Value): Frag = {

--- a/sjsonnet/src/sjsonnet/stdlib/MathModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/MathModule.scala
@@ -3,6 +3,46 @@ package sjsonnet.stdlib
 import sjsonnet._
 import sjsonnet.functions.AbstractFunctionModule
 
+/**
+ * Native implementations for Jsonnet standard-library entries in this module.
+ *
+ * Official Jsonnet stdlib documentation links for this module:
+ *
+ *   - [[https://jsonnet.org/ref/stdlib.html#math std.sqrt(x)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#math std.max(a, b)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#math std.min(a, b)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#math std.mod(a, b)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#math std.modulo(a, b)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-clamp std.clamp(x, minVal, maxVal)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#math std.pow(x, n)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#math std.floor(x)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#math std.round(x)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#math std.ceil(x)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#math std.abs(n)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#math std.sign(n)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#math std.sin(x)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#math std.cos(x)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#math std.tan(x)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#math std.isEven(x)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#math std.isInteger(x)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#math std.isOdd(x)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#math std.isDecimal(x)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#math std.asin(x)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#math std.acos(x)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#math std.atan(x)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#math std.atan2(y, x)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#math std.hypot(a, b)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#math std.deg2rad(x)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#math std.rad2deg(x)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#math std.log(x)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#math std.log2(x)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#math std.log10(x)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#math std.exp(x)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#math std.mantissa(x)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#math std.exponent(x)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-xor std.xor(x, y)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-xnor std.xnor(x, y)]]
+ */
 object MathModule extends AbstractFunctionModule {
   def name = "math"
 
@@ -171,15 +211,44 @@ object MathModule extends AbstractFunctionModule {
     value.isInstanceOf[Val.Num] || value.isInstanceOf[Val.Str]
 
   val functions: Seq[(String, Val.Func)] = Seq(
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#math std.sqrt(x)]].
+     *
+     * Since: 0.10.0. Group: Mathematical Utilities.
+     *
+     * The official docs list std.sqrt(x) as a mathematical function.
+     */
     builtin("sqrt", "x") { (pos, ev, x: Double) =>
       math.sqrt(x)
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#math std.max(a, b)]].
+     *
+     * Since: 0.10.0. Group: Mathematical Utilities.
+     *
+     * The official docs list std.max(a, b) as a mathematical function.
+     */
     builtin("max", "a", "b") { (pos, ev, a: Double, b: Double) =>
       math.max(a, b)
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#math std.min(a, b)]].
+     *
+     * Since: 0.10.0. Group: Mathematical Utilities.
+     *
+     * The official docs list std.min(a, b) as a mathematical function.
+     */
     builtin("min", "a", "b") { (pos, ev, a: Double, b: Double) =>
       math.min(a, b)
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#math std.mod(a, b)]].
+     *
+     * Since: 0.10.0. Group: Mathematical Utilities.
+     *
+     * std.mod(a, b) is what the % operator is desugared to. It performs modulo arithmetic for
+     * numbers, or Python-style string formatting when the left hand side is a string.
+     */
     (
       "mod",
       new Val.Builtin2("mod", "a", "b") {
@@ -191,83 +260,275 @@ object MathModule extends AbstractFunctionModule {
         }
       }
     ),
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#math std.modulo(a, b)]].
+     *
+     * Since: 0.10.0. Group: Mathematical Utilities.
+     *
+     * Performs modulo arithmetic for numeric values.
+     */
     builtin("modulo", "a", "b") { (pos, ev, a: Double, b: Double) =>
       a % b
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-clamp std.clamp(x, minVal, maxVal)]].
+     *
+     * Since: 0.15.0. Group: Mathematical Utilities.
+     *
+     * Clamp a value to fit within the range [minVal, maxVal]. Equivalent to std.max(minVal,
+     * std.min(x, maxVal)).
+     */
     builtin(Clamp),
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#math std.pow(x, n)]].
+     *
+     * Since: 0.10.0. Group: Mathematical Utilities.
+     *
+     * The official docs list std.pow(x, n) as a mathematical function.
+     */
     builtin("pow", "x", "n") { (pos, ev, x: Double, n: Double) =>
       math.pow(x, n)
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#math std.floor(x)]].
+     *
+     * Since: 0.10.0. Group: Mathematical Utilities.
+     *
+     * The official docs list std.floor(x) as a mathematical function.
+     */
     builtin("floor", "x") { (pos, ev, x: Double) =>
       math.floor(x)
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#math std.round(x)]].
+     *
+     * Since: 0.20.0. Group: Mathematical Utilities.
+     *
+     * The official docs list std.round(x) as a mathematical function.
+     */
     builtin("round", "x") { (pos, ev, x: Double) =>
       math.round(x)
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#math std.ceil(x)]].
+     *
+     * Since: 0.10.0. Group: Mathematical Utilities.
+     *
+     * The official docs list std.ceil(x) as a mathematical function.
+     */
     builtin("ceil", "x") { (pos, ev, x: Double) =>
       math.ceil(x)
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#math std.abs(n)]].
+     *
+     * Since: 0.10.0. Group: Mathematical Utilities.
+     *
+     * The official docs list std.abs(n) as a mathematical function.
+     */
     builtin("abs", "n") { (pos, ev, x: Double) =>
       math.abs(x)
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#math std.sign(n)]].
+     *
+     * Since: 0.10.0. Group: Mathematical Utilities.
+     *
+     * The official docs list std.sign(n) as a mathematical function.
+     */
     builtin("sign", "n") { (_, _, x: Double) =>
       if (x > 0) 1 else if (x < 0) -1 else 0
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#math std.sin(x)]].
+     *
+     * Since: 0.10.0. Group: Mathematical Utilities.
+     *
+     * The official docs list std.sin(x) as a mathematical function.
+     */
     builtin("sin", "x") { (pos, ev, x: Double) =>
       math.sin(x)
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#math std.cos(x)]].
+     *
+     * Since: 0.10.0. Group: Mathematical Utilities.
+     *
+     * The official docs list std.cos(x) as a mathematical function.
+     */
     builtin("cos", "x") { (pos, ev, x: Double) =>
       math.cos(x)
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#math std.tan(x)]].
+     *
+     * Since: 0.10.0. Group: Mathematical Utilities.
+     *
+     * The official docs list std.tan(x) as a mathematical function.
+     */
     builtin("tan", "x") { (pos, ev, x: Double) =>
       math.tan(x)
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#math std.isEven(x)]].
+     *
+     * Since: 0.21.0. Group: Mathematical Utilities.
+     *
+     * The official docs list std.isEven(x) as a mathematical function; it uses the integral part of
+     * a floating number to test for even or odd.
+     */
     builtin("isEven", "x") { (_, _, x: Double) =>
       math.round(x) % 2 == 0
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#math std.isInteger(x)]].
+     *
+     * Since: 0.21.0. Group: Mathematical Utilities.
+     *
+     * The official docs list std.isInteger(x) as a mathematical function.
+     */
     builtin("isInteger", "x") { (_, _, x: Double) =>
       math.round(x).toDouble == x
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#math std.isOdd(x)]].
+     *
+     * Since: 0.21.0. Group: Mathematical Utilities.
+     *
+     * The official docs list std.isOdd(x) as a mathematical function; it uses the integral part of
+     * a floating number to test for even or odd.
+     */
     builtin("isOdd", "x") { (_, _, x: Double) =>
       math.round(x) % 2 != 0
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#math std.isDecimal(x)]].
+     *
+     * Since: 0.21.0. Group: Mathematical Utilities.
+     *
+     * The official docs list std.isDecimal(x) as a mathematical function.
+     */
     builtin("isDecimal", "x") { (_, _, x: Double) =>
       math.round(x).toDouble != x
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#math std.asin(x)]].
+     *
+     * Since: 0.10.0. Group: Mathematical Utilities.
+     *
+     * The official docs list std.asin(x) as a mathematical function.
+     */
     builtin("asin", "x") { (pos, ev, x: Double) =>
       math.asin(x)
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#math std.acos(x)]].
+     *
+     * Since: 0.10.0. Group: Mathematical Utilities.
+     *
+     * The official docs list std.acos(x) as a mathematical function.
+     */
     builtin("acos", "x") { (pos, ev, x: Double) =>
       math.acos(x)
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#math std.atan(x)]].
+     *
+     * Since: 0.10.0. Group: Mathematical Utilities.
+     *
+     * The official docs list std.atan(x) as a mathematical function.
+     */
     builtin("atan", "x") { (pos, ev, x: Double) =>
       math.atan(x)
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#math std.atan2(y, x)]].
+     *
+     * Since: 0.21.0. Group: Mathematical Utilities.
+     *
+     * The official docs list std.atan2(y, x) as a mathematical function.
+     */
     builtin("atan2", "x", "y") { (pos, ev, x: Double, y: Double) =>
       math.atan2(x, y)
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#math std.hypot(a, b)]].
+     *
+     * Since: 0.21.0. Group: Mathematical Utilities.
+     *
+     * The official docs list std.hypot(a, b) as a mathematical function.
+     */
     builtin("hypot", "x", "y") { (pos, ev, x: Double, y: Double) =>
       math.hypot(x, y)
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#math std.deg2rad(x)]].
+     *
+     * Since: 0.21.0. Group: Mathematical Utilities.
+     *
+     * The official docs list std.deg2rad(x) as a mathematical function.
+     */
     builtin("deg2rad", "x") { (pos, ev, x: Double) =>
       math.toRadians(x)
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#math std.rad2deg(x)]].
+     *
+     * Since: 0.21.0. Group: Mathematical Utilities.
+     *
+     * The official docs list std.rad2deg(x) as a mathematical function.
+     */
     builtin("rad2deg", "x") { (pos, ev, x: Double) =>
       math.toDegrees(x)
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#math std.log(x)]].
+     *
+     * Since: 0.10.0. Group: Mathematical Utilities.
+     *
+     * The official docs list std.log(x) as a mathematical function.
+     */
     builtin("log", "x") { (pos, ev, x: Double) =>
       math.log(x)
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#math std.log2(x)]].
+     *
+     * Since: 0.21.0. Group: Mathematical Utilities.
+     *
+     * The official docs list std.log2(x) as a mathematical function.
+     */
     builtin("log2", "x") { (pos, ev, x: Double) =>
       // no scala log2, do our best without getting fancy with numerics
       math.log(x) / math.log(2.0)
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#math std.log10(x)]].
+     *
+     * Since: 0.21.0. Group: Mathematical Utilities.
+     *
+     * The official docs list std.log10(x) as a mathematical function.
+     */
     builtin("log10", "x") { (pos, ev, x: Double) =>
       math.log10(x)
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#math std.exp(x)]].
+     *
+     * Since: 0.10.0. Group: Mathematical Utilities.
+     *
+     * The official docs list std.exp(x) as a mathematical function.
+     */
     builtin("exp", "x") { (pos, ev, x: Double) =>
       math.exp(x)
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#math std.mantissa(x)]].
+     *
+     * Since: 0.10.0. Group: Mathematical Utilities.
+     *
+     * The official docs list std.mantissa(x) as a mathematical function.
+     */
     builtin("mantissa", "x") { (pos, ev, x: Double) =>
       if (x == 0) 0
       else {
@@ -275,15 +536,36 @@ object MathModule extends AbstractFunctionModule {
         x * Math.pow(2.0, (-exponent).toDouble)
       }
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#math std.exponent(x)]].
+     *
+     * Since: 0.10.0. Group: Mathematical Utilities.
+     *
+     * The official docs list std.exponent(x) as a mathematical function.
+     */
     builtin("exponent", "x") { (pos, ev, x: Double) =>
       if (x == 0) 0L
       else {
         Math.floor((Math.log(Math.abs(x)) / Math.log(2)) + 1).toLong
       }
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-xor std.xor(x, y)]].
+     *
+     * Since: 0.20.0. Group: Booleans.
+     *
+     * Returns the xor of the two given booleans.
+     */
     builtin("xor", "bool1", "bool2") { (_, _, bool1: Boolean, bool2: Boolean) =>
       bool1 ^ bool2
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-xnor std.xnor(x, y)]].
+     *
+     * Since: 0.20.0. Group: Booleans.
+     *
+     * Returns the xnor of the two given booleans.
+     */
     builtin("xnor", "bool1", "bool2") { (_, _, bool1: Boolean, bool2: Boolean) =>
       !(bool1 ^ bool2)
     }

--- a/sjsonnet/src/sjsonnet/stdlib/ObjectModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/ObjectModule.scala
@@ -4,9 +4,37 @@ import sjsonnet._
 import sjsonnet.Expr.Member.Visibility
 import sjsonnet.functions.AbstractFunctionModule
 
+/**
+ * Native implementations for Jsonnet standard-library entries in this module.
+ *
+ * Official Jsonnet stdlib documentation links for this module:
+ *
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-objectHas std.objectHas(o, f)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-objectHasAll std.objectHasAll(o, f)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-objectFields std.objectFields(o)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-objectFieldsAll std.objectFieldsAll(o)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-objectValues std.objectValues(o)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-objectValuesAll std.objectValuesAll(o)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-get std.get(o, f, default=null, inc_hidden=true)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-mapWithKey std.mapWithKey(func, obj)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-objectKeysValues std.objectKeysValues(o)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-objectKeysValuesAll std.objectKeysValuesAll(o)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-objectRemoveKey std.objectRemoveKey(obj, key)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-mergePatch std.mergePatch(target, patch)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-prune std.prune(a)]]
+ */
 object ObjectModule extends AbstractFunctionModule {
   def name = "object"
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-objectHas std.objectHas(o, f)]].
+   *
+   * Since: 0.10.0. Group: Objects.
+   *
+   * Returns true if the given object has the field (given as a string), otherwise false. Raises an
+   * error if the arguments are not object and string respectively. Returns false if the field is
+   * hidden.
+   */
   private object ObjectHas extends Val.Builtin2("objectHas", "o", "f") {
     def evalRhs(o: Eval, f: Eval, ev: EvalScope, pos: Position): Val =
       Val.bool(o.value.asObj.containsVisibleKey(f.value.asString))
@@ -21,6 +49,13 @@ object ObjectModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-objectHasAll std.objectHasAll(o, f)]].
+   *
+   * Since: 0.10.0. Group: Objects.
+   *
+   * As std.objectHas but also includes hidden fields.
+   */
   private object ObjectHasAll extends Val.Builtin2("objectHasAll", "o", "f") {
     def evalRhs(o: Eval, f: Eval, ev: EvalScope, pos: Position): Val =
       Val.bool(o.value.asObj.containsKey(f.value.asString))
@@ -35,6 +70,14 @@ object ObjectModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-objectFields std.objectFields(o)]].
+   *
+   * Since: 0.10.0. Group: Objects.
+   *
+   * Returns an array of strings, each element being a field from the given object. Does not include
+   * hidden fields.
+   */
   private object ObjectFields extends Val.Builtin1("objectFields", "o") {
     def evalRhs(o: Eval, ev: EvalScope, pos: Position): Val = {
       val keys = getVisibleKeys(ev, o.value.asObj)
@@ -48,6 +91,13 @@ object ObjectModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-objectFieldsAll std.objectFieldsAll(o)]].
+   *
+   * Since: 0.10.0. Group: Objects.
+   *
+   * As std.objectFields but also includes hidden fields.
+   */
   private object ObjectFieldsAll extends Val.Builtin1("objectFieldsAll", "o") {
     def evalRhs(o: Eval, ev: EvalScope, pos: Position): Val = {
       val keys = getAllKeys(ev, o.value.asObj)
@@ -76,6 +126,13 @@ object ObjectModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-objectValues std.objectValues(o)]].
+   *
+   * Since: 0.17.0. Group: Objects.
+   *
+   * Returns an array of the values in the given object. Does not include hidden fields.
+   */
   private object ObjectValues extends Val.Builtin1("objectValues", "o") {
     def evalRhs(_o: Eval, ev: EvalScope, pos: Position): Val = {
       val o = _o.value.asObj
@@ -84,6 +141,13 @@ object ObjectModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-objectValuesAll std.objectValuesAll(o)]].
+   *
+   * Since: 0.17.0. Group: Objects.
+   *
+   * As std.objectValues but also includes hidden fields.
+   */
   private object ObjectValuesAll extends Val.Builtin1("objectValuesAll", "o") {
     def evalRhs(_o: Eval, ev: EvalScope, pos: Position): Val = {
       val o = _o.value.asObj
@@ -92,6 +156,14 @@ object ObjectModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-get std.get(o, f, default=null, inc_hidden=true)]].
+   *
+   * Since: 0.18.0. Group: Objects.
+   *
+   * Returns the object's field if it exists or default value otherwise. inc_hidden controls whether
+   * to include hidden fields.
+   */
   private object Get
       extends Val.Builtin(
         "get",
@@ -112,6 +184,15 @@ object ObjectModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-mapWithKey std.mapWithKey(func, obj)]].
+   *
+   * Since: 0.10.0. Group: Objects.
+   *
+   * Apply the given function to all fields of the given object, also passing the field name. The
+   * function func is expected to take the field name as the first parameter and the field value as
+   * the second.
+   */
   private object MapWithKey extends Val.Builtin2("mapWithKey", "func", "obj") {
     def evalRhs(_func: Eval, _obj: Eval, ev: EvalScope, pos: Position): Val = {
       val func = _func.value.asFunc
@@ -212,6 +293,14 @@ object ObjectModule extends AbstractFunctionModule {
     builtin(ObjectValuesAll),
     builtin(Get),
     builtin(MapWithKey),
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-objectKeysValues std.objectKeysValues(o)]].
+     *
+     * Since: 0.20.0. Group: Objects.
+     *
+     * Returns an array of objects from the given object, each object having two fields: key
+     * (string) and value (object). Does not include hidden fields.
+     */
     builtin("objectKeysValues", "o") { (pos, ev, o: Val.Obj) =>
       val keys = getVisibleKeys(ev, o)
       val noOffsetPos = pos.fileScope.noOffsetPos
@@ -232,6 +321,13 @@ object ObjectModule extends AbstractFunctionModule {
       }
       Val.Arr(pos, result)
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-objectKeysValuesAll std.objectKeysValuesAll(o)]].
+     *
+     * Since: 0.20.0. Group: Objects.
+     *
+     * As std.objectKeysValues but also includes hidden fields.
+     */
     builtin("objectKeysValuesAll", "o") { (pos, ev, o: Val.Obj) =>
       val keys = getAllKeys(ev, o)
       val noOffsetPos = pos.fileScope.noOffsetPos
@@ -252,9 +348,23 @@ object ObjectModule extends AbstractFunctionModule {
       }
       Val.Arr(pos, result)
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-objectRemoveKey std.objectRemoveKey(obj, key)]].
+     *
+     * Since: 0.21.0. Group: Objects.
+     *
+     * Returns a new object after removing the given key from object.
+     */
     builtin("objectRemoveKey", "obj", "key") { (pos, ev, o: Val.Obj, key: String) =>
       o.removeKeys(pos, key)
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-mergePatch std.mergePatch(target, patch)]].
+     *
+     * Since: 0.10.0. Group: JSON Merge Patch.
+     *
+     * Applies patch to target according to RFC7396
+     */
     builtin("mergePatch", "target", "patch") { (pos, ev, target: Val, patch: Val) =>
       val mergePosition = pos
       def createLazyMember(v: => Val) =
@@ -378,6 +488,14 @@ object ObjectModule extends AbstractFunctionModule {
       }
       recPair(target.value, patch.value)
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-prune std.prune(a)]].
+     *
+     * Since: 0.10.0. Group: Types and Reflection.
+     *
+     * Recursively remove all "empty" members of a. "Empty" is defined as zero length `arrays`, zero
+     * length `objects`, or `null` values. The argument a may have any type.
+     */
     builtin("prune", "a") { (pos, ev, s: Val) =>
       def filter(x: Val) = x match {
         case c: Val.Arr if c.length == 0                 => false

--- a/sjsonnet/src/sjsonnet/stdlib/SetModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/SetModule.scala
@@ -6,6 +6,20 @@ import sjsonnet.functions.AbstractFunctionModule
 import scala.collection.mutable
 import scala.collection.Searching.*
 
+/**
+ * Native implementations for Jsonnet standard-library entries in this module.
+ *
+ * Official Jsonnet stdlib documentation links for this module:
+ *
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-set std.set(arr, keyF=id)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-slice std.slice(indexable, index, end, step)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-uniq std.uniq(arr, keyF=id)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-sort std.sort(arr, keyF=id)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-setUnion std.setUnion(a, b, keyF=id)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-setInter std.setInter(a, b, keyF=id)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-setDiff std.setDiff(a, b, keyF=id)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-setMember std.setMember(x, arr, keyF=id)]]
+ */
 object SetModule extends AbstractFunctionModule {
   def name = "set"
 
@@ -13,6 +27,13 @@ object SetModule extends AbstractFunctionModule {
 
   @inline private def isDefaultKeyF(v: Val): Boolean = v.asInstanceOf[AnyRef] eq DefaultKeyF
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-set std.set(arr, keyF=id)]].
+   *
+   * Since: 0.10.0. Group: Sets.
+   *
+   * Shortcut for std.uniq(std.sort(arr)).
+   */
   private object Set_ extends Val.Builtin2("set", "arr", "keyF", Array(null, DefaultKeyF)) {
     def evalRhs(arr: Eval, keyF: Eval, ev: EvalScope, pos: Position): Val = {
       uniqArr(pos, ev, sortArr(pos, ev, arr.value, keyF.value), keyF.value)
@@ -241,16 +262,56 @@ object SetModule extends AbstractFunctionModule {
 
   val functions: Seq[(String, Val.Func)] = Seq(
     builtin(Set_),
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-slice std.slice(indexable, index, end, step)]].
+     *
+     * Since: 0.10.0. Group: Arrays.
+     *
+     * Selects the elements of an array or a string from index to end with step and returns an array
+     * or a string respectively.
+     *
+     * Note that it's recommended to use dedicated slicing syntax both for arrays and strings (e.g.
+     * arr[0:4:1] instead of std.slice(arr, 0, 4, 1)).
+     */
     builtin("slice", "indexable", "index", "end", "step") {
       (pos, ev, indexable: Val, index: Option[Int], _end: Option[Int], _step: Option[Int]) =>
         Util.slice(pos, ev, indexable, index, _end, _step)
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-uniq std.uniq(arr, keyF=id)]].
+     *
+     * Since: 0.10.0. Group: Arrays.
+     *
+     * Removes successive duplicates. When given a sorted array, removes all duplicates.
+     *
+     * Optional argument keyF is a single argument function used to extract comparison key from each
+     * array element. Default value is identity function keyF=function(x) x.
+     */
     builtinWithDefaults("uniq", "arr" -> null, "keyF" -> DefaultKeyF) { (args, pos, ev) =>
       uniqArr(pos, ev, args(0), args(1))
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-sort std.sort(arr, keyF=id)]].
+     *
+     * Since: 0.10.0. Group: Arrays.
+     *
+     * Sorts the array using the <= operator.
+     *
+     * Optional argument keyF is a single argument function used to extract comparison key from each
+     * array element. Default value is identity function keyF=function(x) x.
+     */
     builtinWithDefaults("sort", "arr" -> null, "keyF" -> DefaultKeyF) { (args, pos, ev) =>
       sortArr(pos, ev, args(0), args(1))
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-setUnion std.setUnion(a, b, keyF=id)]].
+     *
+     * Since: 0.10.0. Group: Sets.
+     *
+     * Set union operation (values in any of a or b). Note that + on sets will simply concatenate
+     * the arrays, possibly forming an array that is not a set (due to not being ordered without
+     * duplicates).
+     */
     builtinWithDefaults("setUnion", "a" -> null, "b" -> null, "keyF" -> DefaultKeyF) {
       (args, pos, ev) =>
         val keyF = args(2)
@@ -308,6 +369,13 @@ object SetModule extends AbstractFunctionModule {
           Val.Arr(pos, out.result())
         }
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-setInter std.setInter(a, b, keyF=id)]].
+     *
+     * Since: 0.10.0. Group: Sets.
+     *
+     * Set intersection operation (values in both a and b).
+     */
     builtinWithDefaults("setInter", "a" -> null, "b" -> null, "keyF" -> DefaultKeyF) {
       (args, pos, ev) =>
         val keyF = args(2)
@@ -348,6 +416,13 @@ object SetModule extends AbstractFunctionModule {
 
         Val.Arr(pos, out.result())
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-setDiff std.setDiff(a, b, keyF=id)]].
+     *
+     * Since: 0.10.0. Group: Sets.
+     *
+     * Set difference operation (values in a but not b).
+     */
     builtinWithDefaults("setDiff", "a" -> null, "b" -> null, "keyF" -> DefaultKeyF) {
       (args, pos, ev) =>
         val keyF = args(2)
@@ -396,6 +471,13 @@ object SetModule extends AbstractFunctionModule {
 
         Val.Arr(pos, out.result())
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-setMember std.setMember(x, arr, keyF=id)]].
+     *
+     * Since: 0.10.0. Group: Sets.
+     *
+     * Returns true if x is a member of array, otherwise false.
+     */
     builtinWithDefaults("setMember", "x" -> null, "arr" -> null, "keyF" -> DefaultKeyF) {
       (args, pos, ev) =>
         val keyF = args(2)

--- a/sjsonnet/src/sjsonnet/stdlib/StdLibModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/StdLibModule.scala
@@ -41,6 +41,16 @@ final class StdLibModule(
   )
 }
 
+/**
+ * Native implementations for Jsonnet standard-library entries in this module.
+ *
+ * Official Jsonnet stdlib documentation links for this module:
+ *
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-trace std.trace(str, rest)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-extVar std.extVar(x)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-thisFile std.thisFile]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#math std.pi]]
+ */
 object StdLibModule {
   // Combine all functions from all modules
   private val allModuleFunctions: Map[String, Val.Func] = (
@@ -56,6 +66,13 @@ object StdLibModule {
   ).toMap
 
   // Core std library functions that belong directly in StdLibModule
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-trace std.trace(str, rest)]].
+   *
+   * Since: 0.11.0. Group: Debugging.
+   *
+   * Outputs the given string str to stderr and returns rest as the result.
+   */
   private val traceFunction = new Val.Builtin2("trace", "str", "rest") {
     def evalRhs(str: Eval, rest: Eval, ev: EvalScope, pos: Position): Val = {
       ev.trace(
@@ -65,6 +82,14 @@ object StdLibModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-extVar std.extVar(x)]].
+   *
+   * Since: 0.10.0. Group: External Variables.
+   *
+   * If an external variable with the given name was defined, return its value. Otherwise, raise an
+   * error.
+   */
   private val extVarFunction = new Val.Builtin1("extVar", "x") {
     def evalRhs(_x: Eval, ev: EvalScope, pos: Position): Val = {
       val x = _x.value.asString
@@ -75,6 +100,13 @@ object StdLibModule {
   }
 
   private val additionalStdMembers = Seq(
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-thisFile std.thisFile]].
+     *
+     * Since: 0.10.0. Group: Types and Reflection.
+     *
+     * Note that this is a field. It contains the current Jsonnet filename as a string.
+     */
     (
       "thisFile",
       new Val.Obj.Member(false, Visibility.Hidden, cached = false, deprecatedSkipAsserts = true) {
@@ -82,6 +114,13 @@ object StdLibModule {
           Val.Str(self.pos, fs.currentFile.relativeToString(ev.wd))
       }
     ),
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#math std.pi]].
+     *
+     * Since: 0.21.0. Group: Mathematical Utilities.
+     *
+     * The constant std.pi is available as the mathematical constant pi.
+     */
     (
       "pi",
       new Val.Obj.Member(false, Visibility.Hidden, cached = false, deprecatedSkipAsserts = true) {

--- a/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
@@ -6,11 +6,57 @@ import sjsonnet.functions.AbstractFunctionModule
 import java.nio.charset.StandardCharsets.UTF_8
 import scala.collection.mutable
 
+/**
+ * Native implementations for Jsonnet standard-library entries in this module.
+ *
+ * Official Jsonnet stdlib documentation links for this module:
+ *
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-toString std.toString(a)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-length std.length(x)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-codepoint std.codepoint(str)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-substr std.substr(str, from, len)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-startsWith std.startsWith(a, b)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-endsWith std.endsWith(a, b)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-char std.char(n)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-strReplace std.strReplace(str, from, to)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-stripChars std.stripChars(str, chars)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-lstripChars std.lstripChars(str, chars)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-rstripChars std.rstripChars(str, chars)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-join std.join(sep, arr)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-split std.split(str, c)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-splitLimit std.splitLimit(str, c, maxsplits)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-splitLimitR std.splitLimitR(str, c, maxsplits)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-stringChars std.stringChars(str)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-parseInt std.parseInt(str)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-parseOctal std.parseOctal(str)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-parseHex std.parseHex(str)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-asciiUpper std.asciiUpper(str)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-asciiLower std.asciiLower(str)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-encodeUTF8 std.encodeUTF8(str)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-decodeUTF8 std.decodeUTF8(arr)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-format std.format(str, vals)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-findSubstr std.findSubstr(pat, str)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-isEmpty std.isEmpty(str)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-trim std.trim(str)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-equalsIgnoreCase std.equalsIgnoreCase(str1, str2)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-escapeStringJson std.escapeStringJson(str)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-escapeStringPython std.escapeStringPython(str)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-escapeStringXML std.escapeStringXML(str)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-escapeStringBash std.escapeStringBash(str)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-escapeStringDollars std.escapeStringDollars(str)]]
+ */
 object StringModule extends AbstractFunctionModule {
   def name = "string"
 
   private val whiteSpaces = StripUtils.codePointsSet(" \t\n\f\r\u0085\u00A0")
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-toString std.toString(a)]].
+   *
+   * Since: 0.10.0. Group: String Manipulation.
+   *
+   * Convert the given argument to a string.
+   */
   private object ToString extends Val.Builtin1("toString", "a") {
     def evalRhs(v1: Eval, ev: EvalScope, pos: Position): Val = Val.Str(
       pos,
@@ -21,6 +67,15 @@ object StringModule extends AbstractFunctionModule {
     )
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-length std.length(x)]].
+   *
+   * Since: 0.10.0. Group: Types and Reflection.
+   *
+   * Depending on the type of the value given, either returns the number of elements in the array,
+   * the number of codepoints in the string, the number of parameters in the function, or the number
+   * of fields in the object. Raises an error if given a primitive value, i.e. null, true or false.
+   */
   private object Length extends Val.Builtin1("length", "x") {
     def evalRhs(x: Eval, ev: EvalScope, pos: Position): Val =
       Val.cachedNum(
@@ -35,6 +90,14 @@ object StringModule extends AbstractFunctionModule {
       )
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-codepoint std.codepoint(str)]].
+   *
+   * Since: 0.10.0. Group: String Manipulation.
+   *
+   * Returns the positive integer representing the unicode codepoint of the character in the given
+   * single-character string. This function is the inverse of std.char(n).
+   */
   private object Codepoint extends Val.Builtin1("codepoint", "str") {
     def evalRhs(str: Eval, ev: EvalScope, pos: Position): Val = {
       val s = str.value.asString
@@ -47,6 +110,19 @@ object StringModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-substr std.substr(str, from, len)]].
+   *
+   * Since: 0.10.0. Group: String Manipulation.
+   *
+   * Returns a string that is the part of str that starts at offset from and is len codepoints long.
+   * If the string str is shorter than from+len, the suffix starting at position from will be
+   * returned.
+   *
+   * The slice operator (e.g., str[from:to]) can also be used on strings, as an alternative to this
+   * function. However, note that the slice operator takes a start and an end index, but std.substr
+   * takes a start index and a length.
+   */
   private object Substr extends Val.Builtin3("substr", "str", "from", "len") {
     def evalRhs(_s: Eval, from: Eval, len: Eval, ev: EvalScope, pos: Position): Val = {
       val str = _s.value.asString
@@ -73,16 +149,38 @@ object StringModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-startsWith std.startsWith(a, b)]].
+   *
+   * Since: 0.10.0. Group: String Manipulation.
+   *
+   * Returns whether the string a is prefixed by the string b.
+   */
   private object StartsWith extends Val.Builtin2("startsWith", "a", "b") {
     def evalRhs(a: Eval, b: Eval, ev: EvalScope, pos: Position): Val =
       Val.bool(a.value.asString.startsWith(b.value.asString))
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-endsWith std.endsWith(a, b)]].
+   *
+   * Since: 0.10.0. Group: String Manipulation.
+   *
+   * Returns whether the string a is suffixed by the string b.
+   */
   private object EndsWith extends Val.Builtin2("endsWith", "a", "b") {
     def evalRhs(a: Eval, b: Eval, ev: EvalScope, pos: Position): Val =
       Val.bool(a.value.asString.endsWith(b.value.asString))
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-char std.char(n)]].
+   *
+   * Since: 0.10.0. Group: String Manipulation.
+   *
+   * Returns a string of length one whose only unicode codepoint has integer id n. This function is
+   * the inverse of std.codepoint(str).
+   */
   private object Char_ extends Val.Builtin1("char", "n") {
     def evalRhs(n: Eval, ev: EvalScope, pos: Position): Val = {
       val c = n.value.asInt
@@ -93,6 +191,14 @@ object StringModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-strReplace std.strReplace(str, from, to)]].
+   *
+   * Since: 0.10.0. Group: String Manipulation.
+   *
+   * Returns a copy of the string in which all occurrences of string from have been replaced with
+   * string to.
+   */
   private object StrReplace extends Val.Builtin3("strReplace", "str", "from", "to") {
     def evalRhs(str: Eval, from: Eval, to: Eval, ev: EvalScope, pos: Position): Val = {
       val fromForce = from.value.asString
@@ -216,6 +322,13 @@ object StringModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-stripChars std.stripChars(str, chars)]].
+   *
+   * Since: 0.15.0. Group: String Manipulation.
+   *
+   * Removes characters chars from the beginning and from the end of str.
+   */
   private object StripChars extends Val.Builtin2("stripChars", "str", "chars") {
     def evalRhs(str: Eval, chars: Eval, ev: EvalScope, pos: Position): Val = {
       val charsSet = StripUtils.codePointsSet(chars.value.asString)
@@ -231,6 +344,13 @@ object StringModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-lstripChars std.lstripChars(str, chars)]].
+   *
+   * Since: 0.15.0. Group: String Manipulation.
+   *
+   * Removes characters chars from the beginning of str.
+   */
   private object LStripChars extends Val.Builtin2("lstripChars", "str", "chars") {
     def evalRhs(str: Eval, chars: Eval, ev: EvalScope, pos: Position): Val = {
       val charsSet = StripUtils.codePointsSet(chars.value.asString)
@@ -246,6 +366,13 @@ object StringModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-rstripChars std.rstripChars(str, chars)]].
+   *
+   * Since: 0.15.0. Group: String Manipulation.
+   *
+   * Removes characters chars from the end of str.
+   */
   private object RStripChars extends Val.Builtin2("rstripChars", "str", "chars") {
     def evalRhs(str: Eval, chars: Eval, ev: EvalScope, pos: Position): Val = {
       val charsSet = StripUtils.codePointsSet(chars.value.asString)
@@ -261,6 +388,15 @@ object StringModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-join std.join(sep, arr)]].
+   *
+   * Since: 0.10.0. Group: Arrays.
+   *
+   * If sep is a string, then arr must be an array of strings, in which case they are concatenated
+   * with sep used as a delimiter. If sep is an array, then arr must be an array of arrays, in which
+   * case the arrays are concatenated in the same way, to produce a single array.
+   */
   private object Join extends Val.Builtin2("join", "sep", "arr") {
     def evalRhs(sep: Eval, _arr: Eval, ev: EvalScope, pos: Position): Val = {
       val arr = implicitly[ReadWriter[Val.Arr]].apply(_arr.value)
@@ -329,18 +465,44 @@ object StringModule extends AbstractFunctionModule {
     b.result()
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-split std.split(str, c)]].
+   *
+   * Since: 0.10.0. Group: String Manipulation.
+   *
+   * Split the string str into an array of strings, divided by the string c.
+   *
+   * Note: Versions up to and including 0.18.0 require c to be a single character.
+   */
   private object Split extends Val.Builtin2("split", "str", "c") {
     def evalRhs(str: Eval, c: Eval, ev: EvalScope, pos: Position): Val = {
       Val.Arr(pos, splitLimit(pos, str.value.asString, c.value.asString, -1))
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-splitLimit std.splitLimit(str, c, maxsplits)]].
+   *
+   * Since: 0.10.0. Group: String Manipulation.
+   *
+   * As std.split(str, c) but will stop after maxsplits splits, thereby the largest array it will
+   * return has length maxsplits + 1. A limit of -1 means unlimited.
+   *
+   * Note: Versions up to and including 0.18.0 require c to be a single character.
+   */
   private object SplitLimit extends Val.Builtin3("splitLimit", "str", "c", "maxsplits") {
     def evalRhs(str: Eval, c: Eval, maxSplits: Eval, ev: EvalScope, pos: Position): Val = {
       Val.Arr(pos, splitLimit(pos, str.value.asString, c.value.asString, maxSplits.value.asInt))
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-splitLimitR std.splitLimitR(str, c, maxsplits)]].
+   *
+   * Since: 0.19.0. Group: String Manipulation.
+   *
+   * As std.splitLimit(str, c, maxsplits) but will split from right to left.
+   */
   private object SplitLimitR extends Val.Builtin3("splitLimitR", "str", "c", "maxsplits") {
     def evalRhs(str: Eval, c: Eval, maxSplits: Eval, ev: EvalScope, pos: Position): Val = {
       Val.Arr(
@@ -352,11 +514,25 @@ object StringModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-stringChars std.stringChars(str)]].
+   *
+   * Since: 0.10.0. Group: String Manipulation.
+   *
+   * Split the string str into an array of strings, each containing a single codepoint.
+   */
   private object StringChars extends Val.Builtin1("stringChars", "str") {
     def evalRhs(str: Eval, ev: EvalScope, pos: Position): Val =
       stringChars(pos, str.value.asString)
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-parseInt std.parseInt(str)]].
+   *
+   * Since: 0.10.0. Group: Parsing.
+   *
+   * Parses a signed decimal integer from the input string.
+   */
   private object ParseInt extends Val.Builtin1("parseInt", "str") {
     def evalRhs(str: Eval, ev: EvalScope, pos: Position): Val = {
       val s = str.value.asString
@@ -368,6 +544,13 @@ object StringModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-parseOctal std.parseOctal(str)]].
+   *
+   * Since: 0.10.0. Group: Parsing.
+   *
+   * Parses an unsigned octal integer from the input string. Initial zeroes are tolerated.
+   */
   private object ParseOctal extends Val.Builtin1("parseOctal", "str") {
     def evalRhs(str: Eval, ev: EvalScope, pos: Position): Val = {
       val s = str.value.asString
@@ -376,6 +559,13 @@ object StringModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-parseHex std.parseHex(str)]].
+   *
+   * Since: 0.10.0. Group: Parsing.
+   *
+   * Parses an unsigned hexadecimal integer, from the input string. Case insensitive.
+   */
   private object ParseHex extends Val.Builtin1("parseHex", "str") {
     def evalRhs(str: Eval, ev: EvalScope, pos: Position): Val = {
       val s = str.value.asString
@@ -431,16 +621,37 @@ object StringModule extends AbstractFunctionModule {
     if (out == null) str else new String(out)
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-asciiUpper std.asciiUpper(str)]].
+   *
+   * Since: 0.10.0. Group: String Manipulation.
+   *
+   * Returns a copy of the string in which all ASCII letters are capitalized.
+   */
   private object AsciiUpper extends Val.Builtin1("asciiUpper", "str") {
     def evalRhs(str: Eval, ev: EvalScope, pos: Position): Val =
       Val.Str(pos, asciiUpper(str.value.asString))
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-asciiLower std.asciiLower(str)]].
+   *
+   * Since: 0.10.0. Group: String Manipulation.
+   *
+   * Returns a copy of the string in which all ASCII letters are lower cased.
+   */
   private object AsciiLower extends Val.Builtin1("asciiLower", "str") {
     def evalRhs(str: Eval, ev: EvalScope, pos: Position): Val =
       Val.Str(pos, asciiLower(str.value.asString))
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-encodeUTF8 std.encodeUTF8(str)]].
+   *
+   * Since: 0.13.0. Group: Parsing.
+   *
+   * Encode a string using UTF8. Returns an array of numbers representing bytes.
+   */
   private object EncodeUTF8 extends Val.Builtin1("encodeUTF8", "str") {
     def evalRhs(s: Eval, ev: EvalScope, pos: Position): Val = {
       val bytes = s.value.asString.getBytes(UTF_8)
@@ -454,6 +665,13 @@ object StringModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-decodeUTF8 std.decodeUTF8(arr)]].
+   *
+   * Since: 0.13.0. Group: Parsing.
+   *
+   * Decode an array of numbers representing bytes using UTF8. Returns a string.
+   */
   private object DecodeUTF8 extends Val.Builtin1("decodeUTF8", "arr") {
     def evalRhs(arr: Eval, ev: EvalScope, pos: Position): Val = {
       for ((v, idx) <- arr.value.asArr.iterator.zipWithIndex) {
@@ -470,6 +688,15 @@ object StringModule extends AbstractFunctionModule {
     }
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-format std.format(str, vals)]].
+   *
+   * Since: 0.10.0. Group: String Manipulation.
+   *
+   * Format the string str using the values in vals. The values can be an array, an object, or in
+   * other cases are treated as if they were provided in a singleton array. The string formatting
+   * follows the same rules as Python. The % operator can be used as a shorthand for this function.
+   */
   private object Format_ extends Val.Builtin2("format", "str", "vals") {
     def evalRhs(str: Eval, vals: Eval, ev: EvalScope, pos: Position): Val =
       Val.Str(pos, Format.format(str.value.asString, vals.value, pos)(ev))
@@ -543,6 +770,13 @@ object StringModule extends AbstractFunctionModule {
     builtin(EncodeUTF8),
     builtin(DecodeUTF8),
     builtin(Format_),
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-findSubstr std.findSubstr(pat, str)]].
+     *
+     * Since: 0.10.0. Group: String Manipulation.
+     *
+     * Returns an array that contains the indexes of all occurrences of pat in str.
+     */
     builtin("findSubstr", "pat", "str") { (pos, ev, pat: String, str: String) =>
       if (pat.isEmpty) Val.Arr(pos, new Array[Eval](0))
       else {
@@ -567,6 +801,13 @@ object StringModule extends AbstractFunctionModule {
         }
       }
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-isEmpty std.isEmpty(str)]].
+     *
+     * Since: 0.20.0. Group: String Manipulation.
+     *
+     * Returns true if the given string is of zero length.
+     */
     builtin("isEmpty", "str") { (_, _, value: Val) =>
       value match {
         case Val.Str(_, s) => s.isEmpty
@@ -577,13 +818,36 @@ object StringModule extends AbstractFunctionModule {
           Error.fail("length operates on strings, objects, and arrays, got " + x.prettyName)
       }
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-trim std.trim(str)]].
+     *
+     * Since: 0.21.0. Group: String Manipulation.
+     *
+     * Returns a copy of string after eliminating leading and trailing whitespaces.
+     */
     builtin("trim", "str") { (_, _, str: String) =>
       StripUtils.unspecializedStrip(str, whiteSpaces, true, true)
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-equalsIgnoreCase std.equalsIgnoreCase(str1, str2)]].
+     *
+     * Since: 0.21.0. Group: String Manipulation.
+     *
+     * Returns true if the the given str1 is equal to str2 by doing case insensitive comparison,
+     * false otherwise.
+     */
     builtin("equalsIgnoreCase", "str1", "str2") { (_, _, str1: String, str2: String) =>
       // Official equalsIgnoreCase is defined through asciiLower, not Unicode case folding.
       asciiLower(str1) == asciiLower(str2)
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-escapeStringJson std.escapeStringJson(str)]].
+     *
+     * Since: 0.10.0. Group: String Manipulation.
+     *
+     * Convert str to allow it to be embedded in a JSON representation, within a string. This adds
+     * quotes, escapes backslashes, and escapes unprintable characters.
+     */
     builtin("escapeStringJson", "str_") { (pos, ev, str: Val) =>
       if (str.value.isInstanceOf[Val.Str]) {
         Materializer.stringify(str)(ev)
@@ -593,11 +857,26 @@ object StringModule extends AbstractFunctionModule {
         out.toString
       }
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-escapeStringPython std.escapeStringPython(str)]].
+     *
+     * Since: 0.10.0. Group: String Manipulation.
+     *
+     * Convert str to allow it to be embedded in Python. This is an alias for std.escapeStringJson.
+     */
     builtin("escapeStringPython", "str") { (pos, ev, str: Val) =>
       val out = new java.io.StringWriter()
       BaseRenderer.escape(out, stdToString(str)(ev), unicode = true)
       out.toString
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-escapeStringXML std.escapeStringXML(str)]].
+     *
+     * Since: 0.10.0. Group: String Manipulation.
+     *
+     * Convert str to allow it to be embedded in XML (or HTML). It escapes XML-sensitive characters
+     * (<, >, &, ", and ').
+     */
     builtin("escapeStringXML", "str") { (_, ev, str: Val) =>
       val string = stdToString(str)(ev)
       val out = new java.io.StringWriter()
@@ -615,9 +894,26 @@ object StringModule extends AbstractFunctionModule {
       }
       out.toString
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-escapeStringBash std.escapeStringBash(str)]].
+     *
+     * Since: 0.10.0. Group: String Manipulation.
+     *
+     * Wrap str in single quotes, and escape any single quotes within str by changing them to a
+     * sequence '"'"'. This allows injection of arbitrary strings as arguments of commands in bash
+     * scripts.
+     */
     builtin("escapeStringBash", "str_") { (pos, ev, str: Val) =>
       "'" + stdToString(str)(ev).replace("'", """'"'"'""") + "'"
     },
+    /**
+     * [[https://jsonnet.org/ref/stdlib.html#std-escapeStringDollars std.escapeStringDollars(str)]].
+     *
+     * Since: 0.10.0. Group: String Manipulation.
+     *
+     * Convert $ to $$ in str. This allows injection of arbitrary strings into systems that use $
+     * for string interpolation (like Terraform).
+     */
     builtin("escapeStringDollars", "str_") { (pos, ev, str: Val) =>
       stdToString(str)(ev).replace("$", "$$")
     }

--- a/sjsonnet/src/sjsonnet/stdlib/TypeModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/TypeModule.scala
@@ -3,48 +3,136 @@ package sjsonnet.stdlib
 import sjsonnet._
 import sjsonnet.functions.AbstractFunctionModule
 
+/**
+ * Native implementations for Jsonnet standard-library entries in this module.
+ *
+ * Official Jsonnet stdlib documentation links for this module:
+ *
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-type std.isString(v)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-type std.isBoolean(v)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-type std.isNumber(v)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-type std.isObject(v)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-type std.isArray(v)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-type std.isFunction(v)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-isNull std.isNull(x)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-type std.type(x)]]
+ *   - [[https://jsonnet.org/ref/stdlib.html#std-assertEqual std.assertEqual(a, b)]]
+ */
 object TypeModule extends AbstractFunctionModule {
   def name = "type"
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-type std.isString(v)]].
+   *
+   * Since: 0.10.0. Group: Types and Reflection.
+   *
+   * Return a boolean indicating whether the given value has type string. The official std.type docs
+   * list this helper alongside std.type.
+   */
   private object IsString extends Val.Builtin1("isString", "v") {
     def evalRhs(v: Eval, ev: EvalScope, pos: Position): Val =
       Val.bool(v.value.isInstanceOf[Val.Str])
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-type std.isBoolean(v)]].
+   *
+   * Since: 0.10.0. Group: Types and Reflection.
+   *
+   * Return a boolean indicating whether the given value has type boolean. The official std.type
+   * docs list this helper alongside std.type.
+   */
   private object IsBoolean extends Val.Builtin1("isBoolean", "v") {
     def evalRhs(v: Eval, ev: EvalScope, pos: Position): Val =
       Val.bool(v.value.isInstanceOf[Val.Bool])
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-type std.isNumber(v)]].
+   *
+   * Since: 0.10.0. Group: Types and Reflection.
+   *
+   * Return a boolean indicating whether the given value has type number. The official std.type docs
+   * list this helper alongside std.type.
+   */
   private object IsNumber extends Val.Builtin1("isNumber", "v") {
     def evalRhs(v: Eval, ev: EvalScope, pos: Position): Val =
       Val.bool(v.value.isInstanceOf[Val.Num])
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-type std.isObject(v)]].
+   *
+   * Since: 0.10.0. Group: Types and Reflection.
+   *
+   * Return a boolean indicating whether the given value has type object. The official std.type docs
+   * list this helper alongside std.type.
+   */
   private object IsObject extends Val.Builtin1("isObject", "v") {
     def evalRhs(v: Eval, ev: EvalScope, pos: Position): Val =
       Val.bool(v.value.isInstanceOf[Val.Obj])
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-type std.isArray(v)]].
+   *
+   * Since: 0.10.0. Group: Types and Reflection.
+   *
+   * Return a boolean indicating whether the given value has type array. The official std.type docs
+   * list this helper alongside std.type.
+   */
   private object IsArray extends Val.Builtin1("isArray", "v") {
     def evalRhs(v: Eval, ev: EvalScope, pos: Position): Val =
       Val.bool(v.value.isInstanceOf[Val.Arr])
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-type std.isFunction(v)]].
+   *
+   * Since: 0.10.0. Group: Types and Reflection.
+   *
+   * Return a boolean indicating whether the given value has type function. The official std.type
+   * docs list this helper alongside std.type.
+   */
   private object IsFunction extends Val.Builtin1("isFunction", "v") {
     def evalRhs(v: Eval, ev: EvalScope, pos: Position): Val =
       Val.bool(v.value.isInstanceOf[Val.Func])
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-isNull std.isNull(x)]].
+   *
+   * Since: 0.22.0. Group: Types and Reflection.
+   *
+   * Returns true if the given value is null, false otherwise.
+   */
   private object IsNull extends Val.Builtin1("isNull", "v") {
     def evalRhs(v: Eval, ev: EvalScope, pos: Position): Val =
       Val.bool(v.value.isInstanceOf[Val.Null])
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-type std.type(x)]].
+   *
+   * Since: 0.10.0. Group: Types and Reflection.
+   *
+   * Return a string that indicates the type of the value. The possible return values are: "array",
+   * "boolean", "function", "null", "number", "object", and "string".
+   *
+   * The following functions are also available and return a boolean: std.isArray(v),
+   * std.isBoolean(v), std.isFunction(v), std.isNumber(v), std.isObject(v), and std.isString(v).
+   */
   private object Type extends Val.Builtin1("type", "x") {
     def evalRhs(x: Eval, ev: EvalScope, pos: Position): Val = Val.Str(pos, x.value.prettyName)
   }
 
+  /**
+   * [[https://jsonnet.org/ref/stdlib.html#std-assertEqual std.assertEqual(a, b)]].
+   *
+   * Since: 0.10.0. Group: Assertions and Debugging.
+   *
+   * Ensure that a == b. Returns true or throws an error message.
+   */
   private object AssertEqual extends Val.Builtin2("assertEqual", "a", "b") {
     def evalRhs(v1: Eval, v2: Eval, ev: EvalScope, pos: Position): Val = {
       val a = v1.value


### PR DESCRIPTION
## Motivation
The stdlib native implementations are optimized and split across modules, which makes it harder to compare them against official Jsonnet documentation during future audits, Scaladoc browsing, and AI-assisted changes.

## Modification
Add Scaladoc-style comments derived from google/jsonnet doc/_stdlib_gen/stdlib-content.jsonnet beside the corresponding stdlib implementations.

Each documented stdlib entry now includes a clickable official stdlib link, since version, group, and prose description. Module-level Scaladoc link lists are also added so generated Scaladoc pages expose jump targets even when the actual implementations are private objects or Seq entries.

Notes:
- Functions with dedicated official anchors link to `#std-...`.
- Helpers documented only inside the official math/type sections link to the existing official section anchor, not fabricated anchors.
- Example/pre blocks remain omitted to keep source comments compact and robust.

## Result
- Verified 148 per-entry Scaladoc link blocks.
- Verified 9 module-level Scaladoc link lists.
- Verified 296 official stdlib links total and no invalid anchors against the generated official stdlib HTML.
- Verified the generated Scaladoc HTML renders clickable `jsonnet.org/ref/stdlib.html#...` links.
- Verified the diff only changes comments.
- Ran `git diff --check`.
- Ran `./mill --no-server 'sjsonnet.jvm[3.3.7].checkFormat'`.
- Ran `./mill --no-server 'sjsonnet.jvm[3.3.7].compile'`.
- Ran `./mill --no-server 'sjsonnet.jvm[3.3.7].scalaDocGenerated'`.
- Ran `./mill --no-server 'sjsonnet.jvm[3.3.7].test'`.