### PR TITLE
perf: add ASCII-safe substr fast path

### DIFF
--- a/sjsonnet/src/sjsonnet/Parser.scala
+++ b/sjsonnet/src/sjsonnet/Parser.scala
@@ -748,7 +748,10 @@ class Parser(
     // cost more than the potential memory savings for strings that are unlikely
     // to repeat (e.g., 600KB text block literals)
     val unique = if (s.length > 1024) s else internedStrings.getOrElseUpdate(s, s)
-    Val.Str(pos, unique)
+    val result = Val.Str(pos, unique)
+    if (unique.length > 1024 && CharSWAR.isAsciiJsonSafe(unique))
+      result._asciiSafe = true
+    result
   }
 
   // Any `expr` that isn't naively left-recursive

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -433,11 +433,15 @@ object Val {
       if (ls != null && ls.isEmpty) return right
       if (rs != null && rs.isEmpty) return left
       // Small string eagerness: both flat and combined length <= 128
-      if (ls != null && rs != null && ls.length + rs.length <= 128)
-        return new Str(pos, ls + rs)
+      if (ls != null && rs != null && ls.length + rs.length <= 128) {
+        val result = new Str(pos, ls + rs)
+        if (left._asciiSafe && right._asciiSafe) result._asciiSafe = true
+        return result
+      }
       // Rope node: O(1)
       val node = new Str(pos, null)
       node._children = Array(left, right)
+      if (left._asciiSafe && right._asciiSafe) node._asciiSafe = true
       node
     }
   }

--- a/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
@@ -82,11 +82,14 @@ object StringModule extends AbstractFunctionModule {
       Val.cachedNum(
         pos,
         (x.value match {
-          case Val.Str(_, s) => s.codePointCount(0, s.length)
-          case a: Val.Arr    => a.length
-          case o: Val.Obj    => o.visibleKeyNames.length
-          case o: Val.Func   => o.params.names.length
-          case x             => Error.fail("Cannot get length of " + x.prettyName)
+          case v: Val.Str =>
+            val s = v.str
+            if (v._asciiSafe) s.length
+            else s.codePointCount(0, s.length)
+          case a: Val.Arr  => a.length
+          case o: Val.Obj  => o.visibleKeyNames.length
+          case o: Val.Func => o.params.names.length
+          case x           => Error.fail("Cannot get length of " + x.prettyName)
         }).toDouble
       )
   }
