### PR TITLE
perf: render escaped byte strings in one pass

### DIFF
--- a/sjsonnet/src/sjsonnet/BaseByteRenderer.scala
+++ b/sjsonnet/src/sjsonnet/BaseByteRenderer.scala
@@ -319,9 +319,8 @@ class BaseByteRenderer[T <: java.io.OutputStream](
       arr(pos + 1 + bLen) = '"'.toByte
       elemBuilder.length = pos + bLen + 2
     } else {
-      val escapedLen = escapedStringLength(bytes, bLen, firstEscape)
-      elemBuilder.ensureLength(escapedLen)
-      val arr = elemBuilder.arr
+      elemBuilder.ensureLength(bLen + 2 + (bLen >>> 5))
+      var arr = elemBuilder.arr
       var outPos = elemBuilder.length
       arr(outPos) = '"'.toByte
       outPos += 1
@@ -330,40 +329,38 @@ class BaseByteRenderer[T <: java.io.OutputStream](
       while (escPos >= 0) {
         if (escPos > from) {
           val chunkLen = escPos - from
+          elemBuilder.length = outPos
+          elemBuilder.ensureLength(chunkLen + 6)
+          arr = elemBuilder.arr
+          outPos = elemBuilder.length
           System.arraycopy(bytes, from, arr, outPos, chunkLen)
           outPos += chunkLen
         }
+        elemBuilder.length = outPos
+        elemBuilder.ensureLength(6)
+        arr = elemBuilder.arr
+        outPos = elemBuilder.length
         outPos = escapeByteInline(bytes(escPos) & 0xff, arr, outPos)
         from = escPos + 1
         escPos = if (from < bLen) CharSWAR.findFirstEscapeChar(bytes, from, bLen) else -1
       }
       if (from < bLen) {
         val tailLen = bLen - from
+        elemBuilder.length = outPos
+        elemBuilder.ensureLength(tailLen + 1)
+        arr = elemBuilder.arr
+        outPos = elemBuilder.length
         System.arraycopy(bytes, from, arr, outPos, tailLen)
         outPos += tailLen
       }
+      elemBuilder.length = outPos
+      elemBuilder.ensureLength(1)
+      arr = elemBuilder.arr
+      outPos = elemBuilder.length
       arr(outPos) = '"'.toByte
       elemBuilder.length = outPos + 1
     }
   }
