### PR TITLE
Optimize ASCII-safe string rendering

### DIFF
--- a/sjsonnet/src-js/sjsonnet/Platform.scala
+++ b/sjsonnet/src-js/sjsonnet/Platform.scala
@@ -23,6 +23,18 @@ object Platform {
     }
   }
 
+  // Used only for strings already proven ASCII-safe; copies low bytes without allocation.
+  @inline def copyAsciiStringToBytes(s: String, dst: Array[Byte], dstPos: Int): Unit = {
+    var i = 0
+    var pos = dstPos
+    val len = s.length
+    while (i < len) {
+      dst(pos) = s.charAt(i).toByte
+      i += 1
+      pos += 1
+    }
+  }
+
   private def nodeToJson(node: Node): ujson.Value = node match {
     case _: Node.ScalarNode =>
       YamlDecoder.forAny.construct(node).getOrElse("") match {

--- a/sjsonnet/src-jvm/sjsonnet/Platform.scala
+++ b/sjsonnet/src-jvm/sjsonnet/Platform.scala
@@ -13,6 +13,7 @@ import org.tukaani.xz.XZOutputStream
 import org.yaml.snakeyaml.{LoaderOptions, Yaml}
 import org.yaml.snakeyaml.constructor.SafeConstructor
 
+import scala.annotation.nowarn
 import scala.collection.compat.*
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
@@ -22,6 +23,12 @@ object Platform {
 
   def repeatString(s: String, count: Int): String =
     if (count <= 0) "" else s.repeat(count)
+
+  // Used only for strings already proven ASCII-safe; copies low bytes without allocation.
+  @inline
+  @nowarn("cat=deprecation")
+  def copyAsciiStringToBytes(s: String, dst: Array[Byte], dstPos: Int): Unit =
+    s.getBytes(0, s.length, dst, dstPos)
 
   def gzipBytes(b: Array[Byte]): String = {
     val outputStream: ByteArrayOutputStream = new ByteArrayOutputStream(b.length)

--- a/sjsonnet/src-native/sjsonnet/Platform.scala
+++ b/sjsonnet/src-native/sjsonnet/Platform.scala
@@ -6,6 +6,7 @@ import java.util
 import java.util.Base64
 import java.util.zip.GZIPOutputStream
 import scala.scalanative.regex.Pattern
+import scala.annotation.nowarn
 import scala.collection.mutable
 import org.virtuslab.yaml.*
 
@@ -27,6 +28,12 @@ object Platform {
       builder.toString()
     }
   }
+
+  // Used only for strings already proven ASCII-safe; copies low bytes without allocation.
+  @inline
+  @nowarn("cat=deprecation")
+  def copyAsciiStringToBytes(s: String, dst: Array[Byte], dstPos: Int): Unit =
+    s.getBytes(0, s.length, dst, dstPos)
 
   def gzipBytes(b: Array[Byte]): String = {
     val outputStream: ByteArrayOutputStream = new ByteArrayOutputStream(b.length)

--- a/sjsonnet/src/sjsonnet/BaseByteRenderer.scala
+++ b/sjsonnet/src/sjsonnet/BaseByteRenderer.scala
@@ -253,12 +253,8 @@ class BaseByteRenderer[T <: java.io.OutputStream](
     var pos = elemBuilder.length
     arr(pos) = '"'.toByte
     pos += 1
-    var i = 0
-    while (i < len) {
-      arr(pos) = str.charAt(i).toByte
-      pos += 1
-      i += 1
-    }
+    Platform.copyAsciiStringToBytes(str, arr, pos)
+    pos += len
     arr(pos) = '"'.toByte
     elemBuilder.length = pos + 1
   }

--- a/sjsonnet/src/sjsonnet/stdlib/EncodingModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/EncodingModule.scala
@@ -22,6 +22,16 @@ import sjsonnet.functions.AbstractFunctionModule
 object EncodingModule extends AbstractFunctionModule {
   def name = "encoding"
 
+  @inline private def isAsciiJsonSafe(bytes: Array[Byte]): Boolean = {
+    var i = 0
+    while (i < bytes.length) {
+      val b = bytes(i) & 0xff
+      if (b < 0x20 || b >= 0x80 || b == '"' || b == '\\') return false
+      i += 1
+    }
+    true
+  }
+
   /**
    * [[https://jsonnet.org/ref/stdlib.html#std-md5 std.md5(s)]].
    *
@@ -88,9 +98,12 @@ object EncodingModule extends AbstractFunctionModule {
      * Behaves like std.base64DecodeBytes() except returns a naively encoded string instead of an
      * array of bytes.
      */
-    builtin("base64Decode", "str") { (_, _, str: String) =>
+    builtin("base64Decode", "str") { (pos, _, str: String) =>
       try {
-        new String(PlatformBase64.decode(str), UTF_8)
+        val decoded = PlatformBase64.decode(str)
+        val value = new String(decoded, UTF_8)
+        (if (isAsciiJsonSafe(decoded)) Val.Str.asciiSafe(pos, value)
+         else Val.Str(pos, value)): Val
       } catch {
         case e: IllegalArgumentException =>
           Error.fail("Invalid base64 string: " + e.getMessage)


### PR DESCRIPTION
## Summary
- Optimize rendering for strings that are already proven ASCII-safe.
- JVM/Native use `String#getBytes(srcBegin, srcEnd, dst, dstBegin)` to copy low bytes directly into the renderer buffer without allocation.
- Mark ASCII-safe `std.base64Decode` results so decoded ASCII text can use the same renderer fast path.

## Motivation
The docs base64 benchmarks fold into long ASCII-safe strings, then spend visible time rendering those strings. This keeps the same ASCII-safe precondition but moves JVM/Native to a platform copy path that is friendlier to JIT and GC, and extends the same tagging to decoded base64 text when the decoded bytes are JSON-safe ASCII.

## Benchmarks
Baseline is `upstream/master` at `8b67cb1e`.

JMH, docs regression cases:

| case | upstream | this PR | delta |
| --- | ---: | ---: | ---: |
| `go_suite/base64.jsonnet` | 0.168 ms/op | 0.109 ms/op | 35.1% faster |
| `go_suite/base64Decode.jsonnet` | 0.124 ms/op | 0.076 ms/op | 38.7% faster |
| `go_suite/base64_byte_array.jsonnet` | 0.915 ms/op | 0.782 ms/op | 14.5% faster |

Native CLI hyperfine against latest source-built jrsonnet master `5b43fa8` (`jrsonnet 0.5.0-pre98`):

| case | upstream | this PR | latest jrsonnet | highlight |
| --- | ---: | ---: | ---: | --- |
| `go_suite/base64.jsonnet` | 5.3 +/- 2.2 ms | 4.8 +/- 0.4 ms | 2.7 +/- 0.6 ms | this PR narrows the gap from 1.94x to 1.77x slower; CLI timings are short/noisy |

## Validation
- `git diff --check`
- `./mill -i __.checkFormat`
- `./mill -i 'sjsonnet.jvm[3.3.7].test'`
- `./mill -i 'sjsonnet.js[3.3.7].test'`
- `./mill -i 'sjsonnet.native[3.3.7].test'`
- `./mill -i 'sjsonnet.jvm[2.12.21].compile' 'sjsonnet.jvm[2.13.18].compile' 'sjsonnet.native[2.13.18].compile' 'sjsonnet.js[2.13.18].compile'`
- `./mill -i 'sjsonnet.native[3.3.7].nativeLink'`
- `./mill -i bench.runRegressions bench/resources/go_suite/base64Decode.jsonnet bench/resources/go_suite/base64.jsonnet bench/resources/go_suite/base64_byte_array.jsonnet`
- `hyperfine --warmup 10 --min-runs 50`
- Confirmed JDK 17 still exposes the deprecated `String#getBytes(int, int, byte[], int)` method used here.

## References

- Head: `ba10f26a71bacd88ce0a476f9157a3f56c0f3c1d`
- Latest source-built jrsonnet: `5b43fa88b8c43856dd5a2daa9c5c251153c5e14d`
