### PR TITLE
perf: scan lf text-block lines with indexOf

### DIFF
--- a/sjsonnet/src/sjsonnet/Parser.scala
+++ b/sjsonnet/src/sjsonnet/Parser.scala
@@ -413,11 +413,17 @@ class Parser(
           else if (pos + indentLen <= dataLen && data.regionMatches(pos, indent, 0, indentLen)) {
             val afterIndent = pos + indentLen
             // Find line end (next separator char)
-            var lineEnd = afterIndent
-            while (lineEnd < dataLen && sep.indexOf(data.charAt(lineEnd)) < 0) lineEnd += 1
+            val lineEnd =
+              if (sepLen == 1) data.indexOf(sep.charAt(0), afterIndent)
+              else {
+                var i = afterIndent
+                while (i < dataLen && sep.indexOf(data.charAt(i)) < 0) i += 1
+                i
+              }
             // Verify full separator at lineEnd
             if (
-              lineEnd + sepLen <= dataLen && data.charAt(lineEnd) == sep.charAt(0) &&
+              lineEnd >= 0 && lineEnd + sepLen <= dataLen &&
+              data.charAt(lineEnd) == sep.charAt(0) &&
               (sepLen == 1 || data.charAt(lineEnd + 1) == sep.charAt(1))
             ) {
               // Zero-copy bulk append: extra whitespace + content + separator (skipping indent)


### PR DESCRIPTION
Motivation:
Large text blocks spend visible parser time finding line boundaries with a Scala character loop.

Key Design Decision:
Only single-character LF separators use `String.indexOf('\n')`; CRLF and other multi-character separator paths keep the previous scanner to preserve behavior.

Modification:
In the bulk `|||` text-block body scanner, use `String.indexOf` to find LF line endings after indentation.

Benchmark Results:
| Benchmark | master | PR #841 | Delta | Notes |
| --- | ---: | ---: | ---: | --- |
| Scala Native hyperfine `bench/resources/cpp_suite/large_string_template.jsonnet` | `10.855 +/- 0.773 ms` | `10.300 +/- 0.638 ms` | `-5.12%` | Output matched master. |
| Scala Native exploration A/B | `11.191 ms` | `10.373 ms` | `-7.3%` | Reverse-order A/B against frozen clean binary. |
| Source-built jrsonnet comparison | — | sjsonnet `10.552 +/- 0.656 ms`; jrsonnet `5.611 +/- 0.826 ms` | gap `1.88x` | Same workload, output matched jrsonnet. |

Analysis:
This is a narrow parser optimization with explicit CRLF fallback. Other larger text-block scanner rewrites were tested and rejected, so this PR keeps only the stable LF `indexOf` win.

References:
Source exploration commit: He-Pin/sjsonnet `8f8ed59a`.

Result:
Local `./mill --no-server -j 1 __.reformat` and `./mill --no-server -j 1 __.test` passed on this split branch (`2066/2066`).