### PR TITLE
perf: specialize Builtin1 and Builtin3 apply paths

### DIFF
--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -1906,6 +1906,12 @@ object Val {
         tailstrictMode: TailstrictMode): Val =
       if (namedNames == null && argVals.length == 1) evalRhs(argVals(0).value, ev, outerPos)
       else super.apply(argVals, namedNames, outerPos)
+
+    override def apply1(argVal: Eval, outerPos: Position)(implicit
+        ev: EvalScope,
+        tailstrictMode: TailstrictMode): Val =
+      if (params.names.length == 1) evalRhs(argVal.value, ev, outerPos)
+      else super.apply(Array(argVal), null, outerPos)
   }
 
   abstract class Builtin2(fn: String, pn1: String, pn2: String, defs: Array[Expr] = null)
@@ -1949,6 +1955,13 @@ object Val {
       if (namedNames == null && argVals.length == 3)
         evalRhs(argVals(0).value, argVals(1).value, argVals(2).value, ev, outerPos)
       else super.apply(argVals, namedNames, outerPos)
+
+    override def apply3(argVal1: Eval, argVal2: Eval, argVal3: Eval, outerPos: Position)(implicit
+        ev: EvalScope,
+        tailstrictMode: TailstrictMode): Val =
+      if (params.names.length == 3)
+        evalRhs(argVal1.value, argVal2.value, argVal3.value, ev, outerPos)
+      else super.apply(Array(argVal1, argVal2, argVal3), null, outerPos)
   }
 
   abstract class Builtin4(


### PR DESCRIPTION
Split out from #763.

Motivation:

Reduce allocation and dispatch overhead when one- and three-argument builtins are called through the dynamic `Val.Func.apply1` / `apply3` path.

Key Design Decision:

Keep the optimization local and semantics-preserving. `Builtin2` already has an exact-arity `apply2` override; this adds matching `Builtin1.apply1` and `Builtin3.apply3` overrides. Exact positional calls directly invoke the structured `evalRhs` overload and skip constructing an intermediate `Array`. Non-exact paths still fall back to the generic parent application path.

Correctness:

- The direct path matches the existing `Builtin1.apply` / `Builtin3.apply` exact positional behavior: force the supplied `Eval` values, then call the typed `evalRhs`.
- Named arguments, missing defaults, too many arguments, and other non-exact calls still use the generic function application logic.
- Static `Expr.ApplyBuiltin1` / `Expr.ApplyBuiltin3` paths are unchanged; this only helps dynamic builtin calls such as a builtin stored in a local or returned from another function.

Modification:

- Add `Builtin1.apply1`.
- Add `Builtin3.apply3`.

Validation:

- `./mill --no-server 'sjsonnet.jvm[3.3.7].compile'`
- `./mill --no-server 'sjsonnet.jvm[3.3.7].test'` (`141/141, SUCCESS`)
- `./mill --no-server 'sjsonnet.jvm[3.3.7].checkFormat'`
- `./mill --no-server '_.jvm[_].__.test'` (`1104/1104, SUCCESS`)
- Dynamic builtin smoke checks:
  - `local f = std.length; f([1, 2, 3])` -> `3`
  - `local f = std.substr; f("abcdef", 1, 3)` -> `"bcd"`
  - `local f = std.substr; f(str="abcdef", from=1, len=3)` -> `"bcd"`

Hyperfine:

Toolchain:

- `hyperfine 1.20.0`
- `--warmup 3 --min-runs 25` for targeted dynamic builtin benchmarks
- `--warmup 3 --min-runs 20` for `realistic2`
- JVM assemblies built with `./mill --no-server show 'sjsonnet.jvm[3.3.7].assembly'`
- Base: `upstream/master` at `c04fc804`
- Branch: `2067d8b5`

Targeted `Builtin1` dynamic call benchmark:

```jsonnet
local identity(x) = x;
local len = identity(std.length);
std.foldl(
  function(acc, i) acc + len("abcdef"),
  std.range(1, 5000000),
  0
)
```

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `master builtin1_dynamic` | 649.8 +/- 48.3 | 557.4 | 726.8 | 1.00 |
| `branch builtin1_dynamic` | 661.7 +/- 41.0 | 606.1 | 747.3 | 1.02 +/- 0.10 |

Result: statistically neutral in this hyperfine run.

Targeted `Builtin3` dynamic call benchmark:

```jsonnet
local identity(x) = x;
local substr = identity(std.substr);
std.foldl(
  function(acc, i) acc + std.length(substr("abcdef", 1, 3)),
  std.range(1, 3000000),
  0
)
```

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `master builtin3_dynamic` | 742.5 +/- 156.1 | 594.1 | 1254.7 | 1.12 +/- 0.30 |
| `branch builtin3_dynamic` | 660.4 +/- 110.9 | 534.0 | 962.6 | 1.00 |

Result: branch was faster in this run, but variance is high.

End-to-end `realistic2`:

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `master realistic2` | 544.9 +/- 95.3 | 414.1 | 706.5 | 1.27 +/- 0.27 |
| `branch realistic2` | 428.4 +/- 54.1 | 378.3 | 565.8 | 1.00 |

Result: branch was faster in this run; due JVM-startup and system noise, treat this as a non-regression signal rather than a guaranteed 1.27x speedup.