-
-  private def escapedStringLength(bytes: Array[Byte], bLen: Int, firstEscape: Int): Int = {
-    var len = bLen + 2
-    var from = firstEscape
-    var escPos = firstEscape
-    while (escPos >= 0) {
-      len += escapeExtraLength(bytes(escPos) & 0xff)
-      from = escPos + 1
-      escPos = if (from < bLen) CharSWAR.findFirstEscapeChar(bytes, from, bLen) else -1
-    }
-    len
-  }
-
-  @inline private def escapeExtraLength(b: Int): Int =
-    (b: @scala.annotation.switch) match {
-      case '"' | '\\' | '\b' | '\f' | '\n' | '\r' | '\t' => 1
-      case _                                             => 5
-    }
 
   /** Inline JSON escape for one byte that is known to require escaping. */
   @inline private def escapeByteInline(b: Int, arr: Array[Byte], outPos0: Int): Int = {

--- a/sjsonnet/test/src/sjsonnet/RendererTests.scala
+++ b/sjsonnet/test/src/sjsonnet/RendererTests.scala
@@ -1,5 +1,6 @@
 package sjsonnet
 
+import java.io.ByteArrayOutputStream
 import utest._
 
 object RendererTests extends TestSuite {
@@ -63,6 +64,13 @@ object RendererTests extends TestSuite {
       ujson.transform(ujson.Num(42), new Renderer()).toString ==> "42"
       ujson.transform(ujson.Num(-1), new Renderer()).toString ==> "-1"
       ujson.transform(ujson.Num(1e15), new Renderer()).toString ==> "1000000000000000"
+    }
+
+    test("byteRendererLongEscapedString") {
+      val s = ("abc\n\"\\\t\u0001" * 40) + "tail"
+      val out = new ByteArrayOutputStream
+      ujson.transform(ujson.Str(s), new ByteRenderer(out))
+      out.toString("UTF-8") ==> ujson.transform(ujson.Str(s), new Renderer()).toString
     }
 
     test("indentZero") {


### PR DESCRIPTION
Motivation:
`large_string_template` renders a ~550 KB JSON string with many escaped newlines. ByteRenderer's long-string path already finds the first escaped byte, but the escaped branch then rescanned the rest of the byte array to compute the exact output length before doing the actual copy/escape pass.

Key Design Decision:
Avoid the second escape scan and keep the existing byte-oriented renderer path. The renderer now reserves a conservative initial buffer size, updates `ByteBuilder.length` before capacity checks, and refreshes the backing byte array after each possible growth.

Modification:
- Remove the escaped-length pre-scan from `BaseByteRenderer.visitLongString`.
- Copy clean chunks and inline escaped bytes in one pass after `findFirstEscapeChar`.
- Add a long escaped string regression test comparing ByteRenderer output against the existing char Renderer, covering newline, quote, backslash, tab, `\u00XX` control escaping, and trailing plain text.

Benchmark Results:
JMH, JVM 21, single-threaded `bench.runRegressions` on `bench/resources/cpp_suite/large_string_template.jsonnet`:

| Case | Before | After | Result |
|---|---:|---:|---:|
| `large_string_template` | 0.701-0.722 ms/op | 0.578-0.655 ms/op | positive |
| `repeat_format` guard | 0.135 ms/op | 0.135-0.141 ms/op | neutral/noisy |
| `large_string_join` guard | 0.257 ms/op | 0.255-0.281 ms/op | neutral/noisy |

JMH GC profile on `large_string_template`:

| Case | Score | Alloc/op |
|---|---:|---:|
| Before | 0.701 ms/op | 7,199,720 B/op |
| After | 0.584 ms/op | 7,199,111 B/op |

Scala Native hyperfine, 10 runs, `large_string_template`:

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|---|---:|---:|---:|---:|
| sjsonnet native baseline `ca61a7a3` | 13.1 ± 1.6 | 10.7 | 15.9 | 2.17 ± 0.58 |
| sjsonnet native single-pass escape | 12.9 ± 1.1 | 11.3 | 14.5 | 2.14 ± 0.54 |
| jrsonnet rust | 6.0 ± 1.4 | 4.6 | 9.6 | 1.00 |

jrsonnet upstream benchmark document lists this same case as Rust 2.1 ms and Scala Native 14.5 ms on its machine; local absolute numbers differ, but the remaining local gap is still about 2.1x in favor of jrsonnet.

Analysis:
Stack profiling showed `BaseByteRenderer.visitLongString` and escape scanning on the hot path, while lazy format concatenation itself did not show enough top-stack weight. A rejected side experiment that marked formatted strings as ASCII-safe was incorrect for newline-containing JSON strings; a correct ASCII-only char loop was much slower. The retained change preserves the existing UTF-8 byte path and only removes duplicated escape scanning.

Validation:
- `./mill --no-server --ticker false --color false -j 1 'sjsonnet.jvm[3.3.7]'.test.testOnly sjsonnet.RendererTests` passed.
- `./mill --no-server --ticker false --color false -j 1 'sjsonnet.jvm[3.3.7]'.test` passed.
- `./mill --no-server --ticker false --color false -j 1 __.test` passed.
- `./mill --no-server --ticker false --color false -j 1 __.checkFormat` passed.
- `./mill --no-server --ticker false --color false -j 1 __.reformat` was run before commit.
- `./mill --no-server --ticker false --color false -j 1 'sjsonnet.native[3.3.7]'.nativeLink` passed for both baseline and this branch.

References:
- Target benchmark: `bench/resources/cpp_suite/large_string_template.jsonnet`.
- jrsonnet benchmark source: `jrsonnet/docs/benchmarks.adoc`, section "Large string template".
- Local commit: 55ff93581ab223cc7c10e6a7945097ccce2dc35d.

Result:
Long escaped JSON strings render with one escape/copy pass in ByteRenderer. JVM JMH improves on the target workload; Scala Native is slightly positive but within hyperfine noise, so this remains draft for review.
