### PR TITLE
Optimize default set operations

### DIFF
--- a/sjsonnet/src/sjsonnet/stdlib/SetModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/SetModule.scala
@@ -53,6 +53,165 @@ object SetModule extends AbstractFunctionModule {
     }
   }
 
+  @inline private def trimSetOutput(out: Array[Eval], len: Int): Array[Eval] = {
+    if (len == out.length) out
+    else java.util.Arrays.copyOf(out, len)
+  }
+
+  @inline private def compareDefaultSetKeys(ev: EvalScope, a: Val, b: Val): Int = {
+    a match {
+      case aNum: Val.Num =>
+        b match {
+          case bNum: Val.Num => java.lang.Double.compare(aNum.asDouble, bNum.asDouble)
+          case _             => ev.compare(a, b)
+        }
+      case aStr: Val.Str =>
+        b match {
+          case bStr: Val.Str => Util.compareStringsByCodepoint(aStr.str, bStr.str)
+          case _             => ev.compare(a, b)
+        }
+      case _ => ev.compare(a, b)
+    }
+  }
+
+  // WHY: default-key set operations are hot in numeric/string workloads. Keep the current
+  // forced key at each cursor and compare primitive-like values directly; this avoids repeated
+  // Eval.value calls and generic ev.compare dispatch without changing keyF semantics.
+  private def setUnionDefaultKeyF(
+      pos: Position,
+      ev: EvalScope,
+      a: Array[? <: Eval],
+      b: Array[? <: Eval]): Val.Arr = {
+    val out = new Array[Eval](a.length + b.length)
+
+    var outLen = 0
+    var idxA = 0
+    var idxB = 0
+    var elemA = a(idxA).value
+    var elemB = b(idxB).value
+
+    while (idxA < a.length && idxB < b.length) {
+      val cmp = compareDefaultSetKeys(ev, elemA, elemB)
+      if (cmp < 0) {
+        out(outLen) = a(idxA)
+        outLen += 1
+        idxA += 1
+        if (idxA < a.length) elemA = a(idxA).value
+      } else if (cmp > 0) {
+        out(outLen) = b(idxB)
+        outLen += 1
+        idxB += 1
+        if (idxB < b.length) elemB = b(idxB).value
+      } else {
+        out(outLen) = a(idxA)
+        outLen += 1
+        idxA += 1
+        idxB += 1
+        if (idxA < a.length && idxB < b.length) {
+          elemA = a(idxA).value
+          elemB = b(idxB).value
+        }
+      }
+    }
+
+    while (idxA < a.length) {
+      out(outLen) = a(idxA)
+      outLen += 1
+      idxA += 1
+    }
+    while (idxB < b.length) {
+      out(outLen) = b(idxB)
+      outLen += 1
+      idxB += 1
+    }
+
+    Val.Arr(pos, trimSetOutput(out, outLen))
+  }
+
+  private def setInterDefaultKeyF(
+      pos: Position,
+      ev: EvalScope,
+      a: Array[? <: Eval],
+      b: Array[? <: Eval]): Val.Arr = {
+    if (a.isEmpty || b.isEmpty) return Val.Arr(pos, Array.empty[Eval])
+
+    val out = new Array[Eval](math.min(a.length, b.length))
+
+    var outLen = 0
+    var idxA = 0
+    var idxB = 0
+    var elemA = a(idxA).value
+    var elemB = b(idxB).value
+
+    while (idxA < a.length && idxB < b.length) {
+      val cmp = compareDefaultSetKeys(ev, elemA, elemB)
+      if (cmp < 0) {
+        idxA += 1
+        if (idxA < a.length) elemA = a(idxA).value
+      } else if (cmp > 0) {
+        idxB += 1
+        if (idxB < b.length) elemB = b(idxB).value
+      } else {
+        out(outLen) = a(idxA)
+        outLen += 1
+        idxA += 1
+        idxB += 1
+        if (idxA < a.length && idxB < b.length) {
+          elemA = a(idxA).value
+          elemB = b(idxB).value
+        }
+      }
+    }
+
+    Val.Arr(pos, trimSetOutput(out, outLen))
+  }
+
+  private def setDiffDefaultKeyF(
+      pos: Position,
+      ev: EvalScope,
+      a: Array[? <: Eval],
+      b: Array[? <: Eval]): Val.Arr = {
+    if (a.isEmpty) return Val.Arr(pos, Array.empty[Eval])
+
+    val out = new Array[Eval](a.length)
+
+    var outLen = 0
+    var idxA = 0
+    var idxB = 0
+    var elemB: Val = null
+
+    while (idxA < a.length) {
+      val elemA = a(idxA).value
+      var foundEqual = false
+      var continue = true
+
+      while (idxB < b.length && continue) {
+        if (elemB == null) elemB = b(idxB).value
+        val cmp = compareDefaultSetKeys(ev, elemA, elemB)
+        if (cmp <= 0) {
+          foundEqual = cmp == 0
+          if (foundEqual) {
+            idxB += 1
+            elemB = null
+          }
+          continue = false
+        } else {
+          idxB += 1
+          elemB = null
+        }
+      }
+
+      if (!foundEqual) {
+        out(outLen) = a(idxA)
+        outLen += 1
+      }
+
+      idxA += 1
+    }
+
+    Val.Arr(pos, trimSetOutput(out, outLen))
+  }
+
   private def validateSet(ev: EvalScope, pos: Position, keyF: Val, arr: Val): Unit = {
     if (ev.settings.throwErrorForInvalidSets) {
       val sorted = uniqArr(pos.noOffset, ev, sortArr(pos.noOffset, ev, arr, keyF), keyF)
@@ -325,6 +484,8 @@ object SetModule extends AbstractFunctionModule {
           args(1)
         } else if (b.isEmpty) {
           args(0)
+        } else if (isDefaultKeyF(keyF)) {
+          setUnionDefaultKeyF(pos, ev, a, b)
         } else {
           val out = new mutable.ArrayBuilder.ofRef[Eval]
           out.sizeHint(a.length + b.length)
@@ -385,36 +546,40 @@ object SetModule extends AbstractFunctionModule {
         val a = toArrOrString(args(0), pos, ev)
         val b = toArrOrString(args(1), pos, ev)
 
-        val out = new mutable.ArrayBuilder.ofRef[Eval]
-        // Set a reasonable size hint - intersection will be at most the size of the smaller set
-        out.sizeHint(math.min(a.length, b.length))
+        if (isDefaultKeyF(keyF)) {
+          setInterDefaultKeyF(pos, ev, a, b)
+        } else {
+          val out = new mutable.ArrayBuilder.ofRef[Eval]
+          // Set a reasonable size hint - intersection will be at most the size of the smaller set
+          out.sizeHint(math.min(a.length, b.length))
 
-        var idxA = 0
-        var idxB = 0
+          var idxA = 0
+          var idxB = 0
 
-        while (idxA < a.length && idxB < b.length) {
-          val elemA = a(idxA).value
-          val elemB = b(idxB).value
+          while (idxA < a.length && idxB < b.length) {
+            val elemA = a(idxA).value
+            val elemB = b(idxB).value
 
-          val keyA = applyKeyFunc(elemA, keyF, pos, ev)
-          val keyB = applyKeyFunc(elemB, keyF, pos, ev)
+            val keyA = applyKeyFunc(elemA, keyF, pos, ev)
+            val keyB = applyKeyFunc(elemB, keyF, pos, ev)
 
-          val cmp = ev.compare(keyA, keyB)
-          if (cmp < 0) {
-            // keyA < keyB, elemA not in intersection
-            idxA += 1
-          } else if (cmp > 0) {
-            // keyA > keyB, elemB not in intersection
-            idxB += 1
-          } else {
-            // keyA == keyB, found intersection element
-            out.+=(a(idxA))
-            idxA += 1
-            idxB += 1
+            val cmp = ev.compare(keyA, keyB)
+            if (cmp < 0) {
+              // keyA < keyB, elemA not in intersection
+              idxA += 1
+            } else if (cmp > 0) {
+              // keyA > keyB, elemB not in intersection
+              idxB += 1
+            } else {
+              // keyA == keyB, found intersection element
+              out.+=(a(idxA))
+              idxA += 1
+              idxB += 1
+            }
           }
-        }
 
-        Val.Arr(pos, out.result())
+          Val.Arr(pos, out.result())
+        }
     },
     /**
      * [[https://jsonnet.org/ref/stdlib.html#std-setDiff std.setDiff(a, b, keyF=id)]].
@@ -431,45 +596,49 @@ object SetModule extends AbstractFunctionModule {
 
         val a = toArrOrString(args(0), pos, ev)
         val b = toArrOrString(args(1), pos, ev)
-        val out = new mutable.ArrayBuilder.ofRef[Eval]
-        // Set a reasonable size hint - difference will be at most the size of the first set
-        out.sizeHint(a.length)
+        if (isDefaultKeyF(keyF)) {
+          setDiffDefaultKeyF(pos, ev, a, b)
+        } else {
+          val out = new mutable.ArrayBuilder.ofRef[Eval]
+          // Set a reasonable size hint - difference will be at most the size of the first set
+          out.sizeHint(a.length)
 
-        var idxA = 0
-        var idxB = 0
+          var idxA = 0
+          var idxB = 0
 
-        while (idxA < a.length) {
-          val elemA = a(idxA).value
-          val keyA = applyKeyFunc(elemA, keyF, pos, ev)
+          while (idxA < a.length) {
+            val elemA = a(idxA).value
+            val keyA = applyKeyFunc(elemA, keyF, pos, ev)
 
-          // Advance idxB to find first element >= keyA
-          var foundEqual = false
-          var continue = true
-          while (idxB < b.length && continue) {
-            val elemB = b(idxB).value
-            val keyB = applyKeyFunc(elemB, keyF, pos, ev)
+            // Advance idxB to find first element >= keyA
+            var foundEqual = false
+            var continue = true
+            while (idxB < b.length && continue) {
+              val elemB = b(idxB).value
+              val keyB = applyKeyFunc(elemB, keyF, pos, ev)
 
-            val cmp = ev.compare(keyA, keyB)
-            if (cmp <= 0) {
-              // keyA <= keyB, found position
-              foundEqual = (cmp == 0)
-              if (foundEqual) idxB += 1 // Move past the match
-              continue = false
-            } else {
-              // keyA > keyB, keep advancing in b
-              idxB += 1
+              val cmp = ev.compare(keyA, keyB)
+              if (cmp <= 0) {
+                // keyA <= keyB, found position
+                foundEqual = (cmp == 0)
+                if (foundEqual) idxB += 1 // Move past the match
+                continue = false
+              } else {
+                // keyA > keyB, keep advancing in b
+                idxB += 1
+              }
             }
+
+            // Add elemA if we didn't find it in b
+            if (!foundEqual) {
+              out.+=(a(idxA))
+            }
+
+            idxA += 1
           }
 
-          // Add elemA if we didn't find it in b
-          if (!foundEqual) {
-            out.+=(a(idxA))
-          }
-
-          idxA += 1
+          Val.Arr(pos, out.result())
         }
-
-        Val.Arr(pos, out.result())
     },
     /**
      * [[https://jsonnet.org/ref/stdlib.html#std-setMember std.setMember(x, arr, keyF=id)]].


### PR DESCRIPTION
## Summary

Optimize default-key `std.setUnion`, `std.setInter`, and `std.setDiff` by adding a dedicated default `keyF=id` merge path.

The new path keeps the current forced key at each merge cursor, compares numbers/strings directly, and writes into a pre-sized `Array[Eval]` before trimming. Custom `keyF` keeps the previous implementation, so function-call semantics are unchanged.

This is intentionally narrower than jrsonnet's whole set implementation: the goal is a JVM/JIT-friendly hot path without the large per-type method explosion that did not improve results enough to justify the code size.

## JMH

Command:

```bash
./mill -i bench.runJmh sjsonnet.bench.RegressionBenchmark.main \
  -p 'path=bench/resources/sjsonnet_suite/setUnion.jsonnet,bench/resources/sjsonnet_suite/setInter.jsonnet,bench/resources/sjsonnet_suite/setDiff.jsonnet' \
  -wi 3 -i 5 -w 1s -r 2s -f 1 -tu ms
```

Environment:

- JMH 1.37
- JVM: Zulu/OpenJDK 21.0.10 aarch64
- VM options from environment: `--enable-native-access=ALL-UNNAMED -Xmx4G -XX:+UseG1GC`

| Benchmark | master | this PR | delta |
| --- | ---: | ---: | ---: |
| `setUnion.jsonnet` | 0.594 ± 0.039 ms/op | 0.500 ± 0.036 ms/op | 15.8% faster |
| `setInter.jsonnet` | 0.354 ± 0.024 ms/op | 0.334 ± 0.015 ms/op | 5.6% faster |
| `setDiff.jsonnet` | 0.416 ± 0.053 ms/op | 0.365 ± 0.011 ms/op | 12.3% faster |

## JMH GC profiler

Command:

```bash
./mill -i bench.runJmh sjsonnet.bench.RegressionBenchmark.main \
  -p 'path=bench/resources/sjsonnet_suite/setUnion.jsonnet,bench/resources/sjsonnet_suite/setInter.jsonnet,bench/resources/sjsonnet_suite/setDiff.jsonnet' \
  -wi 2 -i 3 -w 1s -r 1s -f 1 -tu ms -prof gc
```

Normalized allocation is effectively unchanged/slightly lower:

| Benchmark | master alloc.norm | this PR alloc.norm |
| --- | ---: | ---: |
| `setUnion.jsonnet` | 1,512,845.660 B/op | 1,510,378.717 B/op |
| `setInter.jsonnet` | 1,268,889.087 B/op | 1,268,595.813 B/op |
| `setDiff.jsonnet` | 1,329,900.452 B/op | 1,327,755.458 B/op |

## Native hyperfine

Command shape:

```bash
hyperfine --shell=none --warmup 20 --runs 100 \
  '<master native> -J 1 -o /dev/null bench/resources/sjsonnet_suite/setUnion.jsonnet' \
  '<this PR native> -J 1 -o /dev/null bench/resources/sjsonnet_suite/setUnion.jsonnet' \
  '<jrsonnet release> -o /dev/null bench/resources/sjsonnet_suite/setUnion.jsonnet' \
  # repeated for setInter/setDiff
```

| Benchmark | master native | this PR native | jrsonnet release |
| --- | ---: | ---: | ---: |
| `setUnion.jsonnet` | 4.7 ± 0.3 ms | 4.4 ± 0.1 ms | 2.8 ± 0.1 ms |
| `setInter.jsonnet` | 4.2 ± 0.2 ms | 4.2 ± 0.3 ms | 2.1 ± 0.1 ms |
| `setDiff.jsonnet` | 4.2 ± 0.1 ms | 4.2 ± 0.2 ms | 2.4 ± 0.1 ms |

Native CLI remains dominated by startup/whole-program costs on these small inputs. jrsonnet is still about 1.9-2.2x faster for the native CLI set cases.

## Correctness / validation

```bash
./mill -i 'sjsonnet.jvm[3.3.7].test.testOnly' \
  sjsonnet.StdWithKeyFTests \
  sjsonnet.StdSetUnionTests \
  sjsonnet.StdSetDiffTests \
  sjsonnet.StdLibOfficialCompatibilityTests \
  sjsonnet.PreserveOrderTests

./mill -i 'sjsonnet.jvm[3.3.7]'.test
./mill -i 'sjsonnet.js[3.3.7]'.compile 'sjsonnet.native[3.3.7]'.compile '__.checkFormat'
./mill -i 'sjsonnet.native[3.3.7].nativeLink'
```
