### PR TITLE
perf: scan splitLimitR from the right

### DIFF
--- a/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
@@ -606,6 +606,106 @@ object StringModule extends AbstractFunctionModule {
     b.result()
   }
 
+  private final val SplitLimitRPreallocMaxSplits = 4096
+
+  @inline private def lastSplitIndex(str: String, cStr: String, cLen: Int, from: Int): Int = {
+    var i = if (from < str.length - cLen) from else str.length - cLen
+    if (cLen == 1) {
+      val ch = cStr.charAt(0)
+      while (i >= 0) {
+        if (str.charAt(i) == ch) return i
+        i -= 1
+      }
+    } else if (cLen == 2) {
+      val ch0 = cStr.charAt(0)
+      val ch1 = cStr.charAt(1)
+      while (i >= 0) {
+        if (str.charAt(i) == ch0 && str.charAt(i + 1) == ch1) return i
+        i -= 1
+      }
+    } else {
+      val ch0 = cStr.charAt(0)
+      while (i >= 0) {
+        if (str.charAt(i) == ch0) {
+          var j = 1
+          while (j < cLen && str.charAt(i + j) == cStr.charAt(j)) j += 1
+          if (j == cLen) return i
+        }
+        i -= 1
+      }
+    }
+    -1
+  }
+
+  private def splitLimitR(pos: Position, str: String, cStr: String, maxSplits: Int): Array[Eval] = {
+    if (maxSplits == -1) {
+      return splitLimit(pos, str, cStr, maxSplits)
+    }
+
+    if (cStr.isEmpty) {
+      Error.fail("Cannot split by an empty string")
+    }
+
+    if (maxSplits >= 0 && maxSplits <= SplitLimitRPreallocMaxSplits) {
+      return splitLimitRBounded(pos, str, cStr, maxSplits)
+    }
+
+    val b = new mutable.ArrayBuilder.ofRef[Eval]
+    val cLen = cStr.length
+    var sz = 0
+    var end = str.length
+    var next = if (maxSplits == 0) -1 else lastSplitIndex(str, cStr, cLen, end - cLen)
+
+    while (next >= 0 && (maxSplits < 0 || sz < maxSplits)) {
+      b += Val.Str(pos, str.substring(next + cLen, end))
+      end = next
+      sz += 1
+      next =
+        if (maxSplits >= 0 && sz >= maxSplits) -1
+        else lastSplitIndex(str, cStr, cLen, end - cLen)
+    }
+    b += Val.Str(pos, str.substring(0, end))
+
+    val result = b.result()
+    var left = 0
+    var right = result.length - 1
+    while (left < right) {
+      val tmp = result(left)
+      result(left) = result(right)
+      result(right) = tmp
+      left += 1
+      right -= 1
+    }
+    result
+  }
+
+  private def splitLimitRBounded(
+      pos: Position,
+      str: String,
+      cStr: String,
+      maxSplits: Int): Array[Eval] = {
+    val cLen = cStr.length
+    val result = new Array[Eval](maxSplits + 1)
+    var out = maxSplits
+    var sz = 0
+    var end = str.length
+    var next = if (maxSplits == 0) -1 else lastSplitIndex(str, cStr, cLen, end - cLen)
+
+    while (next >= 0 && sz < maxSplits) {
+      result(out) = Val.Str(pos, str.substring(next + cLen, end))
+      out -= 1
+      end = next
+      sz += 1
+      next =
+        if (sz >= maxSplits) -1
+        else lastSplitIndex(str, cStr, cLen, end - cLen)
+    }
+    result(out) = Val.Str(pos, str.substring(0, end))
+
+    if (out == 0) result
+    else java.util.Arrays.copyOfRange(result, out, maxSplits + 1)
+  }
+
   /**
    * [[https://jsonnet.org/ref/stdlib.html#std-split std.split(str, c)]].
    *
@@ -646,12 +746,7 @@ object StringModule extends AbstractFunctionModule {
    */
   private object SplitLimitR extends Val.Builtin3("splitLimitR", "str", "c", "maxsplits") {
     def evalRhs(str: Eval, c: Eval, maxSplits: Eval, ev: EvalScope, pos: Position): Val = {
-      Val.Arr(
-        pos,
-        splitLimit(pos, str.value.asString.reverse, c.value.asString.reverse, maxSplits.value.asInt)
-          .map(s => Val.Str(pos, s.value.asString.reverse))
-          .reverse
-      )
+      Val.Arr(pos, splitLimitR(pos, str.value.asString, c.value.asString, maxSplits.value.asInt))
     }
   }
 

--- a/sjsonnet/test/src/sjsonnet/Std0150FunctionsTests.scala
+++ b/sjsonnet/test/src/sjsonnet/Std0150FunctionsTests.scala
@@ -78,6 +78,20 @@ object Std0150FunctionsTests extends TestSuite {
       eval("""std.splitLimitR("a,b,c", ",", 1.5)""") ==> ujson.Arr("a,b", "c")
     }
 
