### PR TITLE
perf: collect static apply args in one pass

### DIFF
--- a/sjsonnet/src/sjsonnet/StaticOptimizer.scala
+++ b/sjsonnet/src/sjsonnet/StaticOptimizer.scala
@@ -312,8 +312,16 @@ class StaticOptimizer(
       f: Val.Builtin,
       args: Array[Expr],
       tailstrict: Boolean): Expr = {
-    if (f.staticSafe && args.forall(_.isInstanceOf[Val])) {
-      val vargs = args.map(_.asInstanceOf[Val])
+    if (f.staticSafe) {
+      val vargs = new Array[Val](args.length)
+      var i = 0
+      while (i < args.length) {
+        args(i) match {
+          case v: Val => vargs(i) = v
+          case _      => return null
+        }
+        i += 1
+      }
       val tailstrictMode = if (tailstrict) TailstrictModeEnabled else TailstrictModeDisabled
       try f.apply(vargs, null, pos)(ev, tailstrictMode).asInstanceOf[Expr]
       catch { case _: Exception => null }


### PR DESCRIPTION
Motivation:
Reduce repeated traversal in static function-application optimization.

Key Design Decision:
Keep the same folding condition: all arguments must already be `Val`. The change only combines detection and collection into one pass.

Modification:
`StaticOptimizer.tryStaticApply` now fills an `Array[Val]` with a while loop and exits as soon as it sees a non-static argument, replacing the old `forall` plus `map/asInstanceOf` sequence.

Benchmark Results:
| Benchmark | master/prior | PR #838 | Delta | Notes |
| --- | ---: | ---: | ---: | --- |
| `OptimizerBenchmark.main` JMH | `0.422 +/- 0.004 ms/op` | `0.414 +/- 0.005 ms/op` | `-1.90%` | Targeted optimizer benchmark from exploration run. |
| Scala Native hyperfine `realistic2.jsonnet` | `83.700 +/- 1.034 ms` | `84.124 +/- 1.252 ms` | `+0.51%` | Output matched master; end-to-end CLI guard is neutral/noisy. |

Analysis:
The broader historical shortcut was tested and rejected as noisy/negative; this PR keeps only the stable one-pass collection piece. The Native CLI guard does not show a material end-to-end win, but the targeted optimizer benchmark is positive.

References:
Source exploration commit: He-Pin/sjsonnet `0f1fba66`.

Result:
Local `./mill --no-server -j 1 __.reformat` and `./mill --no-server -j 1 __.test` passed on this split branch (`2066/2066`).