### PR TITLE
fix: Add official escapeStringXml stdlib alias

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -1057,7 +1057,8 @@
         ["encodeUTF8", "(str)"], ["decodeUTF8", "(arr)"],
         ["escapeStringJson", "(str)"], ["escapeStringPython", "(str)"],
         ["escapeStringBash", "(str)"], ["escapeStringDollars", "(str)"],
-        ["escapeStringXML", "(str)"], ["equalsIgnoreCase", "(str1, str2)"],
+        ["escapeStringXml", "(str)"], ["escapeStringXML", "(str)"],
+        ["equalsIgnoreCase", "(str1, str2)"],
         ["format", "(str, vals)"],
         // Object functions
         ["objectHas", "(o, f)"], ["objectHasAll", "(o, f)"], ["objectHasEx", "(o, f, inc_hidden)"],

--- a/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
@@ -431,6 +431,23 @@ object StringModule extends AbstractFunctionModule {
     if (out == null) str else new String(out)
   }
 
+  private def escapeStringXmlString(string: String): String = {
+    val out = new java.io.StringWriter()
+    var i = 0
+    while (i < string.length) {
+      string.charAt(i) match {
+        case '<'  => out.write("&lt;")
+        case '>'  => out.write("&gt;")
+        case '&'  => out.write("&amp;")
+        case '"'  => out.write("&quot;")
+        case '\'' => out.write("&apos;")
+        case c    => out.write(c)
+      }
+      i += 1
+    }
+    out.toString
+  }
+
   private object AsciiUpper extends Val.Builtin1("asciiUpper", "str") {
     def evalRhs(str: Eval, ev: EvalScope, pos: Position): Val =
       Val.Str(pos, asciiUpper(str.value.asString))
@@ -598,22 +615,11 @@ object StringModule extends AbstractFunctionModule {
       BaseRenderer.escape(out, stdToString(str)(ev), unicode = true)
       out.toString
     },
+    builtin("escapeStringXml", "str") { (_, ev, str: Val) =>
+      escapeStringXmlString(stdToString(str)(ev))
+    },
     builtin("escapeStringXML", "str") { (_, ev, str: Val) =>
-      val string = stdToString(str)(ev)
-      val out = new java.io.StringWriter()
-      var i = 0
-      while (i < string.length) {
-        string.charAt(i) match {
-          case '<'  => out.write("&lt;")
-          case '>'  => out.write("&gt;")
-          case '&'  => out.write("&amp;")
-          case '"'  => out.write("&quot;")
-          case '\'' => out.write("&apos;")
-          case c    => out.write(c)
-        }
-        i += 1
-      }
-      out.toString
+      escapeStringXmlString(stdToString(str)(ev))
     },
     builtin("escapeStringBash", "str_") { (pos, ev, str: Val) =>
       "'" + stdToString(str)(ev).replace("'", """'"'"'""") + "'"

--- a/sjsonnet/test/src/sjsonnet/StdLibOfficialCompatibilityTests.scala
+++ b/sjsonnet/test/src/sjsonnet/StdLibOfficialCompatibilityTests.scala
@@ -47,6 +47,7 @@ object StdLibOfficialCompatibilityTests extends TestSuite {
       eval("""std.escapeStringBash(10)""") ==> ujson.Str("'10'")
       eval("""std.escapeStringDollars("$a")""") ==> ujson.Str("$$a")
       eval("""std.escapeStringDollars(10)""") ==> ujson.Str("10")
+      eval("""std.escapeStringXml(10)""") ==> ujson.Str("10")
       eval("""std.escapeStringXML(10)""") ==> ujson.Str("10")
     }
 


### PR DESCRIPTION
## Summary
- add the official std.escapeStringXml spelling alongside the existing std.escapeStringXML alias
- share the XML escaping implementation between both names
- update playground completions and add compatibility coverage

## Tests
- ./mill --no-server 'sjsonnet.jvm[3.3.7]'.test
- ./mill --no-server __.checkFormat