### PR TITLE
test: add PartialApplyFmt unit tests for ASCII-safe handling

### DIFF
--- a/sjsonnet/test/src/sjsonnet/FormatTests.scala
+++ b/sjsonnet/test/src/sjsonnet/FormatTests.scala
@@ -1,0 +1,73 @@
+package sjsonnet
+
+import sjsonnet.Expr.Member.Visibility
+import utest._
+
+object FormatTests extends TestSuite {
+  private val pos = new Position(null, 0)
+
+  private implicit val scope: EvalScope = new EvalScope {
+    def extVars: String => Option[Expr] = _ => None
+    def importer: CachedImporter = new CachedImporter(Importer.empty)
+    def wd: Path = DummyPath()
+    def visitExpr(expr: Expr)(implicit scope: ValScope): Val =
+      throw new UnsupportedOperationException("not used")
+    def materialize(v: Val): ujson.Value =
+      throw new UnsupportedOperationException("not used")
+    def equal(x: Val, y: Val): Boolean = x == y
+    def compare(x: Val, y: Val): Int = 0
+    def settings: Settings = Settings.default
+    def debugStats: DebugStats = null
+    def trace(msg: String): Unit = ()
+    def warn(e: Error): Unit = ()
+  }
+
+  def tests: Tests = Tests {
+    test("simple named format preserves ascii-safe result for numeric values") {
+      val fmt = new Format.PartialApplyFmt("hello %(x)s")
+      val obj = Val.Obj.mk(
+        pos,
+        "x" -> new Val.Obj.ConstMember(add2 = false, Visibility.Normal, Val.Num(pos, 3))
+      )
+      val result = fmt.evalRhs(obj, scope, pos).asInstanceOf[Val.Str]
+      result.str ==> "hello 3"
+      result._asciiSafe ==> true
+    }
+
+    test("simple named format does not mark unsafe string values ascii-safe") {
+      val fmt = new Format.PartialApplyFmt("hello %(x)s")
+      val obj = Val.Obj.mk(
+        pos,
+        "x" -> new Val.Obj.ConstMember(add2 = false, Visibility.Normal, Val.Str(pos, "\""))
+      )
+      val result = fmt.evalRhs(obj, scope, pos).asInstanceOf[Val.Str]
+      result.str ==> "hello \""
+      result._asciiSafe ==> false
+    }
+
+    test("simple named format does not mark unsafe static literals ascii-safe") {
+      val fmt = new Format.PartialApplyFmt("hello \"%(x)s")
+      val obj = Val.Obj.mk(
+        pos,
+        "x" -> new Val.Obj.ConstMember(add2 = false, Visibility.Normal, Val.Num(pos, 3))
+      )
+      val result = fmt.evalRhs(obj, scope, pos).asInstanceOf[Val.Str]
+      result.str ==> "hello \"3"
+      result._asciiSafe ==> false
+    }
+
+    test("simple named format combines ascii-safety across multiple keys") {
+      val safe = Val.Str.asciiSafe(pos, "safe")
+      val unsafe = Val.Str(pos, "\\")
+      val fmt = new Format.PartialApplyFmt("%(safe)s %(unsafe)s %(safe)s")
+      val obj = Val.Obj.mk(
+        pos,
+        "safe" -> new Val.Obj.ConstMember(add2 = false, Visibility.Normal, safe),
+        "unsafe" -> new Val.Obj.ConstMember(add2 = false, Visibility.Normal, unsafe)
+      )
+      val result = fmt.evalRhs(obj, scope, pos).asInstanceOf[Val.Str]
+      result.str ==> "safe \\ safe"
+      result._asciiSafe ==> false
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up unit coverage for #860 (which propagates ASCII-safety through Format outputs).

The original branch held the production implementation, but #860 covers the same optimization with a slightly different approach and was merged first. Reduce this PR to the regression tests that were developed for the original implementation — they pass unchanged against the current `Format.scala`.

## Changes

* `sjsonnet/test/src/sjsonnet/FormatTests.scala` — 4 new tests directly exercising `Format.PartialApplyFmt.evalRhs` via a minimal in-memory `EvalScope`:
  1. simple named format preserves ascii-safe result for numeric values
  2. simple named format does not mark unsafe string values ascii-safe
  3. simple named format does not mark unsafe static literals ascii-safe
  4. simple named format combines ascii-safety across multiple keys

## Verification

```bash
./mill 'sjsonnet.jvm[3.3.7]'.test.testOnly sjsonnet.FormatTests
# Tests: 4, Passed: 4, Failed: 0

./mill __.checkFormat
# SUCCESS
```

## References

* #860 — perf: propagate ASCII-safety through Format outputs (merged)