+    test("splitLimitR edge cases") {
+      val bulb = new String(Character.toChars(0x1f4a1))
+      eval("""std.splitLimitR("a" + std.char(128161) + "b" + std.char(128161) + "c", std.char(128161), 1)""") ==>
+      ujson.Arr("a" + bulb + "b", "c")
+      eval("""std.splitLimitR("abc", ",", 3)""") ==> ujson.Arr("abc")
+      eval("""std.splitLimitR("a,b,", ",", 1)""") ==> ujson.Arr("a,b", "")
+      eval("""std.splitLimitR("::a::", "::", 1)""") ==> ujson.Arr("::a", "")
+      eval("""std.splitLimitR("aaaa", "aa", 1)""") ==> ujson.Arr("aa", "")
+      eval("""std.splitLimitR("aaa", "aa", -1)""") ==> ujson.Arr("", "a")
+      eval("""std.splitLimitR("aaa", "aa", -2)""") ==> ujson.Arr("a", "")
+      eval("""std.splitLimit("a::b::c", "::", 1)""") ==> ujson.Arr("a", "b::c")
+      eval("""std.splitLimitR("a::b::c", "::", 1)""") ==> ujson.Arr("a::b", "c")
+    }
+
     test("manifestJsonMinified") {
       eval(
         """std.manifestJsonMinified( { x: [1, 2, 3, true, false, null, "string\nstring", []], y: { a: 1, b: 2, c: [1, 2], d: {} }, })"""


### PR DESCRIPTION
## Motivation

`std.splitLimitR` previously implemented right splits by reversing the input string and separator, calling the left-to-right `splitLimit`, then reversing every output segment again. That creates avoidable string copies on bounded right-split workloads and is unfriendly to both JVM JIT and Scala Native/LLVM because the hot path is dominated by whole-string reversals rather than a tight index scan.

This also fixes a compatibility edge case discovered during review: official CPP Jsonnet treats `maxsplits == -1` as the forward unlimited split behavior for overlapping separators.

## Key Design Decision

Use a direct right-to-left scanner for the normal right-split paths, but keep `maxsplits == -1` delegated to the existing left-to-right `splitLimit` implementation to match official CPP Jsonnet overlap semantics.

For bounded splits up to 4096, the implementation fills a preallocated result array from the right and trims only if fewer splits are found. Larger or unbounded right scans use an `ArrayBuilder` and reverse the small result array, avoiding whole-input and per-segment reversals.

## Modification

- Added a right-to-left separator scanner specialized for 1-char, 2-char, and longer separators.
- Replaced the old `str.reverse` / `splitLimit` / segment reverse implementation in `std.splitLimitR`.
- Preserved official `maxsplits == -1` behavior by delegating to `splitLimit`.
- Added regression coverage for Unicode separators, missing separators, trailing separators, multi-char separators, overlapping separators, and `splitLimit` vs `splitLimitR` direction.

## Benchmark Results

### JVM / JMH mixed split workload

Command:

```bash
./mill --no-server --ticker false --color false -j 1 bench.runRegressions bench/resources/jdk17_suite/split_resolve.jsonnet
```

| Workload | master | this PR | Result |
| --- | ---: | ---: | ---: |
| `bench/resources/jdk17_suite/split_resolve.jsonnet` | 0.159 ms/op | 0.148 ms/op | 6.9% faster |

Note: this is a mixed workload containing `split`, `splitLimit`, `splitLimitR`, `resolvePath`, and joins, so it is a conservative JVM signal rather than an isolated splitLimitR-only benchmark.

### Scala Native / hyperfine splitLimitR repeat

Benchmark expression repeatedly evaluates bounded right splits over a `::`-joined 1024-part string with `maxsplits = 512`.

Command shape:

```bash
hyperfine --warmup 3 --runs 25 -N \
  'sjsonnet-master -o /dev/null split_limitr_repeat.jsonnet' \
  'sjsonnet-this-pr -o /dev/null split_limitr_repeat.jsonnet'
```

| Runtime | Mean +- sigma | Result |
| --- | ---: | ---: |
| sjsonnet master Native | 12.4 +- 0.4 ms | baseline |
| sjsonnet this PR Native | 7.0 +- 0.4 ms | 1.76x faster |

### Scala Native / hyperfine vs jrsonnet

| Runtime | Mean +- sigma | Result |
| --- | ---: | ---: |
| sjsonnet this PR Native | 6.8 +- 0.4 ms | baseline |
| local source-built jrsonnet | 12.1 +- 1.4 ms | sjsonnet is 1.77x faster |

## Analysis

The previous implementation copied the full input once for `str.reverse`, copied the separator, allocated split pieces on the reversed string, then copied every segment again while reversing each piece back. The new implementation scans indexes from the right and only allocates final substrings, so the common bounded path becomes a predictable tight loop with fewer allocations and better cache behavior.

The `maxsplits == -1` branch intentionally keeps the existing left-to-right split path because official CPP Jsonnet returns `["", "a"]` for `std.splitLimitR("aaa", "aa", -1)`. Other negative values, such as `-2`, continue to use right-to-left unlimited splitting and return `["a", ""]` for the same overlapping input.

## References

- Official CPP Jsonnet compatibility check: `jsonnet -e 'std.splitLimitR("aaa", "aa", -1)'` returns `["", "a"]`.
- Local branch commit: `b9ecb1d9 perf: scan splitLimitR from the right`.

## Result

`./mill --no-server --ticker false --color false -j 1 __.test` passed with 438 tests. Formatting was applied with `__.reformat`, and `git diff --check` passed.
