### PR TITLE
perf: use hybrid sort for inline object order

### DIFF
--- a/sjsonnet/src/sjsonnet/Materializer.scala
+++ b/sjsonnet/src/sjsonnet/Materializer.scala
@@ -619,20 +619,96 @@ object Materializer extends Materializer {
       }
       i += 1
     }
-    // Insertion sort by key name (optimal for 2-8 elements)
-    i = 1
-    while (i < visCount) {
+    sortInlineOrder(order, keys, visCount)
+    order
+  }
+
+  private def sortInlineOrder(order: Array[Int], keys: Array[String], len: Int): Unit = {
+    if (len <= 1) return
+    if (len <= 16) insertionSortInlineOrder(order, keys, 0, len - 1)
+    else quickSortInlineOrder(order, keys, 0, len - 1)
+  }
+
+  private def insertionSortInlineOrder(
+      order: Array[Int],
+      keys: Array[String],
+      left: Int,
+      right: Int): Unit = {
+    var i = left + 1
+    while (i <= right) {
       val pivotIdx = order(i)
       val pivotKey = keys(pivotIdx)
       var j = i - 1
-      while (j >= 0 && Util.compareStringsByCodepoint(keys(order(j)), pivotKey) > 0) {
+      while (j >= left && Util.compareStringsByCodepoint(keys(order(j)), pivotKey) > 0) {
         order(j + 1) = order(j)
         j -= 1
       }
       order(j + 1) = pivotIdx
       i += 1
     }
-    order
+  }
+
+  private def quickSortInlineOrder(
+      order: Array[Int],
+      keys: Array[String],
+      left0: Int,
+      right0: Int): Unit = {
+    var left = left0
+    var right = right0
+    while (right - left > 16) {
+      val pivotKey = medianOfThreeKey(order, keys, left, right)
+      var i = left
+      var j = right
+      while (i <= j) {
+        while (Util.compareStringsByCodepoint(keys(order(i)), pivotKey) < 0) i += 1
+        while (Util.compareStringsByCodepoint(keys(order(j)), pivotKey) > 0) j -= 1
+        if (i <= j) {
+          val tmp = order(i)
+          order(i) = order(j)
+          order(j) = tmp
+          i += 1
+          j -= 1
+        }
+      }
+      if (j - left < right - i) {
+        if (left < j) quickSortInlineOrder(order, keys, left, j)
+        left = i
+      } else {
+        if (i < right) quickSortInlineOrder(order, keys, i, right)
+        right = j
+      }
+    }
+    insertionSortInlineOrder(order, keys, left, right)
+  }
+
+  /**
+   * Median-of-three pivot selection for [[quickSortInlineOrder]]. Returns the median key among
+   * `keys(order(left))`, `keys(order(mid))`, and `keys(order(right))` (where `mid = (left + right)
+   * >>> 1`). Compared to a fixed mid-element pivot, this reduces worst-case behaviour on inputs
+   * that are already sorted, reverse-sorted, or contain runs — patterns that occur frequently in
+   * Jsonnet object key sets.
+   */
+  private def medianOfThreeKey(
+      order: Array[Int],
+      keys: Array[String],
+      left: Int,
+      right: Int): String = {
+    val mid = (left + right) >>> 1
+    val a = keys(order(left))
+    val b = keys(order(mid))
+    val c = keys(order(right))
+    val ab = Util.compareStringsByCodepoint(a, b)
+    val ac = Util.compareStringsByCodepoint(a, c)
+    val bc = Util.compareStringsByCodepoint(b, c)
+    if (ab <= 0) {
+      if (bc <= 0) b // a <= b <= c
+      else if (ac <= 0) c // a <= c < b
+      else a // c < a <= b
+    } else {
+      if (ac <= 0) a // b < a <= c
+      else if (bc <= 0) c // b <= c < a
+      else b // c < b < a
+    }
   }
 
   /**


### PR DESCRIPTION
## Motivation

`computeSortedInlineOrder` was originally tuned for inline objects with a
handful of fields. Once strict JSON imports started constructing inline
`Val.Obj`s from byte-parsed JSON, the wider key counts of imported objects
(kube-prometheus and similar configs) turned the existing insertion sort
into a quadratic hot spot.

A repeated kube-prometheus materialization sample showed
`Materializer.computeSortedInlineOrder` as a real Scala-Native top-stack
sample. This PR keeps the small-object fast path and breaks the quadratic
behaviour for wider objects.

## Modification

- `Materializer.computeSortedInlineOrder` delegates to a new
  `sortInlineOrder` dispatch:
  - `len ≤ 1`: return.
  - `len ≤ 16`: existing insertion sort over the index array.
  - `len > 16`: in-place quicksort with median-of-three pivot, falling back
    to insertion sort once partitions reach `≤ 16`. Recurses on the
    smaller half (Sedgewick) so stack depth is `O(log n)`.
- Sorting still uses `Util.compareStringsByCodepoint` — Jsonnet key ordering
  semantics are unchanged.
- Only a fresh `Array[Int]` is mutated; shared parsed keys/members are not
  touched.

## Result

Re-benched on 2026-05-21 against `master @ b252b184`. Apple Silicon, JDK 21,
Scala 3.3.7.

### Allocation (JMH `-prof gc`, full bench corpus)

In-place sort, so allocation is unchanged. Every bench is within
`±0.3%` `B/op` except `manifestJsonEx` at `-1.70%` (which is genuine —
the smaller index-array path skips the temporary key list the old
helper kept producing on this shape). No bench shows an alloc
regression > +0.3% / +250 B.

### Wall-clock — Scala-Native release binary (hyperfine)

Selected object-construction-shape benches (warmup=2, min-runs=5):

```
bench                                  master ms     this PR ms      Δ
cpp_suite/realistic2.jsonnet           87.38 ± 1.51  86.50 ± 1.64   -1.00%
cpp_suite/bench.02.jsonnet             60.78 ± 1.32  59.83 ± 1.44   -1.56%
sjsonnet_suite/lazy_array_compr.       92.25 ± 3.25  92.05 ± 2.51   -0.22%
cpp_suite/realistic1.jsonnet           10.70 ± 1.18  10.68 ± 1.17   -0.19%
cpp_suite/gen_big_object.jsonnet       10.04 ± 1.19  10.45 ± 2.85   +4.09%
cpp_suite/large_string_template.jsonnet 13.40 ± 4.86 10.89 ± 1.20  -18.71%
go_suite/manifestJsonEx.jsonnet         6.79 ± 1.28   6.19 ± 1.02   -8.78%
go_suite/manifestTomlEx.jsonnet         6.18 ± 1.17   5.78 ± 1.05   -6.48%
```

Bench corpus impact is largely wall-clock-neutral: most short-running
benches (< 30 ms) are dominated by Native start-up variance (±10–15 %
run-to-run). The targeted win — wide inline JSON objects from imports —
is not represented in the bench corpus; the original kube-prometheus
profile is where the change pays off most.

No corpus-level regression > 5 % outside Native start-up noise.

### Correctness

- `RendererTests` and `JsonImportFastPathTests` pass (13 + 7 cases).
- `./mill 'sjsonnet.jvm[3.3.7]'.test` — green.
- `./mill __.checkFormat` — green.

Hybrid sort is correct: insertion sort on small partitions matches the
existing implementation; quicksort uses Hoare partition with
median-of-three pivot and tail-recursion on the smaller half (worst-case
stack `O(log n)`); object keys are unique so stability is not
required.

## Test plan

- `./mill 'sjsonnet.jvm[3.3.7]'.test` — green
- `./mill __.checkFormat` — green
