### PR TITLE
perf: reuse manifest json visitors

### DIFF
--- a/sjsonnet/src/sjsonnet/Renderer.scala
+++ b/sjsonnet/src/sjsonnet/Renderer.scala
@@ -206,19 +206,9 @@ final case class MaterializeJsonRenderer(
   private val newLineCharArray = newline.toCharArray
   private val keyValueSeparatorCharArray = keyValueSeparator.toCharArray
 
-  override def visitArray(
-      length: Int,
-      index: Int): upickle.core.ArrVisitor[java.io.StringWriter, java.io.StringWriter] {
+  private val reusableArrVisitor: ArrVisitor[StringWriter, StringWriter] {
     def subVisitor: sjsonnet.MaterializeJsonRenderer
   } = new ArrVisitor[StringWriter, StringWriter] {
-    flushBuffer()
-    elemBuilder.append('[')
-
-    depth += 1
-    // account for rendering differences of whitespaces in ujson and jsonnet manifestJson
-    if (length == 0 && indent != -1)
-      elemBuilder.appendAll(newLineCharArray, newLineCharArray.length)
-    else renderIndent()
     def subVisitor: sjsonnet.MaterializeJsonRenderer = MaterializeJsonRenderer.this
     def visitValue(v: StringWriter, index: Int): Unit = {
       flushBuffer()
@@ -234,19 +224,10 @@ final case class MaterializeJsonRenderer(
     }
   }
 
-  override def visitObject(
-      length: Int,
-      index: Int): upickle.core.ObjVisitor[java.io.StringWriter, java.io.StringWriter] {
+  private val reusableObjVisitor: ObjVisitor[StringWriter, StringWriter] {
     def subVisitor: sjsonnet.MaterializeJsonRenderer
     def visitKey(index: Int): sjsonnet.MaterializeJsonRenderer
   } = new ObjVisitor[StringWriter, StringWriter] {
-    flushBuffer()
-    elemBuilder.append('{')
-    depth += 1
-    // account for rendering differences of whitespaces in ujson and jsonnet manifestJson
-    if (length == 0 && indent != -1)
-      elemBuilder.appendAll(newLineCharArray, newLineCharArray.length)
-    else renderIndent()
     def subVisitor: sjsonnet.MaterializeJsonRenderer = MaterializeJsonRenderer.this
     def visitKey(index: Int): sjsonnet.MaterializeJsonRenderer = MaterializeJsonRenderer.this
     def visitKeyValue(s: Any): Unit = {
@@ -263,6 +244,38 @@ final case class MaterializeJsonRenderer(
       flushCharBuilder()
       out
     }
+  }
+
+  override def visitArray(
+      length: Int,
+      index: Int): upickle.core.ArrVisitor[java.io.StringWriter, java.io.StringWriter] {
+    def subVisitor: sjsonnet.MaterializeJsonRenderer
+  } = {
+    flushBuffer()
+    elemBuilder.append('[')
+
+    depth += 1
+    // account for rendering differences of whitespaces in ujson and jsonnet manifestJson
+    if (length == 0 && indent != -1)
+      elemBuilder.appendAll(newLineCharArray, newLineCharArray.length)
+    else renderIndent()
+    reusableArrVisitor
+  }
+
+  override def visitObject(
+      length: Int,
+      index: Int): upickle.core.ObjVisitor[java.io.StringWriter, java.io.StringWriter] {
+    def subVisitor: sjsonnet.MaterializeJsonRenderer
+    def visitKey(index: Int): sjsonnet.MaterializeJsonRenderer
+  } = {
+    flushBuffer()
+    elemBuilder.append('{')
+    depth += 1
+    // account for rendering differences of whitespaces in ujson and jsonnet manifestJson
+    if (length == 0 && indent != -1)
+      elemBuilder.appendAll(newLineCharArray, newLineCharArray.length)
+    else renderIndent()
+    reusableObjVisitor
   }
 }
 


### PR DESCRIPTION
Motivation:
Reduce allocation pressure in `std.manifestJson*` paths that repeatedly materialize nested arrays and objects.

Key Design Decision:
The reused visitors are stateless with respect to the current container; container state remains in the renderer/materializer traversal, so reuse does not leak values between nested containers.

Modification:
`MaterializeJsonRenderer` reuses shared array and object visitors instead of allocating a new visitor instance per container.

Benchmark Results:
| Benchmark | master | PR #839 | Delta | Notes |
| --- | ---: | ---: | ---: | --- |
| Scala Native hyperfine `bench/resources/go_suite/manifestJsonEx.jsonnet` | `5.452 +/- 0.670 ms` | `5.330 +/- 0.590 ms` | `-2.24%` | Output matched master. |
| Scala Native hyperfine kube-prometheus exploration | `235.971 +/- 12.925 ms` | `224.975 +/- 11.550 ms` | `-4.66%` | Stacked exploration result; source-built jrsonnet same run: `88.576 +/- 0.915 ms`. |
| Focused JMH guards | — | `manifestJsonEx 0.052 ms/op`, `realistic2 40.068 ms/op`, `large_string_template 1.137 ms/op` | stable | No guard regression observed in exploration. |

Analysis:
This targets allocation overhead in manifestation without changing rendered JSON semantics.

References:
Source exploration commit: He-Pin/sjsonnet `aac92b03`.

Result:
Local `./mill --no-server -j 1 __.reformat` and `./mill --no-server -j 1 __.test` passed on this split branch (`2066/2066`).