### PR TITLE
perf: chunk long string byte escaping

### DIFF
--- a/sjsonnet/src-js/sjsonnet/CharSWAR.scala
+++ b/sjsonnet/src-js/sjsonnet/CharSWAR.scala
@@ -33,4 +33,14 @@ object CharSWAR {
     }
     false
   }
+
+  def findFirstEscapeChar(arr: Array[Byte], from: Int, to: Int): Int = {
+    var i = from
+    while (i < to) {
+      val b = arr(i) & 0xff
+      if (b < 32 || b == '"' || b == '\\') return i
+      i += 1
+    }
+    -1
+  }
 }

--- a/sjsonnet/src-jvm/sjsonnet/CharSWAR.java
+++ b/sjsonnet/src-jvm/sjsonnet/CharSWAR.java
@@ -90,6 +90,31 @@ final class CharSWAR {
         return false;
     }
 
+    /**
+     * Find the first byte in {@code arr[from..to)} that needs JSON string escaping, or {@code -1}
+     * when the range is clean.
+     */
+    static int findFirstEscapeChar(byte[] arr, int from, int to) {
+        int i = from;
+        int limit = to - 7;
+        while (i < limit) {
+            long word = (long) LONG_VIEW.get(arr, i);
+            if (swarHasMatch(word)) {
+                for (int j = i; j < i + 8; j++) {
+                    int b = arr[j] & 0xFF;
+                    if (b < 32 || b == '"' || b == '\\') return j;
+                }
+            }
+            i += 8;
+        }
+        while (i < to) {
+            int b = arr[i] & 0xFF;
+            if (b < 32 || b == '"' || b == '\\') return i;
+            i++;
+        }
+        return -1;
+    }
+
     private static boolean hasEscapeCharSWAR(byte[] arr, int from, int to) {
         int i = from;
         int limit = to - 7; // 8 bytes per VarHandle.get

--- a/sjsonnet/src-jvm/sjsonnet/CharSWAR.java
+++ b/sjsonnet/src-jvm/sjsonnet/CharSWAR.java
@@ -31,6 +31,7 @@ final class CharSWAR {
     //   MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder)
     private static final VarHandle LONG_VIEW =
             MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.nativeOrder());
+    private static final boolean LITTLE_ENDIAN = ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN;
 
     // --- 8-bit SWAR constants (Netty/Pekko pattern) ---
     //
@@ -99,11 +100,9 @@ final class CharSWAR {
         int limit = to - 7;
         while (i < limit) {
             long word = (long) LONG_VIEW.get(arr, i);
-            if (swarHasMatch(word)) {
-                for (int j = i; j < i + 8; j++) {
-                    int b = arr[j] & 0xFF;
-                    if (b < 32 || b == '"' || b == '\\') return j;
-                }
+            long mask = swarMatchMask(word);
+            if (mask != 0L) {
+                return i + firstMatchedByte(mask);
             }
             i += 8;
         }
@@ -120,7 +119,7 @@ final class CharSWAR {
         int limit = to - 7; // 8 bytes per VarHandle.get
         while (i < limit) {
             long word = (long) LONG_VIEW.get(arr, i);
-            if (swarHasMatch(word)) return true;
+            if (swarMatchMask(word) != 0L) return true;
             i += 8;
         }
         // Tail: remaining 0-7 bytes
@@ -139,7 +138,7 @@ final class CharSWAR {
      * <p>Uses Netty/Pekko pattern: XOR to produce zero lanes, then
      * Hacker's Delight formula to detect zero bytes.
      */
-    private static boolean swarHasMatch(long word) {
+    private static long swarMatchMask(long word) {
         // 1. Detect '"' via XOR + zero-detection (Netty SWARUtil.applyPattern)
         long q = word ^ QUOTE;
         long qz = ~((q & HOLE) + HOLE | q | HOLE);
@@ -152,7 +151,13 @@ final class CharSWAR {
         long c = word & CTRL;
         long cz = ~((c & HOLE) + HOLE | c | HOLE);
 
-        return (qz | bz | cz) != 0L;
+        return qz | bz | cz;
+    }
+
+    private static int firstMatchedByte(long mask) {
+        return (LITTLE_ENDIAN
+                ? Long.numberOfTrailingZeros(mask)
+                : Long.numberOfLeadingZeros(mask)) >>> 3;
     }
 
     /** Scalar scan for String (used for short strings). */

--- a/sjsonnet/src-native/sjsonnet/CharSWAR.scala
+++ b/sjsonnet/src-native/sjsonnet/CharSWAR.scala
@@ -89,6 +89,32 @@ object CharSWAR {
     false
   }
 
+  def findFirstEscapeChar(arr: Array[Byte], from: Int, to: Int): Int = {
+    val len = to - from
+    if (len < 8) return findFirstEscapeCharScalar(arr, from, to)
+    val barr = arr.asInstanceOf[ByteArray]
+    var i = from
+    val limit = to - 7
+    while (i < limit) {
+      val word = Intrinsics.loadLong(barr.atRawUnsafe(i))
+      if (swarHasMatch(word)) {
+        var j = i
+        while (j < i + 8) {
+          val b = arr(j) & 0xff
+          if (b < 32 || b == '"' || b == '\\') return j
+          j += 1
+        }
+      }
+      i += 8
+    }
+    while (i < to) {
+      val b = arr(i) & 0xff
+      if (b < 32 || b == '"' || b == '\\') return i
+      i += 1
+    }
+    -1
+  }
+
   @inline private def hasEscapeCharScalar(s: String, len: Int): Boolean = {
     var i = 0
     while (i < len) {
@@ -107,5 +133,15 @@ object CharSWAR {
       i += 1
     }
     false
+  }
+
+  @inline private def findFirstEscapeCharScalar(arr: Array[Byte], from: Int, to: Int): Int = {
+    var i = from
+    while (i < to) {
+      val b = arr(i) & 0xff
+      if (b < 32 || b == '"' || b == '\\') return i
+      i += 1
+    }
+    -1
   }
 }

--- a/sjsonnet/src-native/sjsonnet/CharSWAR.scala
+++ b/sjsonnet/src-native/sjsonnet/CharSWAR.scala
@@ -21,12 +21,14 @@ object CharSWAR {
   private final val QUOTE = 0x2222222222222222L
   private final val BSLAS = 0x5c5c5c5c5c5c5c5cL
   private final val CTRL = 0xe0e0e0e0e0e0e0e0L
+  private final val LITTLE_ENDIAN =
+    java.nio.ByteOrder.nativeOrder() == java.nio.ByteOrder.LITTLE_ENDIAN
 
   /**
-   * SWAR: returns true if any byte lane in `word` contains '"' (0x22), '\\' (0x5C), or a control
+   * SWAR: returns a mask for byte lanes in `word` containing '"' (0x22), '\\' (0x5C), or a control
    * char (< 0x20).
    */
-  @inline private def swarHasMatch(word: Long): Boolean = {
+  @inline private def swarMatchMask(word: Long): Long = {
     // 1. Detect '"' via XOR + zero-detection
     val q = word ^ QUOTE
     val qz = ~((q & HOLE) + HOLE | q | HOLE)
@@ -39,8 +41,12 @@ object CharSWAR {
     val c = word & CTRL
     val cz = ~((c & HOLE) + HOLE | c | HOLE)
 
-    (qz | bz | cz) != 0L
+    qz | bz | cz
   }
+
+  @inline private def firstMatchedByte(mask: Long): Int =
+    (if (LITTLE_ENDIAN) java.lang.Long.numberOfTrailingZeros(mask)
+     else java.lang.Long.numberOfLeadingZeros(mask)) >>> 3
 
   def hasEscapeChar(s: String): Boolean = {
     val len = s.length
@@ -77,7 +83,7 @@ object CharSWAR {
     val limit = to - 7
     while (i < limit) {
       val word = Intrinsics.loadLong(barr.atRawUnsafe(i))
-      if (swarHasMatch(word)) return true
+      if (swarMatchMask(word) != 0L) return true
       i += 8
     }
     // Tail: remaining 0-7 bytes
@@ -97,13 +103,9 @@ object CharSWAR {
     val limit = to - 7
     while (i < limit) {
       val word = Intrinsics.loadLong(barr.atRawUnsafe(i))
-      if (swarHasMatch(word)) {
-        var j = i
-        while (j < i + 8) {
-          val b = arr(j) & 0xff
-          if (b < 32 || b == '"' || b == '\\') return j
-          j += 1
-        }
+      val mask = swarMatchMask(word)
+      if (mask != 0L) {
+        return i + firstMatchedByte(mask)
       }
       i += 8
     }

--- a/sjsonnet/src/sjsonnet/BaseByteRenderer.scala
+++ b/sjsonnet/src/sjsonnet/BaseByteRenderer.scala
@@ -307,13 +307,14 @@ class BaseByteRenderer[T <: java.io.OutputStream](
   }
 
   /**
-   * SWAR-accelerated path for long strings. Converts to UTF-8 bytes once, scans with SWAR, and
-   * bulk-copies if clean. The getBytes allocation is amortized by avoiding per-char processing.
+   * SWAR-accelerated path for long strings. Converts to UTF-8 bytes once, then bulk-copies clean
+   * chunks and escapes only the bytes that require it.
    */
   private def visitLongString(str: String): Unit = {
     val bytes = str.getBytes(java.nio.charset.StandardCharsets.UTF_8)
-    if (!CharSWAR.hasEscapeChar(bytes, 0, bytes.length)) {
-      val bLen = bytes.length
+    val bLen = bytes.length
+    val firstEscape = CharSWAR.findFirstEscapeChar(bytes, 0, bLen)
+    if (firstEscape < 0) {
       elemBuilder.ensureLength(bLen + 2)
       val arr = elemBuilder.arr
       val pos = elemBuilder.length
@@ -322,13 +323,87 @@ class BaseByteRenderer[T <: java.io.OutputStream](
       arr(pos + 1 + bLen) = '"'.toByte
       elemBuilder.length = pos + bLen + 2
     } else {
-      upickle.core.RenderUtils.escapeByte(
-        unicodeCharBuilder,
-        elemBuilder,
-        str,
-        escapeUnicode = false,
-        wrapQuotes = true
-      )
+      val escapedLen = escapedStringLength(bytes, bLen, firstEscape)
+      elemBuilder.ensureLength(escapedLen)
+      elemBuilder.appendUnsafeC('"')
+      var from = 0
+      var escPos = firstEscape
+      while (escPos >= 0) {
+        if (escPos > from) {
+          val chunkLen = escPos - from
+          elemBuilder.ensureLength(chunkLen)
+          val arr = elemBuilder.arr
+          val pos = elemBuilder.length
+          System.arraycopy(bytes, from, arr, pos, chunkLen)
+          elemBuilder.length = pos + chunkLen
+        }
+        escapeByteInline(bytes(escPos) & 0xff)
+        from = escPos + 1
+        escPos = if (from < bLen) CharSWAR.findFirstEscapeChar(bytes, from, bLen) else -1
+      }
+      if (from < bLen) {
+        val tailLen = bLen - from
+        elemBuilder.ensureLength(tailLen)
+        val arr = elemBuilder.arr
+        val pos = elemBuilder.length
+        System.arraycopy(bytes, from, arr, pos, tailLen)
+        elemBuilder.length = pos + tailLen
+      }
+      elemBuilder.ensureLength(1)
+      elemBuilder.appendUnsafeC('"')
+    }
+  }
+
+  private def escapedStringLength(bytes: Array[Byte], bLen: Int, firstEscape: Int): Int = {
+    var len = bLen + 2
+    var from = firstEscape
+    var escPos = firstEscape
+    while (escPos >= 0) {
+      len += escapeExtraLength(bytes(escPos) & 0xff)
+      from = escPos + 1
+      escPos = if (from < bLen) CharSWAR.findFirstEscapeChar(bytes, from, bLen) else -1
+    }
+    len
+  }
+
+  @inline private def escapeExtraLength(b: Int): Int =
+    (b: @scala.annotation.switch) match {
+      case '"' | '\\' | '\b' | '\f' | '\n' | '\r' | '\t' => 1
+      case _                                             => 5
+    }
+
+  /** Inline JSON escape for one byte that is known to require escaping. */
+  private def escapeByteInline(b: Int): Unit = {
+    elemBuilder.ensureLength(6)
+    (b: @scala.annotation.switch) match {
+      case '"' =>
+        elemBuilder.appendUnsafeC('\\')
+        elemBuilder.appendUnsafeC('"')
+      case '\\' =>
+        elemBuilder.appendUnsafeC('\\')
+        elemBuilder.appendUnsafeC('\\')
+      case '\b' =>
+        elemBuilder.appendUnsafeC('\\')
+        elemBuilder.appendUnsafeC('b')
+      case '\f' =>
+        elemBuilder.appendUnsafeC('\\')
+        elemBuilder.appendUnsafeC('f')
+      case '\n' =>
+        elemBuilder.appendUnsafeC('\\')
+        elemBuilder.appendUnsafeC('n')
+      case '\r' =>
+        elemBuilder.appendUnsafeC('\\')
+        elemBuilder.appendUnsafeC('r')
+      case '\t' =>
+        elemBuilder.appendUnsafeC('\\')
+        elemBuilder.appendUnsafeC('t')
+      case c =>
+        elemBuilder.appendUnsafeC('\\')
+        elemBuilder.appendUnsafeC('u')
+        elemBuilder.appendUnsafeC('0')
+        elemBuilder.appendUnsafeC('0')
+        elemBuilder.appendUnsafeC(BaseByteRenderer.HEX_CHARS((c >> 4) & 0xf))
+        elemBuilder.appendUnsafeC(BaseByteRenderer.HEX_CHARS(c & 0xf))
     }
   }
 
@@ -376,6 +451,9 @@ object BaseByteRenderer {
     java.util.Arrays.fill(a, ' '.toByte)
     a
   }
+
+  /** Hex digits used by inline byte escaping for control chars. */
+  private[sjsonnet] val HEX_CHARS: Array[Char] = "0123456789abcdef".toCharArray
 
   /**
    * Reusable scratch buffer for writeLongDirect (max 20 bytes for Long.MinValue). Not thread-safe,

--- a/sjsonnet/src/sjsonnet/BaseByteRenderer.scala
+++ b/sjsonnet/src/sjsonnet/BaseByteRenderer.scala
@@ -325,32 +325,29 @@ class BaseByteRenderer[T <: java.io.OutputStream](
     } else {
       val escapedLen = escapedStringLength(bytes, bLen, firstEscape)
       elemBuilder.ensureLength(escapedLen)
-      elemBuilder.appendUnsafeC('"')
+      val arr = elemBuilder.arr
+      var outPos = elemBuilder.length
+      arr(outPos) = '"'.toByte
+      outPos += 1
       var from = 0
       var escPos = firstEscape
       while (escPos >= 0) {
         if (escPos > from) {
           val chunkLen = escPos - from
-          elemBuilder.ensureLength(chunkLen)
-          val arr = elemBuilder.arr
-          val pos = elemBuilder.length
-          System.arraycopy(bytes, from, arr, pos, chunkLen)
-          elemBuilder.length = pos + chunkLen
+          System.arraycopy(bytes, from, arr, outPos, chunkLen)
+          outPos += chunkLen
         }
-        escapeByteInline(bytes(escPos) & 0xff)
+        outPos = escapeByteInline(bytes(escPos) & 0xff, arr, outPos)
         from = escPos + 1
         escPos = if (from < bLen) CharSWAR.findFirstEscapeChar(bytes, from, bLen) else -1
       }
       if (from < bLen) {
         val tailLen = bLen - from
-        elemBuilder.ensureLength(tailLen)
-        val arr = elemBuilder.arr
-        val pos = elemBuilder.length
-        System.arraycopy(bytes, from, arr, pos, tailLen)
-        elemBuilder.length = pos + tailLen
+        System.arraycopy(bytes, from, arr, outPos, tailLen)
+        outPos += tailLen
       }
-      elemBuilder.ensureLength(1)
-      elemBuilder.appendUnsafeC('"')
+      arr(outPos) = '"'.toByte
+      elemBuilder.length = outPos + 1
     }
   }
 
@@ -373,37 +370,45 @@ class BaseByteRenderer[T <: java.io.OutputStream](
     }
 
   /** Inline JSON escape for one byte that is known to require escaping. */
-  private def escapeByteInline(b: Int): Unit = {
-    elemBuilder.ensureLength(6)
+  @inline private def escapeByteInline(b: Int, arr: Array[Byte], outPos0: Int): Int = {
+    val outPos = outPos0
     (b: @scala.annotation.switch) match {
       case '"' =>
-        elemBuilder.appendUnsafeC('\\')
-        elemBuilder.appendUnsafeC('"')
+        arr(outPos) = '\\'.toByte
+        arr(outPos + 1) = '"'.toByte
+        outPos + 2
       case '\\' =>
-        elemBuilder.appendUnsafeC('\\')
-        elemBuilder.appendUnsafeC('\\')
+        arr(outPos) = '\\'.toByte
+        arr(outPos + 1) = '\\'.toByte
+        outPos + 2
       case '\b' =>
-        elemBuilder.appendUnsafeC('\\')
-        elemBuilder.appendUnsafeC('b')
+        arr(outPos) = '\\'.toByte
+        arr(outPos + 1) = 'b'.toByte
+        outPos + 2
       case '\f' =>
-        elemBuilder.appendUnsafeC('\\')
-        elemBuilder.appendUnsafeC('f')
+        arr(outPos) = '\\'.toByte
+        arr(outPos + 1) = 'f'.toByte
+        outPos + 2
       case '\n' =>
-        elemBuilder.appendUnsafeC('\\')
-        elemBuilder.appendUnsafeC('n')
+        arr(outPos) = '\\'.toByte
+        arr(outPos + 1) = 'n'.toByte
+        outPos + 2
       case '\r' =>
-        elemBuilder.appendUnsafeC('\\')
-        elemBuilder.appendUnsafeC('r')
+        arr(outPos) = '\\'.toByte
+        arr(outPos + 1) = 'r'.toByte
+        outPos + 2
       case '\t' =>
-        elemBuilder.appendUnsafeC('\\')
-        elemBuilder.appendUnsafeC('t')
+        arr(outPos) = '\\'.toByte
+        arr(outPos + 1) = 't'.toByte
+        outPos + 2
       case c =>
-        elemBuilder.appendUnsafeC('\\')
-        elemBuilder.appendUnsafeC('u')
-        elemBuilder.appendUnsafeC('0')
-        elemBuilder.appendUnsafeC('0')
-        elemBuilder.appendUnsafeC(BaseByteRenderer.HEX_CHARS((c >> 4) & 0xf))
-        elemBuilder.appendUnsafeC(BaseByteRenderer.HEX_CHARS(c & 0xf))
+        arr(outPos) = '\\'.toByte
+        arr(outPos + 1) = 'u'.toByte
+        arr(outPos + 2) = '0'.toByte
+        arr(outPos + 3) = '0'.toByte
+        arr(outPos + 4) = BaseByteRenderer.HEX_BYTES((c >> 4) & 0xf)
+        arr(outPos + 5) = BaseByteRenderer.HEX_BYTES(c & 0xf)
+        outPos + 6
     }
   }
 
@@ -453,7 +458,24 @@ object BaseByteRenderer {
   }
 
   /** Hex digits used by inline byte escaping for control chars. */
-  private[sjsonnet] val HEX_CHARS: Array[Char] = "0123456789abcdef".toCharArray
+  private[sjsonnet] val HEX_BYTES: Array[Byte] = Array(
+    '0'.toByte,
+    '1'.toByte,
+    '2'.toByte,
+    '3'.toByte,
+    '4'.toByte,
+    '5'.toByte,
+    '6'.toByte,
+    '7'.toByte,
+    '8'.toByte,
+    '9'.toByte,
+    'a'.toByte,
+    'b'.toByte,
+    'c'.toByte,
+    'd'.toByte,
+    'e'.toByte,
+    'f'.toByte
+  )
 
   /**
    * Reusable scratch buffer for writeLongDirect (max 20 bytes for Long.MinValue). Not thread-safe,


### PR DESCRIPTION
Motivation:

Split the JMH-positive, JDK17/JIT/GC-friendly long-string rendering piece out of #776. Keep this PR focused on byte rendering for long strings that contain JSON escapes; this does not include the broader format, stdlib, compareStrings, or Scala Native experiments from #776.

Modification:

- Add `CharSWAR.findFirstEscapeChar(byte[], from, to)` on JVM, Scala.js, and Scala Native.
- In `BaseByteRenderer`, keep the existing UTF-8 byte array for long strings, locate escape bytes, bulk-copy clean chunks with `System.arraycopy`, and escape only matching bytes inline.
- Precompute the exact escaped output length, reserve `ByteBuilder` once, then write directly to the backing byte array. This removes repeated `ensureLength`/`appendUnsafeC` calls from the dirty long-string loop.
- Use a static byte hex table for `\u00XX` control escapes.

JIT / GC shape:

- Hot code stays in simple `while` loops, `System.arraycopy`, and small private helpers.
- No reflection, no internal JDK APIs, no closures/iterators in the rendering loop.
- No per-chunk or per-escape objects are allocated by this follow-up; the existing per-long-string UTF-8 byte array remains the only temporary for this path.
- I tested a no-allocation ASCII scalar path, but rejected it because it regressed `large_string_template` and `large_string_join` JMH.

Notable results only:

JMH target run, same machine, same command shape on `upstream/master` and this branch:

`./mill -i bench.runRegressions bench/resources/cpp_suite/large_string_template.jsonnet bench/resources/cpp_suite/large_string_join.jsonnet`

| Benchmark | upstream/master | PR | Delta |
| --- | ---: | ---: | ---: |
| `large_string_template` | 1.552 ms/op | 1.154 ms/op | -25.6% / 1.34x faster |

Scala Native hyperfine, release-full native binary, 20 runs:

| Benchmark | upstream/master | PR | Delta |
| --- | ---: | ---: | ---: |
| `large_string_template` | 10.5 +/- 0.2 ms | 9.6 +/- 0.3 ms | -8.6% / 1.09x faster |

`large_string_join` was rechecked as a guardrail and stayed neutral, so it is intentionally omitted from the result tables.

Verification:

- `./mill -i 'sjsonnet.jvm[3.3.7].compile'`
- `./mill -i 'sjsonnet.jvm[3.3.7].test'`
- `./mill -i 'sjsonnet.js[3.3.7].compile' 'sjsonnet.native[3.3.7].compile'`
- `./mill -i 'sjsonnet.native[3.3.7].nativeLink'`
- `./mill -i __.checkFormat`
- `git diff --check`
- Focused JMH and Native hyperfine commands above

References:

- Split from #776
- Base: `b4c667d55d82d7c50c2103db967c33bebb0c2c98`
- Head: `ff70b63e`
