### PR TITLE
fix: preserve byte renderer fallback context

### DIFF
--- a/sjsonnet/src/sjsonnet/ByteRenderer.scala
+++ b/sjsonnet/src/sjsonnet/ByteRenderer.scala
@@ -222,13 +222,13 @@ class ByteRenderer(out: OutputStream = new java.io.ByteArrayOutputStream(), inde
           materializeDirectArr(xs, matDepth + 1, ctx)
         else
           // Fall back to generic visitor path for extremely deep nesting
-          Materializer.apply0(v, this)(evaluator)
+          Materializer.materializeStackless(v, this, ctx)(evaluator)
       case 6 => // TAG_OBJ
         val obj = v.asInstanceOf[Val.Obj]
         if (matDepth < ctx.recursiveDepthLimit)
           materializeDirectObj(obj, matDepth + 1, ctx)
         else
-          Materializer.apply0(v, this)(evaluator)
+          Materializer.materializeStackless(v, this, ctx)(evaluator)
       case 7 => // TAG_FUNC
         val s = v.asInstanceOf[Val.Func]
         Error.fail(

--- a/sjsonnet/src/sjsonnet/Materializer.scala
+++ b/sjsonnet/src/sjsonnet/Materializer.scala
@@ -333,7 +333,7 @@ abstract class Materializer {
 
   // Iterative materialization for deep nesting. Used as a fallback when recursive depth exceeds
   // the recursive depth limit. Uses an explicit ArrayDeque stack to avoid StackOverflowError.
-  private def materializeStackless[T](
+  private[sjsonnet] def materializeStackless[T](
       v: Val,
       visitor: Visitor[T, T],
       ctx: Materializer.MaterializeContext)(implicit evaluator: EvalScope): T = {

--- a/sjsonnet/test/src/sjsonnet/RendererTests.scala
+++ b/sjsonnet/test/src/sjsonnet/RendererTests.scala
@@ -1,5 +1,6 @@
 package sjsonnet
 
+import java.io.ByteArrayOutputStream
 import utest._
 
 object RendererTests extends TestSuite {
@@ -63,6 +64,36 @@ object RendererTests extends TestSuite {
       ujson.transform(ujson.Num(42), new Renderer()).toString ==> "42"
       ujson.transform(ujson.Num(-1), new Renderer()).toString ==> "-1"
       ujson.transform(ujson.Num(1e15), new Renderer()).toString ==> "1000000000000000"
+    }
+
+    test("byteRendererFallbackPreservesCycleContext") {
+      val interpreter = new Interpreter(
+        Map(),
+        Map(),
+        DummyPath(),
+        Importer.empty,
+        parseCache = new DefaultParseCache,
+        settings = Settings.default.copy(materializeRecursiveDepthLimit = 2, maxMaterializeDepth = 2)
+      )
+      val value = interpreter.evaluate(
+        """local o = {
+          |  a: std.repeat("x", 10000),
+          |  z: { b: o },
+          |};
+          |{ root: o }""".stripMargin,
+        DummyPath("(memory)")
+      ) match {
+        case Right(v)  => v
+        case Left(err) => throw new Exception(Error.formatError(err))
+      }
+      val out = new ByteArrayOutputStream
+      val e = interpreter.materialize(value, new ByteRenderer(out)) match {
+        case Left(err) => Error.formatError(err)
+        case Right(_)  => throw new Exception("Expected recursive value materialization error")
+      }
+      assert(e.contains("Stackoverflow while materializing, possibly due to recursive value"))
+      // Losing the outer materialization context re-renders `o.a` before detecting the cycle.
+      assert(out.size() < 15000)
     }
 
     test("indentZero") {


### PR DESCRIPTION
Motivation:
ByteRenderer's direct materialization path falls back to the generic stackless materializer for very deep arrays/objects. That fallback previously started via `Materializer.apply0`, which creates a fresh `MaterializeContext` and drops the objects already being materialized on the active ByteRenderer path.

Key Design Decision:
Reuse the active `MaterializeContext` when switching from ByteRenderer's direct recursive path to stackless materialization. This keeps `visitedObjects`, sort behavior, assertion logic, and materialization limits consistent across the fallback boundary.

Modification:
- Change deep array/object ByteRenderer fallback to call `Materializer.materializeStackless(v, this, ctx)`.
- Widen `materializeStackless` to `private[sjsonnet]` so ByteRenderer can reuse it without exposing it publicly.
- Add a regression test that proves the old path duplicated partial output before detecting a recursive object, while the fixed path preserves the outer cycle context.

Benchmark Results:
N/A — correctness-only split from render optimization review material. No performance claim is made for this PR.

Analysis:
The old fallback still eventually reported the same recursive materialization error, but it did extra work with a fresh context first. The regression test uses a recursive object with a large string field and a low fallback threshold: the fixed path flushes one copy of the large field before detecting the cycle, while the old path re-rendered the field again before failing.

Validation:
- `./mill --no-server --ticker false --color false -j 1 'sjsonnet.jvm[3.3.7]'.test.testOnly sjsonnet.RendererTests` passed.
- `./mill --no-server --ticker false --color false -j 1 'sjsonnet.jvm[3.3.7]'.test` passed.
- `./mill --no-server --ticker false --color false -j 1 __.test` passed.
- `./mill --no-server --ticker false --color false -j 1 __.checkFormat` passed.

References:
- Split from render optimization review/source material in #776.
- Local commit: 7651bb79a9e8dbff09af143d55cb05220c1fec73.

Result:
ByteRenderer fallback now preserves recursive-object detection context across the direct-to-stackless transition without changing external APIs or successful rendering semantics.