### PR TITLE
perf: skip builders for single-spec formats

### DIFF
--- a/sjsonnet/src/sjsonnet/Format.scala
+++ b/sjsonnet/src/sjsonnet/Format.scala
@@ -574,9 +574,13 @@ object Format {
     }
     val labels = parsed.labels
     val specBits = parsed.specBits
+    val singleSpecNoStatic = specBits.length == 1 && parsed.staticChars == 0
     // Pre-size StringBuilder based on static chars + estimated dynamic content
-    val output = new java.lang.StringBuilder(parsed.staticChars + specBits.length * 8)
-    appendLeading(output, parsed)
+    val output =
+      if (singleSpecNoStatic) null
+      else new java.lang.StringBuilder(parsed.staticChars + specBits.length * 8)
+    if (!singleSpecNoStatic) appendLeading(output, parsed)
+    var singleFormatted: String = null
     var i = 0
     var idx = 0
     // Use while-loop instead of for/zipWithIndex to avoid iterator allocation
@@ -731,8 +735,11 @@ object Format {
           i += 1
           formattedValue
       }
-      output.append(cooked0)
-      appendLiteral(output, parsed, idx)
+      if (singleSpecNoStatic) singleFormatted = cooked0
+      else {
+        output.append(cooked0)
+        appendLiteral(output, parsed, idx)
+      }
       idx += 1
     }
 
@@ -741,7 +748,7 @@ object Format {
         "Too many values to format: %d, expected %d".format(valuesArr.length, i)
       )
     }
-    output.toString()
+    if (singleSpecNoStatic) singleFormatted else output.toString()
   }
 
   /**


### PR DESCRIPTION
Motivation:

PR #776 showed that format-heavy workloads benefit when the format path avoids unnecessary intermediate assembly. This split keeps only the smallest safe idea: short format strings with exactly one specifier and no static literal text (for example `%08d`, `%010x`, `%-20s`, `%20s`) do not need a `StringBuilder` after the formatted value has already been computed.

Key Design Decision:

Keep the existing generic formatting implementation and all validation/arity checks. The optimization only bypasses appending to `StringBuilder` after the single formatted value is known, so format semantics and error behavior stay unchanged.

Modification:

- Detect `specBits.length == 1 && parsed.staticChars == 0` in `Format.format`.
- Avoid allocating/appending a `StringBuilder` for that case.
- Return the computed formatted value directly after the existing too-many/too-few value checks.

Benchmark Results:

JMH (`./mill -j 1 bench.runRegressions ...`, ms/op lower is better; ops/ms higher is better):

| Case | master ms/op | PR ms/op | master ops/ms | PR ops/ms | Delta |
|---|---:|---:|---:|---:|---:|
| `repeat_format` | 0.190 | 0.133 | 5.263 | 7.519 | +42.9% |
| `large_string_template` guard | 1.155 | 1.160 | 0.866 | 0.862 | -0.4% noisy/neutral |

Scala Native hyperfine (`hyperfine --warmup 10 --min-runs 50 -N`, ms lower is better):

| Case | master native | PR native | jrsonnet | Result |
|---|---:|---:|---:|---|
| `repeat_format` | 6.4 ± 0.9 ms | 6.4 ± 0.7 ms | 5.6 ± 1.0 ms | Native neutral; JMH target positive |
| `large_string_template` guard | 12.6 ± 7.4 ms | 11.4 ± 0.8 ms | 5.4 ± 0.9 ms | No Native regression observed |

Analysis:

The target case is dominated by many short format expressions. Returning the already computed formatted string removes a redundant builder allocation/append path on the JVM. The guard case does not use this single-spec/no-static-literal path and remains effectively unchanged within benchmark noise.

References:

- Source idea: https://github.com/databricks/sjsonnet/pull/776
- Split branch commit: He-Pin/sjsonnet@1f58504d

Result:

- `./mill -j 1 __.reformat && ./mill -j 1 __.test` passed locally.
- Draft PR split from the broader #776 optimization branch to keep the change reviewable and avoid carrying unrelated Native template work.