### PR TITLE
perf: optimize array stdlib hot paths

### DIFF
--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -8,6 +8,7 @@ import scala.annotation.{nowarn, tailrec}
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
+import scala.util.control.NonFatal
 
 /**
  * [[Eval]] is the common parent trait for both lazy and eager evaluation, providing a unified
@@ -126,6 +127,21 @@ final class LazyApply2(
       val r = funcOrVal.asInstanceOf[Val.Func].apply2(arg1, arg2, pos)(ev, TailstrictModeDisabled)
       funcOrVal = r
       arg1 = null; arg2 = null; pos = null; ev = null
+      r
+    }
+  }
+}
+
+private final class LazyIndexedElem(private var owner: Val.LazyIndexedArr, private val index: Int)
+    extends Lazy {
+  private var cached: Val = _
+  def value: Val = {
+    val o = owner
+    if (o == null) cached
+    else {
+      val r = o.value(index)
+      cached = r
+      owner = null
       r
     }
   }
@@ -695,6 +711,129 @@ object Val {
     }
   }
 
+  object LazyIndexedArr {
+    private object Computing
+  }
+
+  private[sjsonnet] abstract class LazyIndexedArr(pos0: Position, size: Int)
+      extends Arr(pos0, null) {
+    import LazyIndexedArr.*
+
+    _length = size
+    // Compact slot state:
+    //   null       = never evaluated
+    //   Computing  = currently evaluating this index
+    //   Val        = cached successful result
+    //
+    // Exceptions intentionally reset the slot to null rather than being cached. That matches the
+    // existing LazyFunc/LazyExpr behavior and avoids changing observable std.trace/error behavior
+    // on repeated failed evaluation.
+    private[this] var slots: Array[AnyRef] = null
+
+    protected def computeValue(i: Int): Val
+
+    protected def errorScope: EvalErrorScope
+
+    private[this] def ensureSlots(): Array[AnyRef] = {
+      val current = slots
+      if (current != null) current
+      else {
+        val fresh = new Array[AnyRef](_length)
+        slots = fresh
+        fresh
+      }
+    }
+
+    override def value(i: Int): Val = {
+      val currentSlots = slots
+      if (currentSlots != null) {
+        currentSlots(i) match {
+          case null      =>
+          case Computing => Error.fail("Infinite recursion detected", pos0)(errorScope)
+          case v         => return v.asInstanceOf[Val]
+        }
+      }
+      val target = ensureSlots()
+      target(i) = Computing
+      try {
+        val computed = computeValue(i)
+        target(i) = computed
+        computed
+      } catch {
+        case NonFatal(e) =>
+          target(i) = null
+          throw e
+      }
+    }
+
+    override def eval(i: Int): Eval = {
+      val currentSlots = slots
+      if (currentSlots != null) {
+        currentSlots(i) match {
+          case v: Val => return v
+          case _      =>
+        }
+      }
+      new LazyIndexedElem(this, i)
+    }
+
+    override def asLazyArray: Array[Eval] = {
+      val len = _length
+      val result = new Array[Eval](len)
+      val currentSlots = slots
+      var i = 0
+      while (i < len) {
+        result(i) =
+          if (currentSlots == null) new LazyIndexedElem(this, i)
+          else
+            currentSlots(i) match {
+              case v: Val => v
+              case _      => new LazyIndexedElem(this, i)
+            }
+        i += 1
+      }
+      result
+    }
+
+    override def reversed(newPos: Position): Arr = {
+      val result = Arr(newPos, asLazyArray)
+      result._reversed = true
+      result
+    }
+  }
+
+  private final class RepeatedArr(pos0: Position, private[this] val source: Arr, count: Int)
+      extends Arr(pos0, null) {
+    // Keep std.repeat(array, n) as an indexed view. The common consumers either index a subset or
+    // materialize later anyway; eagerly copying here multiplies thunks and stresses young-gen GC.
+    private[this] val sourceLen = source.length
+    private[this] val totalLen = sourceLen.toLong * count.toLong
+    if (totalLen > Int.MaxValue) throw new IllegalArgumentException("array too large")
+    _length = totalLen.toInt
+
+    override def value(i: Int): Val =
+      source.value(i % sourceLen)
+
+    override def eval(i: Int): Eval =
+      source.eval(i % sourceLen)
+
+    override def asLazyArray: Array[Eval] = {
+      val sourceArr = source.asLazyArray
+      val sourceLen = this.sourceLen
+      val len = _length
+      val result = new Array[Eval](len)
+      var offset = 0
+      while (offset < len) {
+        System.arraycopy(sourceArr, 0, result, offset, sourceLen)
+        offset += sourceLen
+      }
+      result
+    }
+
+    override def reversed(newPos: Position): Arr =
+      new RepeatedArr(newPos, source.reversed(newPos), count)
+  }
+
   /**
    * Lazy range array representing the integer sequence [from, from+1, ..., from+size-1]. Separate
    * subclass keeps the `rangeFrom` field out of regular `Arr` instances, saving ~9 bytes per
@@ -826,6 +965,10 @@ object Val {
 
   object Arr {
     def apply(pos: Position, arr: Array[? <: Eval]): Arr = new Arr(pos, arr)
+
+    def repeated(pos: Position, source: Arr, count: Int): Arr =
+      if (count == 0 || source.length == 0) Arr(pos, EMPTY_EVAL_ARRAY)
+      else new RepeatedArr(pos, source, count)
 
     /** Create a byte-backed array from raw bytes (e.g. base64DecodeBytes output). */
     def fromBytes(pos: Position, bytes: Array[Byte]): Arr = new ByteArr(pos, bytes)
