### PR TITLE
fix: keep std.trace lazy during static optimization

### DIFF
--- a/sjsonnet/src/sjsonnet/stdlib/StdLibModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/StdLibModule.scala
@@ -80,6 +80,8 @@ object StdLibModule {
       )
       rest.value
     }
+
+    override def staticSafe = false
   }
 
   /**

--- a/sjsonnet/test/resources/test_suite/trace.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/trace.jsonnet.golden
@@ -7,6 +7,6 @@ TRACE: trace.jsonnet
 TRACE: trace.jsonnet 
 TRACE: trace.jsonnet 
 TRACE: trace.jsonnet 
-TRACE: trace.jsonnet Some Trace Message
 TRACE: trace.jsonnet 
+TRACE: trace.jsonnet Some Trace Message
 true

--- a/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
+++ b/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
@@ -4,6 +4,23 @@ import utest._
 import TestUtils.{eval, evalErr}
 
 object EvaluatorTests extends TestSuite {
+  private def evalWithTraces(s: String): (ujson.Value, Vector[String]) = {
+    var traces = Vector.empty[String]
+    val interpreter = new Interpreter(
+      Map(),
+      Map(),
+      DummyPath(),
+      Importer.empty,
+      parseCache = new DefaultParseCache,
+      logger = (isTrace, msg) => if (isTrace) traces :+= msg
+    )
+    val result = interpreter.interpret(s, DummyPath("(memory)")) match {
+      case Right(value) => value
+      case Left(err)    => throw new Exception(err)
+    }
+    (result, traces)
+  }
+
   def tests: Tests = Tests {
     test("arithmetic") {
       eval("1 + 2 + 3") ==> ujson.Num(6)
@@ -568,6 +585,23 @@ object EvaluatorTests extends TestSuite {
       )
       eval("\"%()s %()s!\" % [\"Hello\", \"World\"]") ==> ujson
         .Str("Hello World!")
+    }
+    test("trace laziness") {
+      val (unusedObj, unusedObjTraces) = evalWithTraces(
+        """local x = {a: std.trace("unused object", "ok")}; 0"""
+      )
+      unusedObj ==> ujson.Num(0)
+      unusedObjTraces ==> Vector.empty
+
+      val (unusedFormat, unusedFormatTraces) = evalWithTraces(
+        """local x = "%% %(a)s %%" % {a: std.trace("unused format", "ok")}; 0"""
+      )
+      unusedFormat ==> ujson.Num(0)
+      unusedFormatTraces ==> Vector.empty
+
+      val (used, usedTraces) = evalWithTraces("""std.trace("used trace", 1)""")
+      used ==> ujson.Num(1)
+      usedTraces ==> Vector("TRACE: (memory) used trace")
     }
     test("binaryOps") {
       val ex = assertThrows[Exception](


### PR DESCRIPTION
## Motivation

`std.trace` has an observable side effect: it writes a trace message and returns the `rest` value. The static optimizer previously considered it safe to fold, so it could execute traces while optimizing expressions that the Jsonnet runtime never forces.

That caused two correctness problems:

- unused values such as object fields could emit traces too early;
- trace output could be reordered compared with official Jsonnet runtime behavior.

## Key Design Decision

Mark `std.trace` as not static-safe. This keeps the existing optimizer behavior for pure builtins while preventing the optimizer from executing this side-effecting builtin.

## Modification

- Override `staticSafe = false` on the `std.trace` builtin.
- Add regression tests proving unused traces inside object fields and format RHS values stay silent.
- Keep a positive regression test proving directly used `std.trace` still logs and returns its `rest` value.
- Update the upstream `trace.jsonnet.golden` trace order to match runtime evaluation order.

## Benchmark Results

This is a correctness/compatibility PR, not a performance PR. No benchmark change is expected.

## Analysis

`StaticOptimizer.tryStaticApply` can execute static-safe builtins during optimization. That is correct for pure functions, but `std.trace` is intentionally observable, so executing it before runtime changes program behavior. Disabling static folding for this builtin preserves Jsonnet laziness and official trace ordering without changing the runtime implementation.

## References

- Jsonnet stdlib: `std.trace(str, rest)` outputs `str` and returns `rest`.
- Local commit: `e176c85b fix: keep std.trace lazy during static optimization`.

## Result

`./mill --no-server --ticker false --color false -j 1 __.test` passed with 438 tests. Formatting was applied with `__.reformat`, `git diff --check` passed, and three independent reviews reported no blockers.