@@ -126,7 +129,9 @@ object StringModule extends AbstractFunctionModule {
    */
   private object Substr extends Val.Builtin3("substr", "str", "from", "len") {
     def evalRhs(_s: Eval, from: Eval, len: Eval, ev: EvalScope, pos: Position): Val = {
-      val str = _s.value.asString
+      val srcVal = _s.value
+      val str = srcVal.asString
+      val srcAsciiSafe = srcVal.isInstanceOf[Val.Str] && srcVal.asInstanceOf[Val.Str]._asciiSafe
       val offset = from.value match {
         case v: Val.Num => v.asPositiveInt
         case _ => Error.fail("Expected a number for offset in substr, got " + from.value.prettyName)
@@ -138,6 +143,16 @@ object StringModule extends AbstractFunctionModule {
 
       if (length <= 0) {
         Val.Str(pos, "")
+      } else if (srcAsciiSafe) {
+        val strLen = str.length
+        val safeOffset = math.min(offset, strLen)
+        val safeLength = math.min(length, strLen - safeOffset)
+        if (safeLength <= 0) Val.Str(pos, "")
+        else {
+          val result = Val.Str(pos, str.substring(safeOffset, safeOffset + safeLength))
+          result._asciiSafe = true
+          result
+        }
       } else {
         val requestedEnd = offset.toLong + length.toLong
         if (

--- a/sjsonnet/test/src/sjsonnet/UnicodeHandlingTests.scala
+++ b/sjsonnet/test/src/sjsonnet/UnicodeHandlingTests.scala
@@ -13,6 +13,7 @@ object UnicodeHandlingTests extends TestSuite {
     test("stringLength") {
       eval("std.length('🌍')") ==> ujson.Num(1)
       eval("std.length('Hello 🌍')") ==> ujson.Num(7)
+      eval("std.length('ASCII only')") ==> ujson.Num(10)
       // Jsonnet strings are defined over codepoints, not grapheme clusters, so the
       // following "family" emoji has a length of 7 (because it has 7 codepoints):
       eval("std.length('👨‍👩‍👧‍👦')") ==> ujson.Num(7)
@@ -53,8 +54,17 @@ object UnicodeHandlingTests extends TestSuite {
       eval("std.substr('A🌍B', 0, 1)") ==> ujson.Str("A")
       eval("std.substr('A🌍B', 1, 1)") ==> ujson.Str("🌍")
       eval("std.substr('A🌍B', 2, 1)") ==> ujson.Str("B")
+      eval("std.substr('ASCII only', 6, 4)") ==> ujson.Str("only")
       eval("std.substr('Hello 🌍 World', 6, 100)") ==> ujson.Str("🌍 World")
       eval("std.substr('🌍', 1, 5)") ==> ujson.Str("") // Beyond string length
+    }
+
+    test("longAsciiLengthAndSubstr") {
+      val longAscii = "a" * 1030
+      eval(s"std.length('$longAscii')") ==> ujson.Num(1030)
+      eval(s"std.substr('$longAscii', 1028, 20)") ==> ujson.Str("aa")
+      eval(s"std.substr('$longAscii', 1031, 20)") ==> ujson.Str("")
+      eval(s"std.substr('$longAscii' + '$longAscii', 2058, 10)") ==> ujson.Str("aa")
     }
 
     test("stringSlice") {


### PR DESCRIPTION
Motivation:
Long printable ASCII strings can use UTF-16 length and substring indexes directly because every UTF-16 code unit is also one Jsonnet codepoint. `std.substr` currently still pays codepoint offset checks for these proven-safe long literals.

Key Design Decision:
Reuse the existing `_asciiSafe` runtime marker, but only set it for long (>1024 chars) string literals that are printable ASCII and JSON-render safe. This keeps parser overhead off short-string-heavy workloads and avoids broad runtime ASCII scans. JVM uses byte-level SWAR for the long-string safety scan; Scala Native and Scala.js keep a scalar single-pass scan because the byte-buffer SWAR variant regressed Native due UTF-8 allocation cost.

Modification:
- Add `CharSWAR.isAsciiJsonSafe` on JVM, Native, and JS.
- Use JVM byte-SWAR to check long strings for ASCII + JSON-safe bytes.
- Mark long ASCII JSON-safe literals in `Parser.makeStr`.
- Propagate `_asciiSafe` through `Val.Str.concat` when both operands are safe.
- Let `std.length` and `std.substr` use direct `String.length` / `substring` only for proven-safe strings.
- Add Unicode/ASCII regression coverage for long ASCII length, substr bounds, and concat propagation.

Benchmark Results:
JMH, lower is better (`./mill --no-server -j 1 bench.runRegressions ...`):

| benchmark | master ms/op | this PR ms/op | result |
| --- | ---: | ---: | ---: |
| `go_suite/substr.jsonnet` | 0.056 | 0.045 | ~20% faster |
| `jdk17_suite/split_resolve.jsonnet` | 0.147 | 0.146 | neutral |
| `cpp_suite/realistic2.jsonnet` | 44.529 | 45.024 | neutral/no stable regression signal |

Scala Native hyperfine, lower is better (`--shell=none --warmup 5 --runs 20`):

| command | mean | note |
| --- | ---: | --- |
| master native `go_suite/substr.jsonnet` | 7.7 ± 1.8 ms | baseline |
| this PR native `go_suite/substr.jsonnet` | 6.5 ± 1.0 ms | neutral/slightly faster vs master |
| jrsonnet `go_suite/substr.jsonnet` | 4.0 ± 0.6 ms | still ahead |

Analysis:
The broad #776 ASCII/string fast-path ideas were narrowed aggressively. Runtime ASCII scans in `std.length`/`std.substr` caused guard regressions, and all-platform UTF-8 byte-SWAR regressed Scala Native. This version uses byte-SWAR only where it measured well (JVM), keeps Native/JS allocation-free, and only takes fast paths when the marker is already proven, preserving Jsonnet codepoint semantics for all non-ASCII strings.

References:
- Source idea: https://github.com/databricks/sjsonnet/pull/776
- Narrowed from commit: https://github.com/He-Pin/sjsonnet/commit/a190a800

Result:
Draft PR for review. JVM substr benchmark is positive; Native is neutral/slightly positive with no-shell hyperfine; full `./mill --no-server -j 1 __.reformat && ./mill --no-server -j 1 __.test` passed locally.