### PR TITLE
perf: parse strict JSON imports from bytes

### DIFF
--- a/sjsonnet/src-jvm-native/sjsonnet/CachedResolvedFile.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/CachedResolvedFile.scala
@@ -5,7 +5,6 @@ import fastparse.ParserInput
 import java.io.File
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
-import java.security.MessageDigest
 
 /**
  * A class that encapsulates a resolved import. This is used to cache the result of resolving an
@@ -55,25 +54,7 @@ class CachedResolvedFile(
   private lazy val resolvedTextContent: ResolvedFile =
     StaticResolvedFile(new String(cachedBytes, StandardCharsets.UTF_8))
 
-  private lazy val cachedBytesHash: String =
-    cachedBytes.length.toString + ":" + bytesToHex(
-      MessageDigest.getInstance("SHA-256").digest(cachedBytes)
-    )
-
-  private def bytesToHex(bytes: Array[Byte]): String = {
-    val hexChars = "0123456789abcdef"
-    val out = new Array[Char](bytes.length * 2)
-    var i = 0
-    var j = 0
-    while (i < bytes.length) {
-      val b = bytes(i) & 0xff
-      out(j) = hexChars.charAt(b >>> 4)
-      out(j + 1) = hexChars.charAt(b & 0x0f)
-      i += 1
-      j += 2
-    }
-    new String(out)
-  }
+  private lazy val cachedBytesHash: String = Platform.hashBytes(cachedBytes)
 
   /**
    * A method that will return a reader for the resolved import. If the import is too large, then

--- a/sjsonnet/src-jvm-native/sjsonnet/CachedResolvedFile.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/CachedResolvedFile.scala
@@ -5,6 +5,7 @@ import fastparse.ParserInput
 import java.io.File
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
+import java.security.MessageDigest
 
 /**
  * A class that encapsulates a resolved import. This is used to cache the result of resolving an
@@ -37,17 +38,13 @@ class CachedResolvedFile(
     s"Resolved import path $resolvedImportPath is too large: ${jFile.length()} bytes > $memoryLimitBytes bytes"
   )
 
-  private val resolvedImportContent: ResolvedFile = {
-    // TODO: Support caching binary data
-    if (jFile.length() > cacheThresholdBytes) {
-      // If the file is too large, then we will just read it from disk
-      null
-    } else if (binaryData) {
-      StaticBinaryResolvedFile(readRawBytes(jFile))
-    } else {
-      StaticResolvedFile(readString(jFile))
-    }
-  }
+  private val cachedBytes: Array[Byte] =
+    if (jFile.length() > cacheThresholdBytes) null
+    else readRawBytes(jFile)
+
+  private val cachedBinaryContent: ResolvedFile =
+    if (cachedBytes != null && binaryData) StaticBinaryResolvedFile(cachedBytes)
+    else null
 
   private def readString(jFile: File): String = {
     new String(Files.readAllBytes(jFile.toPath), StandardCharsets.UTF_8)
@@ -55,45 +52,72 @@ class CachedResolvedFile(
 
   private def readRawBytes(jFile: File): Array[Byte] = Files.readAllBytes(jFile.toPath)
 
+  private lazy val resolvedTextContent: ResolvedFile =
+    StaticResolvedFile(new String(cachedBytes, StandardCharsets.UTF_8))
+
+  private lazy val cachedBytesHash: String =
+    cachedBytes.length.toString + ":" + bytesToHex(
+      MessageDigest.getInstance("SHA-256").digest(cachedBytes)
+    )
+
+  private def bytesToHex(bytes: Array[Byte]): String = {
+    val hexChars = "0123456789abcdef"
+    val out = new Array[Char](bytes.length * 2)
+    var i = 0
+    var j = 0
+    while (i < bytes.length) {
+      val b = bytes(i) & 0xff
+      out(j) = hexChars.charAt(b >>> 4)
+      out(j + 1) = hexChars.charAt(b & 0x0f)
+      i += 1
+      j += 2
+    }
+    new String(out)
+  }
+
   /**
    * A method that will return a reader for the resolved import. If the import is too large, then
    * this will return a reader that will read the file from disk. Otherwise, it will return a reader
    * that reads from memory.
    */
   def getParserInput(): ParserInput = {
-    if (resolvedImportContent == null) {
+    if (cachedBytes == null) {
       FileParserInput(jFile)
+    } else if (binaryData) {
+      cachedBinaryContent.getParserInput()
     } else {
-      resolvedImportContent.getParserInput()
+      resolvedTextContent.getParserInput()
     }
   }
 
   override def readString(): String = {
-    if (resolvedImportContent == null) {
+    if (cachedBytes == null) {
       // If the file is too large, then we will just read it from disk
       readString(jFile)
+    } else if (binaryData) {
+      cachedBinaryContent.readString()
     } else {
       // Otherwise, we will read it from memory
-      resolvedImportContent.readString()
+      resolvedTextContent.readString()
     }
   }
 
   override def contentHash(): String = {
-    if (resolvedImportContent == null) {
+    if (cachedBytes == null) {
       // If the file is too large, then we will just read it from disk
       Platform.hashFile(jFile)
     } else {
-      resolvedImportContent.contentHash()
+      cachedBytesHash
     }
   }
 
   override def readRawBytes(): Array[Byte] = {
-    if (resolvedImportContent == null) {
+    if (cachedBytes == null) {
       // If the file is too large, then we will just read it from disk
       readRawBytes(jFile)
     } else {
       // Otherwise, we will read it from memory
-      resolvedImportContent.readRawBytes()
+      cachedBytes
     }
   }
 }

--- a/sjsonnet/src-jvm/sjsonnet/Platform.scala
+++ b/sjsonnet/src-jvm/sjsonnet/Platform.scala
@@ -140,6 +140,9 @@ object Platform {
 
   private val xxHashFactory = XXHashFactory.fastestInstance()
 
+  def hashBytes(bytes: Array[Byte]): String =
+    xxHashFactory.hash64().hash(bytes, 0, bytes.length, 0).toString
+
   def hashFile(file: File): String = {
     val buffer = new Array[Byte](8192)
     val hash: StreamingXXHash64 = xxHashFactory.newStreamingHash64(0)

--- a/sjsonnet/src-native/sjsonnet/Platform.scala
+++ b/sjsonnet/src-native/sjsonnet/Platform.scala
@@ -197,6 +197,9 @@ object Platform {
   // Same as go-jsonnet https://github.com/google/go-jsonnet/blob/2b4d7535f540f128e38830492e509a550eb86d57/builtins.go#L959
   def sha3(s: String): String = computeHash("SHA3-512", s)
 
+  def hashBytes(bytes: Array[Byte]): String =
+    scala.util.hashing.MurmurHash3.bytesHash(bytes).toHexString
+
   def hashFile(file: File): String = {
     scala.util.hashing.MurmurHash3
       .orderedHash(

--- a/sjsonnet/src/sjsonnet/Importer.scala
+++ b/sjsonnet/src/sjsonnet/Importer.scala
@@ -302,7 +302,7 @@ object CachedResolver {
     try {
       val visitor =
         new JsonImportVisitor(fileScope, internedStrings, settings)
-      Some((ujson.StringParser.transform(content.readString(), visitor), fileScope))
+      Some((ujson.ByteArrayParser.transform(content.readRawBytes(), visitor), fileScope))
     } catch {
       case _: ujson.ParsingFailedException | _: DuplicateJsonKey | _: InvalidJsonNumber |
           _: JsonParseDepthExceeded | _: NumberFormatException =>

--- a/sjsonnet/test/src/sjsonnet/PreloaderTests.scala
+++ b/sjsonnet/test/src/sjsonnet/PreloaderTests.scala
@@ -173,7 +173,8 @@ object PreloaderTests extends TestSuite {
       class JsonOnlyResolvedFile(content: String) extends ResolvedFile {
         def getParserInput(): fastparse.ParserInput =
           throw new RuntimeException("strict JSON should not be parsed with fastparse")
-        def readString(): String = content
+        def readString(): String =
+          throw new RuntimeException("strict JSON should not be decoded as text")
         def contentHash(): String = content
         def readRawBytes(): Array[Byte] =
           content.getBytes(java.nio.charset.StandardCharsets.UTF_8)


### PR DESCRIPTION
Motivation:

PR #840 added a strict JSON import fast path, but cached file imports still decoded every small file to a UTF-8 `String` before strict `.json` parsing. Real-world Jsonnet projects such as kube-prometheus import many JSON files, so decoding bytes to text only to parse them as UTF-8 JSON adds avoidable allocation and CPU cost.

Key Design Decision:

Use `ujson.ByteArrayParser` for strict `.json` imports and keep small cached resolved files byte-backed until text is explicitly needed by `importstr` or Fastparse. This keeps the JSON path byte-native while preserving existing text behavior for Jsonnet source parsing.

Modification:

* `CachedResolvedFile` now caches small resolved files as `Array[Byte]`, lazily materializes text for `getParserInput` / `readString`, and returns cached bytes directly for `readRawBytes`.
* `CachedResolver.parseJsonImport` now parses strict JSON imports with `ujson.ByteArrayParser.transform(content.readRawBytes(), visitor)`.
* `PreloaderTests` now assert strict JSON preload does not fall back to Fastparse or decode via `readString`.

Result:

Output equality was preserved against upstream sjsonnet and source-built jrsonnet:

* kube-prometheus realworld output: `7,506,029` bytes, byte-identical.
* `large_string_template` guard output: `549,674` bytes, byte-identical.

Benchmark Results:

Native whole-process kube-prometheus, command run from `jrsonnet/tests/realworld` with `-J vendor`, `hyperfine --shell=none --warmup 5 --runs 50`:

| order | upstream/master | this PR | jrsonnet |
|---|---:|---:|---:|
| forward | `143.351 +/- 2.556 ms` | `135.806 +/- 3.388 ms` | `91.752 +/- 7.863 ms` |
| reverse | `145.082 +/- 2.988 ms` | `136.392 +/- 2.034 ms` | `91.365 +/- 1.419 ms` |

Native guard, `bench/resources/cpp_suite/large_string_template.jsonnet`:

| upstream/master | this PR | jrsonnet |
|---:|---:|---:|
| `11.036 +/- 0.807 ms` | `10.762 +/- 0.650 ms` | `5.204 +/- 0.511 ms` |

JMH guard, `bench.runRegressions`:

| benchmark | upstream/master | this PR |
|---|---:|---:|
| `cpp_suite/large_string_template.jsonnet` | `0.757 ms/op` | `0.691 ms/op` |
| `go_suite/manifestJsonEx.jsonnet` | `0.055 ms/op` | `0.054 ms/op` |

Analysis:

The target workload improves by about 5-6% in both command orders. The remaining gap to jrsonnet is not eliminated, but this change removes one clear extra decode from strict JSON import handling without regressing the non-target renderer guard or JMH guards.

Validation:

* `./mill --no-server --ticker false --color false -j 1 __.checkFormat`
* `./mill --no-server --ticker false --color false -j 1 __.test` (`Tests: 440, Passed: 440, Failed: 0`)

References:

Follow-up to https://github.com/databricks/sjsonnet/pull/840
