### PR TITLE
Presize array copy consumers

### DIFF
--- a/sjsonnet/src/sjsonnet/stdlib/ArrayModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/ArrayModule.scala
@@ -41,6 +41,7 @@ object ArrayModule extends AbstractFunctionModule {
 
   private val DefaultKeyF = Val.Null(dummyPos)
   private val DefaultOnEmpty = Val.Null(dummyPos)
+  private val PresizedCopyMaxParts = 1024
 
   @inline private def isDefaultKeyF(v: Val): Boolean = v.asInstanceOf[AnyRef] eq DefaultKeyF
   @inline private def isDefaultOnEmpty(v: Val): Boolean =
@@ -381,18 +382,47 @@ object ArrayModule extends AbstractFunctionModule {
    */
   private object FlattenArrays extends Val.Builtin1("flattenArrays", "arrs") {
     def evalRhs(arrs: Eval, ev: EvalScope, pos: Position): Val = {
-      val out = new mutable.ArrayBuilder.ofRef[Eval]
       val arr = arrs.value.asArr
-      out.sizeHint(arr.length * 4) // Rough size hint
-      for (x <- arr) {
-        x.value match {
+      val len = arr.length
+      if (len > PresizedCopyMaxParts) {
+        val out = new mutable.ArrayBuilder.ofRef[Eval]
+        out.sizeHint(len * 4)
+        var i = 0
+        while (i < len) {
+          arr.value(i) match {
+            case v: Val.Arr =>
+              v.copyEvalTo(out)
+            case x =>
+              Error.fail("binary operator + requires matching types, got array and " + x.prettyName)
+          }
+          i += 1
+        }
+        return Val.Arr(pos, out.result())
+      }
+
+      val parts = new Array[Val.Arr](len)
+      var totalLen = 0L
+      var i = 0
+      while (i < len) {
+        arr.value(i) match {
           case v: Val.Arr =>
-            v.copyEvalTo(out)
+            parts(i) = v
+            totalLen += v.length
+            if (totalLen > Int.MaxValue) Error.fail("array too large", pos)(ev)
           case x =>
             Error.fail("binary operator + requires matching types, got array and " + x.prettyName)
         }
+        i += 1
       }
-      Val.Arr(pos, out.result())
+
+      val result = new Array[Eval](totalLen.toInt)
+      var offset = 0
+      i = 0
+      while (i < len) {
+        offset = parts(i).copyEvalTo(result, offset)
+        i += 1
+      }
+      Val.Arr(pos, result)
     }
   }
 

--- a/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
@@ -49,6 +49,7 @@ object StringModule extends AbstractFunctionModule {
   def name = "string"
 
   private val whiteSpaces = StripUtils.codePointsSet(" \t\n\f\r\u0085\u00A0")
+  private val PresizedCopyMaxParts = 1024
 
   /**
    * [[https://jsonnet.org/ref/stdlib.html#std-toString std.toString(a)]].
@@ -417,10 +418,6 @@ object StringModule extends AbstractFunctionModule {
    * case the arrays are concatenated in the same way, to produce a single array.
    */
   private object Join extends Val.Builtin2("join", "sep", "arr") {
-    private def appendArray(out: mutable.ArrayBuilder.ofRef[Eval], arr: Val.Arr): Unit = {
-      arr.copyEvalTo(out)
-    }
-
     def evalRhs(sep: Eval, _arr: Eval, ev: EvalScope, pos: Position): Val = {
       val arr = implicitly[ReadWriter[Val.Arr]].apply(_arr.value)
       sep.value match {
@@ -441,21 +438,54 @@ object StringModule extends AbstractFunctionModule {
           }
           Val.Str(pos, b.toString)
         case sep: Val.Arr =>
-          val out = new mutable.ArrayBuilder.ofRef[Eval]
-          // Set a reasonable size hint based on estimated result size
-          out.sizeHint(arr.length * 2)
-          var added = false
-          for (x <- arr) {
-            x match {
+          val len = arr.length
+          if (len > PresizedCopyMaxParts) {
+            val out = new mutable.ArrayBuilder.ofRef[Eval]
+            out.sizeHint(len * 2)
+            var added = false
+            var i = 0
+            while (i < len) {
+              arr.value(i) match {
+                case Val.Null(_) => // do nothing
+                case v: Val.Arr  =>
+                  if (added) sep.copyEvalTo(out)
+                  added = true
+                  v.copyEvalTo(out)
+                case x => Error.fail("Cannot join " + x.prettyName)
+              }
+              i += 1
+            }
+            return Val.Arr(pos, out.result())
+          }
+
+          val parts = new Array[Val.Arr](len)
+          val sepLen = sep.length
+          var partCount = 0
+          var totalLen = 0L
+          var i = 0
+          while (i < len) {
+            arr.value(i) match {
               case Val.Null(_) => // do nothing
               case v: Val.Arr  =>
-                if (added) appendArray(out, sep)
-                added = true
-                appendArray(out, v)
+                if (partCount > 0) totalLen += sepLen
+                totalLen += v.length
+                if (totalLen > Int.MaxValue) Error.fail("array too large", pos)(ev)
+                parts(partCount) = v
+                partCount += 1
               case x => Error.fail("Cannot join " + x.prettyName)
             }
+            i += 1
           }
-          Val.Arr(pos, out.result())
+
+          val result = new Array[Eval](totalLen.toInt)
+          var offset = 0
+          i = 0
+          while (i < partCount) {
+            if (i > 0 && sepLen != 0) offset = sep.copyEvalTo(result, offset)
+            offset = parts(i).copyEvalTo(result, offset)
+            i += 1
+          }
+          Val.Arr(pos, result)
         case x => Error.fail("Cannot join " + x.prettyName)
       }
     }


### PR DESCRIPTION
## Motivation

#822 gives consumers a cheap `Eval` copy API, but `std.flattenArrays` and array-separator `std.join` can still pay `ArrayBuilder` growth/copy costs when the outer array has a modest number of large child arrays.

This PR adds a guarded two-pass pre-size path for those consumers. The goal is to remove avoidable intermediate allocation in few-large-array workloads without regressing many-small-array workloads.

Constraints:

- do not force element values
- avoid many-small-array regressions
- guard total length before allocation
- keep hot paths as straight indexed loops
- keep this PR narrowly stacked on #822

## Modification

Stacked on #822.

Use `Arr.copyEvalTo` to presize high-volume array-copy consumers:

- `std.flattenArrays`
- array-separator `std.join`

The pre-sized path uses two linear scans only when the outer part count is modest (`<= 1024`). Large outer arrays fall back to the one-pass `ArrayBuilder + copyEvalTo` path from #822.

## Result

Rebased onto latest `upstream/master` at `8b67cb1e`.

JMH, JVM harness, lower is better:

| Benchmark | master | #822 | this PR | Delta vs #822 |
| --- | ---: | ---: | ---: | ---: |
| `sjsonnet_suite/array_copy_views` | 18.027 ms/op | 13.972 ms/op | 8.068 ms/op | -42.3% |

Scala Native hyperfine against latest source-built jrsonnet master `5b43fa8` (`jrsonnet 0.5.0-pre98`), lower is better:

| Benchmark | master-native | #822-native | this PR | latest jrsonnet | Result |
| --- | ---: | ---: | ---: | ---: | --- |
| `sjsonnet_suite/array_copy_views` | 23.0 +/- 1.6 ms | 9.1 +/- 3.1 ms | 6.6 +/- 1.8 ms | 9.4 +/- 3.0 ms | this PR is 3.49x faster than master; CLI timings are outlier-heavy |
| `realistic2` | 91.4 +/- 13.0 ms | n/a | 83.0 +/- 1.4 ms | 136.6 +/- 1.8 ms | this PR is 1.65x faster than latest jrsonnet |

JIT / GC review:

- The second pass copies `Eval` references into one preallocated `Array[Eval]`; it does not force element values.
- `totalLen` is accumulated as `Long` and checked before allocating the final `Array[Eval]`.
- `PresizedCopyMaxParts = 1024` avoids turning many-small arrays into an always-two-pass workload.
- The fallback path preserves #822 behavior for large outer arrays.
- The hot path is simple counted while-loops plus `copyEvalTo`, so it stays friendly to JIT inlining and Scala Native codegen.

Verification:

- `git diff --check`
- `./mill --no-server 'sjsonnet.jvm[3.3.7].compile'`
- `./mill --no-server 'sjsonnet.jvm[2.13.18].compile'`
- `./mill --no-server 'sjsonnet.jvm[2.12.21].compile'`
- `./mill --no-server 'sjsonnet.jvm[3.3.7].test'`
- `./mill --no-server 'sjsonnet.jvm[3.3.7].checkFormat'`
- `./mill -i 'sjsonnet.native[3.3.7].nativeLink'`
- `./mill -i bench.runRegressions bench/resources/sjsonnet_suite/array_copy_views.jsonnet`
- `hyperfine --warmup 10 --min-runs 50`

Rollback boundary:

- This PR only changes fully-consumed array-copy consumers.
- It does not change string join, renderer, sort, callback invocation, or global array view semantics.
- If a workload shows a many-small regression, the threshold can be lowered or the affected consumer can use the #822 one-pass path.

## References

- Builds on #822 array eval copy API.
- Head: `a5fb04737be227d73a3a08331534acfaf108cc1d`
- Latest source-built jrsonnet: `5b43fa88b8c43856dd5a2daa9c5c251153c5e14d`
