### PR TITLE
fix: preserve TCO through error values

### DIFF
--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -1515,7 +1515,7 @@ class Evaluator(
   private def visitAndRhsTailPos(rhs: Expr, andPos: Position)(implicit scope: ValScope): Val = {
     visitExprWithTailCallSupport(rhs) match {
       case b: Val.Bool  => b
-      case tc: TailCall => tc.withBooleanCheck(new TailCall.BooleanCheck("&&", andPos))
+      case tc: TailCall => tc.withBooleanCheck(isAnd = true, andPos)
       case unknown      =>
         Error.fail(s"binary operator && does not operate on ${unknown.prettyName}s.", andPos)
     }
@@ -1524,11 +1524,22 @@ class Evaluator(
   private def visitOrRhsTailPos(rhs: Expr, orPos: Position)(implicit scope: ValScope): Val = {
     visitExprWithTailCallSupport(rhs) match {
       case b: Val.Bool  => b
-      case tc: TailCall => tc.withBooleanCheck(new TailCall.BooleanCheck("||", orPos))
+      case tc: TailCall => tc.withBooleanCheck(isAnd = false, orPos)
       case unknown      =>
         Error.fail(s"binary operator || does not operate on ${unknown.prettyName}s.", orPos)
     }
   }
+
+  // The value of `error value` is evaluated immediately before throwing. If that value is a
+  // tail-position TailCall, keep the throw as delayed continuation state on the TailCall so the
+  // trampoline remains stack-safe. Resolving here would re-enter the trampoline inside the current
+  // function body and can restore recursive stack growth for deep `error f(n - 1)` chains.
+  private def visitErrorValueTailPos(value: Expr, errorPos: Position)(implicit
+      scope: ValScope): Val =
+    visitExprWithTailCallSupport(value) match {
+      case tc: TailCall => tc.withErrorValueCheck(errorPos)
+      case value        => Error.fail(materializeError(value), errorPos)
+    }
 
   /**
    * Evaluate an expression with tail-call support. When a `tailstrict` call is encountered at a
@@ -1536,8 +1547,8 @@ class Evaluator(
    * `TailCall.resolve` in `visitApply*` to iterate rather than grow the JVM stack.
    *
    * Potential tail positions are propagated through: IfElse (both branches), LocalExpr (returned),
-   * AssertExpr (returned), And (rhs), and Or (rhs). All other expression types delegate to normal
-   * `visitExpr`.
+   * AssertExpr (returned), And (rhs), Or (rhs), and Expr.Error (value). All other expression types
+   * delegate to normal `visitExpr`.
    */
   @tailrec
   private def visitExprWithTailCallSupport(e: Expr)(implicit scope: ValScope): Val = e match {
@@ -1600,7 +1611,7 @@ class Evaluator(
           Error.fail(s"binary operator || does not operate on ${unknown.prettyName}s.", e.pos)
       }
     case e: Expr.Error =>
-      Error.fail(materializeError(visitExpr(e.value)), e.pos)
+      visitErrorValueTailPos(e.value, e.pos)
     // Tail-position tailstrict calls: match TailstrictableExpr to unify the tailstrict guard,
     // then dispatch by concrete type.
     //

--- a/sjsonnet/src/sjsonnet/StaticOptimizer.scala
+++ b/sjsonnet/src/sjsonnet/StaticOptimizer.scala
@@ -657,9 +657,12 @@ class StaticOptimizer(
         // lhs is NOT in tail position, but provides a control-flow exit path (returns true
         // when lhs is true). We must still check rhs for non-recursive exits.
         hasNonRecursiveExit(e.rhs, selfName, selfIdx, paramCount)
-      case _: Expr.Error =>
-        // error value is the last thing evaluated before throwing -> non-recursive exit
-        true
+      case e: Expr.Error =>
+        // error value is in tail position, so it is only a non-recursive exit if the value
+        // expression itself has a non-recursive exit. Treating every error expression as an exit
+        // would auto-TCO `local f() = error f()`, turning a max-stack diagnostic into an infinite
+        // trampoline loop.
+        hasNonRecursiveExit(e.value, selfName, selfIdx, paramCount)
       case e if isSelfTailCall(e) =>
         false // this path IS a self-recursive tail call → not a non-recursive exit
       case _ =>

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -2518,31 +2518,66 @@ final class TailCall(
     val args: Array[Eval],
     val namedNames: Array[String],
     val callSiteExpr: Expr,
-    val strict: Boolean = false,
-    private var booleanCheck: TailCall.BooleanCheck = null)
+    val strict: Boolean = false)
     extends Val {
   private[sjsonnet] def valTag: Byte = -1
   var pos: Position = callSiteExpr.pos
   def prettyName = "tailcall"
   override def exprErrorString: String = callSiteExpr.exprErrorString
 
-  def withBooleanCheck(check: TailCall.BooleanCheck): TailCall = {
-    if (booleanCheck eq null) booleanCheck = check
+  private[sjsonnet] var resultBooleanIsAnd: Boolean = false
+  private[sjsonnet] var resultBooleanPos: Position = null
+  private[sjsonnet] var resultErrorValuePos: Position = null
+
+  @inline def withBooleanCheck(isAnd: Boolean, pos: Position): TailCall = {
+    if ((resultBooleanPos eq null) && (resultErrorValuePos eq null)) {
+      resultBooleanIsAnd = isAnd
+      resultBooleanPos = pos
+    }
     this
   }
 
-  private[sjsonnet] def pendingBooleanCheck: TailCall.BooleanCheck = booleanCheck
+  @inline def withErrorValueCheck(pos: Position): TailCall = {
+    if (resultErrorValuePos eq null) resultErrorValuePos = pos
+    this
+  }
 }
 
 object TailCall {
-  // Delayed result validation for tail-position &&/||. It deliberately lives on the TailCall rather
-  // than resolving nested TailCalls inside Evaluator.visitAndRhsTailPos/visitOrRhsTailPos, because
-  // nested resolution would undermine stack-safety and could force work at a different lazy boundary.
-  final class BooleanCheck(val op: String, val pos: Position) {
-    def check(result: Val)(implicit ev: EvalErrorScope): Val = result match {
-      case b: Val.Bool => b
-      case unknown     =>
-        Error.fail(s"binary operator $op does not operate on ${unknown.prettyName}s.", pos)
+  private def materializeErrorValue(value: Val)(implicit ev: EvalScope): String = value match {
+    case Val.Str(_, s) => s
+    case r             => Materializer.stringify(r)
+  }
+
+  @inline private def applyResultChecks(
+      result: Val,
+      booleanIsAnd: Boolean,
+      booleanPos: Position,
+      errorValuePos: Position)(implicit ev: EvalScope): Val = {
+    val checked =
+      if (booleanPos eq null) result
+      else
+        result match {
+          case b: Val.Bool => b
+          case unknown     =>
+            val op = if (booleanIsAnd) "&&" else "||"
+            Error.fail(
+              s"binary operator $op does not operate on ${unknown.prettyName}s.",
+              booleanPos
+            )
+        }
+    if (errorValuePos eq null) checked
+    else Error.fail(materializeErrorValue(checked), errorValuePos)
+  }
+
+  @inline private def resolveNext(tc: TailCall)(implicit ev: EvalScope): Val = {
+    val mode: TailstrictMode =
+      if (tc.strict) TailstrictModeEnabled else TailstrictModeAutoTCO
+    try {
+      tc.func.apply(tc.args, tc.namedNames, tc.callSiteExpr.pos)(ev, mode)
+    } catch {
+      case e: Error =>
+        throw e.addFrame(tc.callSiteExpr.pos, tc.callSiteExpr)
     }
   }
 
@@ -2560,26 +2595,41 @@ object TailCall {
    * Error frames preserve the original call-site expression name (e.g. "Apply2") so that TCO does
    * not alter user-visible stack traces.
    */
-  def resolve(current: Val)(implicit ev: EvalScope): Val = resolve(current, null)
+  def resolve(current: Val)(implicit ev: EvalScope): Val = resolve(current, false, null, null)
 
   @tailrec
-  private def resolve(current: Val, booleanCheck: BooleanCheck)(implicit ev: EvalScope): Val =
+  private def resolve(
+      current: Val,
+      booleanIsAnd: Boolean,
+      booleanPos: Position,
+      errorValuePos: Position)(implicit ev: EvalScope): Val =
     current match {
       case tc: TailCall =>
-        val mode: TailstrictMode =
-          if (tc.strict) TailstrictModeEnabled else TailstrictModeAutoTCO
-        val nextCheck =
-          if (tc.pendingBooleanCheck != null) tc.pendingBooleanCheck else booleanCheck
-        val next =
-          try {
-            tc.func.apply(tc.args, tc.namedNames, tc.callSiteExpr.pos)(ev, mode)
-          } catch {
-            case e: Error =>
-              throw e.addFrame(tc.callSiteExpr.pos, tc.callSiteExpr)
-          }
-        resolve(next, nextCheck)
+        val tcErrorPos = tc.resultErrorValuePos
+        val tcBooleanPos = tc.resultBooleanPos
+        if (tcErrorPos ne null) {
+          // Inner error throws before any outer continuation can run.
+          resolve(
+            resolveNext(tc),
+            tc.resultBooleanIsAnd,
+            tcBooleanPos,
+            tcErrorPos
+          )
+        } else if (tcBooleanPos ne null) {
+          // If the inner boolean check passes, outer boolean checks necessarily pass on the same
+          // boolean value. Preserve only an outer error, which still runs after the inner check.
+          resolve(
+            resolveNext(tc),
+            tc.resultBooleanIsAnd,
+            tcBooleanPos,
+            errorValuePos
+          )
+        } else {
+          resolve(resolveNext(tc), booleanIsAnd, booleanPos, errorValuePos)
+        }
       case result =>
-        if (booleanCheck == null) result else booleanCheck.check(result)
+        if ((booleanPos eq null) && (errorValuePos eq null)) result
+        else applyResultChecks(result, booleanIsAnd, booleanPos, errorValuePos)
     }
 }
 

--- a/sjsonnet/test/resources/new_test_suite/auto_tco_directional.jsonnet
+++ b/sjsonnet/test/resources/new_test_suite/auto_tco_directional.jsonnet
@@ -123,6 +123,7 @@ local asymmetric_if(n) =
   else asymmetric_if(n - 1);
 
 // 1.18 Tail call through error expression value
+// Erroring behavior is covered by error.auto_tco_error_value_tail_call.jsonnet.
 local error_value(n) =
   if n <= 0 then error "done at " + n
   else error_value(n - 1);

--- a/sjsonnet/test/resources/new_test_suite/error.auto_tco_bool_check_precedes_outer_error_value.jsonnet
+++ b/sjsonnet/test/resources/new_test_suite/error.auto_tco_bool_check_precedes_outer_error_value.jsonnet
@@ -1,0 +1,7 @@
+// The error message expression is evaluated before the outer error throws. If
+// that expression itself fails a delayed boolean check, the boolean error wins.
+local f(n) =
+  if n <= 0 then 0
+  else true && f(n - 1);
+
+error f(1000)

--- a/sjsonnet/test/resources/new_test_suite/error.auto_tco_bool_check_precedes_outer_error_value.jsonnet.golden
+++ b/sjsonnet/test/resources/new_test_suite/error.auto_tco_bool_check_precedes_outer_error_value.jsonnet.golden
@@ -1,0 +1,1 @@
+sjsonnet.Error: binary operator && does not operate on numbers.

--- a/sjsonnet/test/resources/new_test_suite/error.auto_tco_error_value_nested_exit_tail_call.jsonnet
+++ b/sjsonnet/test/resources/new_test_suite/error.auto_tco_error_value_nested_exit_tail_call.jsonnet
@@ -1,0 +1,7 @@
+// The non-recursive exit can be inside the `error value` expression. This should
+// still be auto-TCO'd, because the value expression eventually produces the
+// message that the surrounding error throws.
+local f(n) =
+  error if n <= 0 then "done" else f(n - 1);
+
+f(10000)

--- a/sjsonnet/test/resources/new_test_suite/error.auto_tco_error_value_nested_exit_tail_call.jsonnet.golden
+++ b/sjsonnet/test/resources/new_test_suite/error.auto_tco_error_value_nested_exit_tail_call.jsonnet.golden
@@ -1,0 +1,1 @@
+sjsonnet.Error: done

--- a/sjsonnet/test/resources/new_test_suite/error.auto_tco_error_value_no_exit_not_marked.jsonnet
+++ b/sjsonnet/test/resources/new_test_suite/error.auto_tco_error_value_no_exit_not_marked.jsonnet
@@ -1,0 +1,6 @@
+// `error value` is a tail position, but it is not automatically a non-recursive
+// exit. A function whose only path is `error f()` must not be auto-TCO'd,
+// otherwise the trampoline loops forever instead of reporting max stack.
+local f() = error f();
+
+f()

--- a/sjsonnet/test/resources/new_test_suite/error.auto_tco_error_value_no_exit_not_marked.jsonnet.golden
+++ b/sjsonnet/test/resources/new_test_suite/error.auto_tco_error_value_no_exit_not_marked.jsonnet.golden
@@ -1,0 +1,1 @@
+sjsonnet.Error: [f] Max stack frames exceeded.

--- a/sjsonnet/test/resources/new_test_suite/error.auto_tco_error_value_precedes_outer_bool_check.jsonnet
+++ b/sjsonnet/test/resources/new_test_suite/error.auto_tco_error_value_precedes_outer_bool_check.jsonnet
@@ -1,0 +1,7 @@
+// Inner `error value` throws before the surrounding boolean operator can check
+// the rhs result type.
+local f(n) =
+  if n <= 0 then 0
+  else error f(n - 1);
+
+true && f(1000)

--- a/sjsonnet/test/resources/new_test_suite/error.auto_tco_error_value_precedes_outer_bool_check.jsonnet.golden
+++ b/sjsonnet/test/resources/new_test_suite/error.auto_tco_error_value_precedes_outer_bool_check.jsonnet.golden
@@ -1,0 +1,1 @@
+sjsonnet.Error: 0

--- a/sjsonnet/test/resources/new_test_suite/error.auto_tco_error_value_tail_call.jsonnet
+++ b/sjsonnet/test/resources/new_test_suite/error.auto_tco_error_value_tail_call.jsonnet
@@ -1,0 +1,8 @@
+// The value of `error value` is the last evaluated expression before throwing.
+// A self-tail call there should still use the auto-TCO trampoline and preserve
+// lazy arguments.
+local f(n, unused) =
+  if n <= 0 then "done"
+  else error f(n - 1, unused);
+
+f(10000, error "unused must stay lazy")

--- a/sjsonnet/test/resources/new_test_suite/error.auto_tco_error_value_tail_call.jsonnet.golden
+++ b/sjsonnet/test/resources/new_test_suite/error.auto_tco_error_value_tail_call.jsonnet.golden
@@ -1,0 +1,1 @@
+sjsonnet.Error: done

--- a/sjsonnet/test/resources/new_test_suite/error.auto_tco_negative_lhs_not_tail.jsonnet
+++ b/sjsonnet/test/resources/new_test_suite/error.auto_tco_negative_lhs_not_tail.jsonnet
@@ -1,0 +1,7 @@
+// Recursive calls in the lhs of && are not in tail position. This should remain
+// unoptimized and hit max-stack at deep recursion rather than being auto-TCO'd.
+local f(n) =
+  if n <= 0 then true
+  else f(n - 1) && true;
+
+f(10000)

--- a/sjsonnet/test/resources/new_test_suite/error.auto_tco_negative_lhs_not_tail.jsonnet.golden
+++ b/sjsonnet/test/resources/new_test_suite/error.auto_tco_negative_lhs_not_tail.jsonnet.golden
@@ -1,0 +1,1 @@
+sjsonnet.Error: [f] Max stack frames exceeded.

--- a/sjsonnet/test/resources/new_test_suite/error.auto_tco_nested_bool_check_order.jsonnet
+++ b/sjsonnet/test/resources/new_test_suite/error.auto_tco_nested_bool_check_order.jsonnet
@@ -1,0 +1,7 @@
+// Nested boolean continuations should report the innermost operator that first
+// observes the non-boolean TailCall result.
+local f(n) =
+  if n <= 0 then 0
+  else true && (false || f(n - 1));
+
+f(1000)

--- a/sjsonnet/test/resources/new_test_suite/error.auto_tco_nested_bool_check_order.jsonnet.golden
+++ b/sjsonnet/test/resources/new_test_suite/error.auto_tco_nested_bool_check_order.jsonnet.golden
@@ -1,0 +1,1 @@
+sjsonnet.Error: binary operator || does not operate on numbers.

--- a/sjsonnet/test/resources/new_test_suite/error.tailstrict_error_value_tail_call.jsonnet
+++ b/sjsonnet/test/resources/new_test_suite/error.tailstrict_error_value_tail_call.jsonnet
@@ -1,0 +1,7 @@
+// Explicit tailstrict inside `error value` should also be resolved by the
+// outer trampoline instead of nested resolving inside the error expression.
+local f(n) =
+  if n <= 0 then "done"
+  else error (f(n - 1) tailstrict);
+
+f(10000)

--- a/sjsonnet/test/resources/new_test_suite/error.tailstrict_error_value_tail_call.jsonnet.golden
+++ b/sjsonnet/test/resources/new_test_suite/error.tailstrict_error_value_tail_call.jsonnet.golden
@@ -1,0 +1,1 @@
+sjsonnet.Error: done


### PR DESCRIPTION
Rebased onto current `master` at `b4c667d5` (`Add lazy array views for large stdlib arrays (#814)`).

## Motivation

`error value` evaluates `value` immediately before throwing. That value is a tail position for auto-TCO and explicit `tailstrict`, but resolving a `TailCall` inside the `error` expression would re-enter the trampoline from the current function body and can bring back recursive stack growth for deep `error f(n - 1)` chains.

`error value` also must not be treated as an unconditional non-recursive exit. A function like `local f() = error f()` has no base case; auto-TCOing it would turn the existing max-stack diagnostic into an infinite trampoline loop.

## Implementation

- Evaluate tail-position `error value` with tail-call support and attach a delayed error-value continuation to the returned `TailCall`.
- Store delayed result continuations directly on `TailCall` as primitive/ref fields: optional `&&`/`||` validation plus optional `error value` throw.
- Avoid linked continuation nodes, wrapper values, and per-wrapper check objects on deep recursive paths.
- Keep the trampoline hot path simple: `TailCall.resolve` carries pending checks in local parameters and returns immediately when no final check is pending.
- Preserve continuation order:
  - inner `error value` preempts any outer boolean check or outer error throw
  - inner boolean validation runs before an outer error throw
  - redundant outer boolean validations collapse after the innermost boolean check
- Update auto-TCO exit analysis so `Expr.Error` recursively inspects its value expression instead of always counting as a non-recursive exit.

## Performance notes

- No allocation is introduced for delayed boolean/error continuations; the only state is stored on the existing `TailCall`.
- The resolve loop is tail-recursive, monomorphic in the common path, and uses null/reference checks rather than allocating small continuation objects.
- Final result validation is skipped entirely for tail calls without delayed checks.

## Tests

New golden tests cover:

- auto-TCO and explicit `tailstrict` through `error value`
- lazy unused arguments through a 10000-deep recursive `error f(n - 1, unused)` chain
- boolean-check-before-outer-error ordering
- inner-error-before-outer-bool ordering
- nested boolean continuation ordering
- a non-tail lhs negative case
- an `error value` expression whose non-recursive exit is inside the error value
- a no-exit `error f()` case that must keep the max-stack diagnostic

## Verification

- `./mill --no-server 'sjsonnet.jvm[3.3.7].compile'`
- `./mill --no-server 'sjsonnet.jvm[2.13.18].compile'`
- `./mill --no-server 'sjsonnet.jvm[2.12.21].compile'`
- `./mill --no-server 'sjsonnet.jvm[3.3.7].test.testOnly' sjsonnet.FileTests sjsonnet.TailCallOptimizationTests`
- `./mill --no-server 'sjsonnet.js[2.13.18].compile' 'sjsonnet.wasm[2.13.18].compile'`
- `./mill --no-server 'sjsonnet.native[2.13.18].compile'`
- `./mill --no-server '__.checkFormat'`
- `./mill --no-server '_.jvm[_].__.test'`
- `./mill --no-server '_.js[_].__.test'`
- `./mill --no-server '_.wasm[_].__.test'`
- `./mill --no-server '_.native[_].__.test'`
- `git diff --check`

## Rebase note

The previous CI failures were caused by the stale base: `EncodingModule.scala` had an unused `UTF_8` import on that revision. Current `master` uses that import, so rebasing fixes those compile failures.