@@ -1604,6 +1747,23 @@ object Val {
       TailCall.resolve(evalRhs(scope, ev, fs, pos))(ev)
 
     def evalDefault(expr: Expr, vs: ValScope, es: EvalScope): Val = null
+
+    final private[sjsonnet] def isIdentityFunction: Boolean =
+      params.names.length == 1 && {
+        bodyExpr match {
+          case id: Expr.ValidId => id.nameIdx == defSiteValScope.length
+          case _                => false
+        }
+      }
+
+    final private[sjsonnet] def isUnaryMinusParamFunction: Boolean =
+      params.names.length == 1 && {
+        bodyExpr match {
+          case Expr.UnaryOp(_, Expr.UnaryOp.OP_-, id: Expr.ValidId) =>
+            id.nameIdx == defSiteValScope.length
+          case _ => false
+        }
+      }
 
     /** Override to provide a function name for error messages. Only called on error paths. */
     def functionName: String = null

--- a/sjsonnet/src/sjsonnet/stdlib/ArrayModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/ArrayModule.scala
@@ -276,28 +276,27 @@ object ArrayModule extends AbstractFunctionModule {
       val arg = arr.value
       arg match {
         case Val.Str(_, str) => evalStr(func, str, ev, pos.noOffset)
-        case _               => evalArr(func, arg.asArr.asLazyArray, ev, pos)
+        case _               => evalArr(func, arg.asArr, ev, pos)
       }
     }
 
-    private def evalArr(
-        _func: Val.Func,
-        arg: Array[Eval],
-        ev: EvalScope,
-        pos: Position): Val.Arr = {
+    private def evalArr(_func: Val.Func, arg: Val.Arr, ev: EvalScope, pos: Position): Val.Arr = {
+      // Keep map as per-element LazyApply1 thunks. On the JVM this is faster for the common
+      // "map then fully consume" path than an indexed view with a shared state side table, while
+      // still preserving lazy element evaluation.
       val noOff = pos.noOffset
-      // Pre-sized array with while-loop avoids .map closure overhead
-      val result = new Array[Eval](arg.length)
+      val len = arg.length
+      val result = new Array[Eval](len)
       var i = 0
-      while (i < arg.length) {
-        result(i) = new LazyApply1(_func, arg(i), noOff, ev)
+      while (i < len) {
+        result(i) = new LazyApply1(_func, arg.eval(i), noOff, ev)
         i += 1
       }
       Val.Arr(pos, result)
     }
 
     private def evalStr(_func: Val.Func, arg: String, ev: EvalScope, pos: Position): Val.Arr = {
-      evalArr(_func, stringChars(pos, arg).asLazyArray, ev, pos)
+      evalArr(_func, stringChars(pos, arg), ev, pos)
     }
   }
 
@@ -870,15 +869,9 @@ object ArrayModule extends AbstractFunctionModule {
           }
           Val.Str(pos, builder.toString())
         case a: Val.Arr =>
-          val lazyArray = a.asLazyArray
-          val elemLen = lazyArray.length
-          val result = new Array[Eval](elemLen * count)
-          var i = 0
-          while (i < count) {
-            System.arraycopy(lazyArray, 0, result, i * elemLen, elemLen)
-            i += 1
-          }
-          Val.Arr(pos, result)
+          if (a.length.toLong * count.toLong > Int.MaxValue)
+            Error.fail("array too large", pos)(ev)
+          Val.Arr.repeated(pos, a, count)
         case x => Error.fail("std.repeat first argument must be an array or a string")
       }
       res

--- a/sjsonnet/src/sjsonnet/stdlib/EncodingModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/EncodingModule.scala
@@ -3,6 +3,8 @@ package sjsonnet.stdlib
 import sjsonnet._
 import sjsonnet.functions.AbstractFunctionModule
 
+import java.nio.charset.StandardCharsets.UTF_8
+
 /**
  * Native implementations for Jsonnet standard-library entries in this module.
  *
@@ -47,26 +49,28 @@ object EncodingModule extends AbstractFunctionModule {
     builtin("base64", "input") { (pos, _, input: Val) =>
       (input match {
         case Val.Str(_, value) =>
-          Val.Str.asciiSafe(pos, PlatformBase64.encodeToString(value.getBytes("UTF-8")))
+          Val.Str.asciiSafe(pos, PlatformBase64.encodeToString(value.getBytes(UTF_8)))
         case ba: Val.ByteArr =>
           Val.Str.asciiSafe(pos, PlatformBase64.encodeToString(ba.rawBytes))
         case arr: Val.Arr =>
-          val byteArr = new Array[Byte](arr.length)
+          val len = arr.length
+          val byteArr = new Array[Byte](len)
           var i = 0
-          while (i < arr.length) {
-            val v = arr.value(i)
-            if (!v.isInstanceOf[Val.Num]) {
-              Error.fail(
-                f"Expected an array of numbers, got a ${v.prettyName} at position $i"
-              )
+          while (i < len) {
+            arr.value(i) match {
+              case v: Val.Num =>
+                val vInt = v.asInt
+                if (vInt < 0 || vInt > 255) {
+                  Error.fail(
+                    f"Found an invalid codepoint value at position $i (must be 0 <= X <= 255), got $vInt"
+                  )
+                }
+                byteArr(i) = vInt.toByte
+              case v =>
+                Error.fail(
+                  f"Expected an array of numbers, got a ${v.prettyName} at position $i"
+                )
             }
-            val vInt = v.asInt
-            if (vInt < 0 || vInt > 255) {
-              Error.fail(
-                f"Found an invalid codepoint value at position $i (must be 0 <= X <= 255), got $vInt"
-              )
-            }
-            byteArr(i) = vInt.toByte
             i += 1
           }
           Val.Str.asciiSafe(pos, PlatformBase64.encodeToString(byteArr))
@@ -86,7 +90,7 @@ object EncodingModule extends AbstractFunctionModule {
      */
     builtin("base64Decode", "str") { (_, _, str: String) =>
       try {
-        new String(PlatformBase64.decode(str), "UTF-8")
+        new String(PlatformBase64.decode(str), UTF_8)
       } catch {
         case e: IllegalArgumentException =>
           Error.fail("Invalid base64 string: " + e.getMessage)

--- a/sjsonnet/src/sjsonnet/stdlib/ObjectModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/ObjectModule.scala
@@ -264,15 +264,59 @@ object ObjectModule extends AbstractFunctionModule {
       pos: Position,
       ev: EvalScope,
       v1: Val.Obj,
-      keys: Array[String]): Val.Arr = {
-    val result = new Array[Eval](keys.length)
-    var i = 0
-    while (i < keys.length) {
+      keys: Array[String]): Val.Arr =
+    new ObjectValuesArr(pos, v1, keys, ev)
+
+  private final class ObjectValuesArr(
+      pos0: Position,
+      private[this] val source: Val.Obj,
+      private[this] val keys: Array[String],
+      private[this] val ev: EvalScope)
+      extends Val.LazyIndexedArr(pos0, keys.length) {
+    private[this] val fieldPos = pos0.noOffset
+
+    protected def computeValue(i: Int): Val =
+      source.value(keys(i), fieldPos)(ev)
+
+    protected def errorScope: EvalErrorScope = ev
+  }
+
+  private final class ObjectKeysValuesArr(
+      pos0: Position,
+      private[this] val source: Val.Obj,
+      private[this] val keys: Array[String],
+      private[this] val ev: EvalScope)
+      extends Val.LazyIndexedArr(pos0, keys.length) {
+    private[this] val fieldPos = pos0.fileScope.noOffsetPos
+
+    protected def computeValue(i: Int): Val = {
       val k = keys(i)
-      result(i) = new LazyFunc(() => v1.value(k, pos.noOffset)(ev))
-      i += 1
+      // Keep the generated object's value field lazy. Callers often inspect only key fields after
+      // objectKeysValues; forcing every source field here defeats Jsonnet's object-field laziness and
+      // creates avoidable work on large objects.
+      Val.Obj.mk(
+        fieldPos,
+        "key" -> new Val.Obj.ConstMember(false, Visibility.Normal, Val.Str(fieldPos, k)),
+        "value" -> new ObjectKeyValueMember(source, k, fieldPos, ev)
+      )
     }
-    Val.Arr(pos, result)
+
+    protected def errorScope: EvalErrorScope = ev
+  }
+
+  private final class ObjectKeyValueMember(
+      private[this] val source: Val.Obj,
+      private[this] val key: String,
+      private[this] val pos: Position,
+      private[this] val ev: EvalScope)
+      extends Val.Obj.Member(
+        false,
+        Visibility.Normal,
+        cached = true,
+        deprecatedSkipAsserts = true
+      ) {
+    def invoke(self: Val.Obj, sup: Val.Obj, fs: FileScope, callerEv: EvalScope): Val =
+      source.value(key, pos)(ev)
   }
 
   val functions: Seq[(String, Val.Func)] = Seq(
@@ -303,23 +347,7 @@ object ObjectModule extends AbstractFunctionModule {
      */
     builtin("objectKeysValues", "o") { (pos, ev, o: Val.Obj) =>
       val keys = getVisibleKeys(ev, o)
-      val noOffsetPos = pos.fileScope.noOffsetPos
-      val result = new Array[Eval](keys.length)
-      var i = 0
-      while (i < keys.length) {
-        val k = keys(i)
-        result(i) = Val.Obj.mk(
-          noOffsetPos,
-          "key" -> new Val.Obj.ConstMember(false, Visibility.Normal, Val.Str(noOffsetPos, k)),
-          "value" -> new Val.Obj.ConstMember(
-            false,
-            Visibility.Normal,
-            o.value(k, noOffsetPos)(ev)
-          )
-        )
-        i += 1
-      }
-      Val.Arr(pos, result)
+      (new ObjectKeysValuesArr(pos, o, keys, ev): Val.Arr)
     },
     /**
      * [[https://jsonnet.org/ref/stdlib.html#std-objectKeysValuesAll std.objectKeysValuesAll(o)]].
@@ -330,23 +358,7 @@ object ObjectModule extends AbstractFunctionModule {
      */
     builtin("objectKeysValuesAll", "o") { (pos, ev, o: Val.Obj) =>
       val keys = getAllKeys(ev, o)
-      val noOffsetPos = pos.fileScope.noOffsetPos
-      val result = new Array[Eval](keys.length)
-      var i = 0
-      while (i < keys.length) {
-        val k = keys(i)
-        result(i) = Val.Obj.mk(
-          noOffsetPos,
-          "key" -> new Val.Obj.ConstMember(false, Visibility.Normal, Val.Str(noOffsetPos, k)),
-          "value" -> new Val.Obj.ConstMember(
-            false,
-            Visibility.Normal,
-            o.value(k, noOffsetPos)(ev)
-          )
-        )
-        i += 1
-      }
-      Val.Arr(pos, result)
+      (new ObjectKeysValuesArr(pos, o, keys, ev): Val.Arr)
     },
     /**
      * [[https://jsonnet.org/ref/stdlib.html#std-objectRemoveKey std.objectRemoveKey(obj, key)]].

--- a/sjsonnet/src/sjsonnet/stdlib/SetModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/SetModule.scala
@@ -27,6 +27,9 @@ object SetModule extends AbstractFunctionModule {
 
   @inline private def isDefaultKeyF(v: Val): Boolean = v.asInstanceOf[AnyRef] eq DefaultKeyF
 
+  @inline private def isIdentityKeyF(v: Val): Boolean =
+    v == null || isDefaultKeyF(v) || (v.isInstanceOf[Val.Func] && v.asFunc.isIdentityFunction)
+
   /**
    * [[https://jsonnet.org/ref/stdlib.html#std-set std.set(arr, keyF=id)]].
    *
@@ -41,7 +44,7 @@ object SetModule extends AbstractFunctionModule {
   }
 
   private def applyKeyFunc(elem: Val, keyF: Val, pos: Position, ev: EvalScope): Val = {
-    if (isDefaultKeyF(keyF)) elem
+    if (isIdentityKeyF(keyF)) elem
     else keyF.asFunc.apply1(elem, pos.noOffset)(ev, TailstrictModeDisabled).value
   }
 
@@ -111,7 +114,7 @@ object SetModule extends AbstractFunctionModule {
     while (i < arrValue.length) {
       val v = arrValue(i)
       val vKey =
-        if (isDefaultKeyF(keyF)) v.value
+        if (isIdentityKeyF(keyF)) v.value
         else keyF.asFunc.apply1(v, pos.noOffset)(ev, TailstrictModeDisabled)
       if (lastAddedKey == null || !ev.equal(vKey, lastAddedKey)) {
         out.+=(v)
@@ -126,11 +129,19 @@ object SetModule extends AbstractFunctionModule {
   private def sortArr(pos: Position, ev: EvalScope, arr: Val, keyF: Val): Val = {
     // Fast path: range arrays are already sorted ascending by construction.
     // Avoids O(n) materialization + O(n log n) sort for already-sorted data.
-    if (keyF == null || keyF.isInstanceOf[Val.False]) {
+    if (isIdentityKeyF(keyF) || keyF.isInstanceOf[Val.False]) {
       arr match {
         case a: Val.Arr =>
           val sorted = a.asSortedIfKnown(pos)
           if (sorted != null) return sorted
+        case _ =>
+      }
+    }
+    if (keyF != null && keyF.isInstanceOf[Val.Func] && keyF.asFunc.isUnaryMinusParamFunction) {
+      arr match {
+        case a: Val.Arr =>
+          val sorted = a.asSortedIfKnown(pos)
+          if (sorted != null) return sorted.reversed(pos)
         case _ =>
       }
     }
@@ -143,7 +154,7 @@ object SetModule extends AbstractFunctionModule {
       arr
     } else {
       val keyFFunc =
-        if (keyF == null || isDefaultKeyF(keyF)) null else keyF.asFunc
+        if (isIdentityKeyF(keyF)) null else keyF.asFunc
       Val.Arr(
         pos,
         if (keyFFunc != null) {

--- a/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
+++ b/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
@@ -13,6 +13,8 @@ object EvaluatorTests extends TestSuite {
     }
     test("objects") {
       eval("{x: 1}.x") ==> ujson.Num(1)
+      eval("std.objectKeysValues({a: error 'unused'})[0].key") ==> ujson.Str("a")
+      assert(evalErr("std.objectKeysValues({a: error 'boom'})[0].value").contains("boom"))
     }
     test("arrays") {
       eval("[1, [2, 3], 4][1][0]") ==> ujson.Num(2)

--- a/sjsonnet/test/src/sjsonnet/StdMapTests.scala
+++ b/sjsonnet/test/src/sjsonnet/StdMapTests.scala
@@ -14,6 +14,8 @@ object StdMapTests extends TestSuite {
 
       // Test lazy evaluation
       eval("std.map(function(x) assert x != 'A'; x + x, 'AB')[1]") ==> ujson.Str("BB")
+      eval("std.map(function(x) x, [error 'unused', 1])[1]") ==> ujson.Num(1)
+      eval("local f = error 'unused'; std.map(function(x) f(f(x)), [])") ==> ujson.Arr()
 
       // Test returning arbitrary values from the mapping function
       eval("std.map(function(x) std.codepoint(x), 'AB')") ==> ujson.Arr(65, 66)

--- a/sjsonnet/test/src/sjsonnet/StdWithKeyFTests.scala
+++ b/sjsonnet/test/src/sjsonnet/StdWithKeyFTests.scala
@@ -54,6 +54,7 @@ object StdWithKeyFTests extends TestSuite {
       eval("""std.sort([1, 2, 3])""").toString() ==> """[1,2,3]"""
       eval("""std.sort([1,2,3], keyF=function(x) -x)""").toString() ==> """[3,2,1]"""
       eval("""std.sort([1,2,3], function(x) -x)""").toString() ==> """[3,2,1]"""
+      eval("""local f = error "unused"; std.sort([], function(x) f(f(x)))""").toString() ==> "[]"
       eval(
         """std.sort([[1,'b'], [2], [1], [], [1,'a']])"""
       ).toString() ==> """[[],[1],[1,"a"],[1,"b"],[2]]"""


### PR DESCRIPTION
## Summary

This PR now keeps only generic stdlib hot-path improvements. In response to review, it removes the benchmark-specific identity-composition proof for `function(x) f(f(x))` chains and also removes the `std.map(function(x) x, arr)` identity shortcut. The `bench.07` identity-composition benchmark is intentionally no longer used as evidence for this PR.

- Add `LazyIndexedArr` for object value/key-value lazy indexed views, keeping `std.objectKeysValues(...)[i].key` from forcing `.value`.
- Make `std.repeat(array, count)` an indexed view, while keeping the old `System.arraycopy` bulk materialization path for `asLazyArray`.
- Keep `std.map` as per-element `LazyApply1` thunks, but read source arrays through `arr.eval(i)` so existing array views do not have to materialize first.
- Optimize standard set/sort `keyF=id` and `function(x) -x` range paths.
- Use `StandardCharsets.UTF_8` and a tighter base64 array loop.

JVM/code-quality notes:

- Broader `MappedArr` / `MakeArrayArr` indexed views are intentionally not included; local JMH showed they regress common JVM full-consumption paths because the shared state side table adds dispatch and memory traffic.
- `LazyIndexedArr` caches successful values only. Exceptions reset the slot to `null`, matching existing `LazyFunc` / `LazyExpr` retry behavior and avoiding observable `std.trace`/error behavior changes.
- The remaining function identity check is limited to structural `keyF=id` handling in set/sort-style APIs, not general function application or benchmark-specific composition proving.

## Correctness

Added coverage for:

- `std.objectKeysValues({a: error ...})[0].key` not forcing `.value`
- `std.objectKeysValues({a: error ...})[0].value` still forcing and reporting the source error
- `std.map` laziness on arrays, without a map identity fast path
- empty `std.map` / `std.sort` not forcing callback bodies

Ran:

- `./mill -i 'sjsonnet.jvm[3.3.7].test.testOnly' sjsonnet.StdMapTests sjsonnet.StdWithKeyFTests sjsonnet.TailCallOptimizationTests sjsonnet.EvaluatorTests`
- `./mill -i 'sjsonnet.jvm[3.3.7].test'`
- `./mill -i '__.checkFormat'`
- `./mill -i 'sjsonnet.js[3.3.7].compile'`
- `./mill -i 'sjsonnet.native[3.3.7].compile'`
- `git diff --check`

## Benchmarks

Environment: same machine, Zulu JDK 21.0.10, G1GC, `-Xss100m`, JMH 1.37. Lower is better. This table excludes `bench.07` because that workload is specifically the identity-composition case discussed in review.

Command:

```bash
./mill -i bench.runRegressions \
  bench/resources/cpp_suite/bench.04.jsonnet \
  bench/resources/cpp_suite/bench.06.jsonnet \
  bench/resources/cpp_suite/bench.09.jsonnet \
  bench/resources/cpp_suite/gen_big_object.jsonnet \
  bench/resources/go_suite/base64_stress.jsonnet \
  bench/resources/cpp_suite/large_string_join.jsonnet
```

| benchmark | master | PR | result |
| --- | ---: | ---: | ---: |
| `bench.04` | 0.105 ms/op | 0.105 ms/op | neutral |
| `bench.06` | 0.209 ms/op | 0.137 ms/op | 1.53x faster |
| `bench.09` | 0.041 ms/op | 0.038 ms/op | neutral |
| `gen_big_object` | 0.859 ms/op | 0.792 ms/op | neutral |
| `base64_stress` | 0.172 ms/op | 0.173 ms/op | neutral |
| `large_string_join` | 0.538 ms/op | 0.537 ms/op | neutral |
