### PR TITLE
perf: replace Val.Str._asciiSafe flag with AsciiSafeStr subclass

### DIFF
--- a/sjsonnet/src/sjsonnet/ByteRenderer.scala
+++ b/sjsonnet/src/sjsonnet/ByteRenderer.scala
@@ -193,7 +193,7 @@ class ByteRenderer(out: OutputStream = new java.io.ByteArrayOutputStream(), inde
     (vt: @scala.annotation.switch) match {
       case 0 => // TAG_STR
         val s = v.asInstanceOf[Val.Str]
-        if (s._asciiSafe) renderAsciiSafeString(s.str)
+        if (s.isInstanceOf[Val.AsciiSafeStr]) renderAsciiSafeString(s.str)
         else renderQuotedString(s.str)
       case 1 => // TAG_NUM
         renderDouble(v.asDouble)

--- a/sjsonnet/src/sjsonnet/Format.scala
+++ b/sjsonnet/src/sjsonnet/Format.scala
@@ -50,7 +50,8 @@ object Format {
       /**
        * True when every literal segment (leading + inter-spec literals) contains only printable
        * ASCII with no `"` or `\`. Computed once at parse time; combined at format time with the
-       * ASCII-safety of each interpolated value to set the result's [[Val.Str._asciiSafe]] flag.
+       * ASCII-safety of each interpolated value to decide whether the result is a
+       * [[Val.AsciiSafeStr]].
        */
       val literalsAsciiSafe: Boolean)
       extends CompiledFormat
@@ -868,27 +869,30 @@ object Format {
 
   /**
    * ASCII-safety predicate matching the output of [[simpleStringValue]] (used by the simple
-   * `%(name)s` fast path). Numeric/boolean/null literals are always ASCII; strings forward their
-   * cached `_asciiSafe` flag; complex types route through Renderer which may emit non-ASCII.
+   * `%(name)s` fast path). Numeric/boolean/null literals are always ASCII; strings forward via
+   * subclass check ([[Val.AsciiSafeStr]]); complex types route through Renderer which may emit
+   * non-ASCII.
    */
   @inline private def simpleStringValueAsciiSafe(rawVal: Val): Boolean = rawVal match {
-    case vs: Val.Str  => vs._asciiSafe
-    case _: Val.Num   => true
-    case _: Val.True  => true
-    case _: Val.False => true
-    case _: Val.Null  => true
-    case _            => false
+    case _: Val.AsciiSafeStr => true
+    case _: Val.Str          => false
+    case _: Val.Num          => true
+    case _: Val.True         => true
+    case _: Val.False        => true
+    case _: Val.Null         => true
+    case _                   => false
   }
 
   /**
    * ASCII-safety predicate for the output of a single format spec, used by the general [[format]]
-   * path. Mirrors the conversion logic below: strings forward their cached flag, numerics produce
+   * path. Mirrors the conversion logic below: strings forward via subclass check, numerics produce
    * ASCII (except `%c` which depends on the codepoint), other scalars are always ASCII, and Arr/Obj
    * go through Renderer (which preserves non-ASCII source bytes).
    */
   @inline private def specOutputAsciiSafe(rawVal: Val, conversion: Char): Boolean = rawVal match {
-    case vs: Val.Str => vs._asciiSafe
-    case vn: Val.Num =>
+    case _: Val.AsciiSafeStr => true
+    case _: Val.Str          => false
+    case vn: Val.Num         =>
       conversion match {
         case 'c' =>
           val ch = vn.asDouble.toInt

--- a/sjsonnet/src/sjsonnet/Parser.scala
+++ b/sjsonnet/src/sjsonnet/Parser.scala
@@ -754,10 +754,10 @@ class Parser(
     // cost more than the potential memory savings for strings that are unlikely
     // to repeat (e.g., 600KB text block literals)
     val unique = if (s.length > 1024) s else internedStrings.getOrElseUpdate(s, s)
-    val result = Val.Str(pos, unique)
     if (unique.length > 1024 && CharSWAR.isAsciiJsonSafe(unique))
-      result._asciiSafe = true
-    result
+      Val.Str.asciiSafe(pos, unique)
+    else
+      Val.Str(pos, unique)
   }
 
   // Any `expr` that isn't naively left-recursive

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -328,9 +328,11 @@ object Val {
    * strings). Concat nodes have `_str == null` and non-null children; the flat string is lazily
    * computed on first `.str` access, then cached and children cleared for GC.
    *
-   * Single monomorphic class ensures optimal JIT inlining — no virtual dispatch on `.str`.
+   * Subclassing: only [[Val.AsciiSafeStr]] extends this class. The two-class hierarchy lets the JIT
+   * still devirtualize `.str` access through CHA (only one non-final implementation in the
+   * codebase) while saving 8 bytes per instance compared to a boolean field plus alignment padding.
    */
-  final class Str private[sjsonnet] (var pos: Position, private[sjsonnet] var _str: String)
+  class Str private[sjsonnet] (var pos: Position, private[sjsonnet] var _str: String)
       extends Literal {
 
     // DO NOT CHANGE to separate _left/_right fields.
@@ -339,11 +341,6 @@ object Val {
     // per leaf, and 99%+ of all Str instances are leaves. The array indirection only matters on the
     // cold flatten path, which is amortized O(1) per character.
     private[sjsonnet] var _children: Array[Str] = null
-
-    // Flag indicating this string is known to contain only printable ASCII (0x20-0x7E) with no
-    // characters requiring JSON escaping (no ", \, or control chars). When true, the renderer
-    // can skip SWAR escape scanning and UTF-8 encoding, writing bytes directly.
-    private[sjsonnet] var _asciiSafe: Boolean = false
 
     def prettyName = "string"
     private[sjsonnet] def valTag: Byte = TAG_STR
@@ -407,17 +404,23 @@ object Val {
     override def toString: String = s"Str($pos, $str)"
   }
 
+  /**
+   * String known to contain only printable ASCII (0x20-0x7E) with no characters requiring JSON
+   * escaping (no `"`, `\`, or control chars). [[ByteRenderer]] checks for this subclass to skip
+   * SWAR escape scanning and UTF-8 encoding, writing bytes directly.
+   *
+   * Marker subclass instead of a boolean field saves 8 bytes per instance (boolean + alignment
+   * padding) — significant for string-heavy workloads where Val.Str instances number in millions.
+   */
+  final class AsciiSafeStr private[sjsonnet] (pos0: Position, str0: String) extends Str(pos0, str0)
+
   object Str {
 
     /** Create a leaf string node — zero overhead vs the old case class. */
     def apply(pos: Position, s: String): Str = new Str(pos, s)
 
     /** Create a leaf string node marked as ASCII-safe (no JSON escaping needed). */
-    def asciiSafe(pos: Position, s: String): Str = {
-      val v = new Str(pos, s)
-      v._asciiSafe = true
-      v
-    }
+    def asciiSafe(pos: Position, s: String): Str = new AsciiSafeStr(pos, s)
 
     /** Backward-compatible extractor: `case Val.Str(pos, s) =>` still works. */
     def unapply(s: Str): Option[(Position, String)] = Some((s.pos, s.str))
@@ -432,16 +435,15 @@ object Val {
       // Empty string elimination
       if (ls != null && ls.isEmpty) return right
       if (rs != null && rs.isEmpty) return left
+      val bothSafe = left.isInstanceOf[AsciiSafeStr] && right.isInstanceOf[AsciiSafeStr]
       // Small string eagerness: both flat and combined length <= 128
       if (ls != null && rs != null && ls.length + rs.length <= 128) {
-        val result = new Str(pos, ls + rs)
-        if (left._asciiSafe && right._asciiSafe) result._asciiSafe = true
-        return result
+        val combined = ls + rs
+        return if (bothSafe) new AsciiSafeStr(pos, combined) else new Str(pos, combined)
       }
       // Rope node: O(1)
-      val node = new Str(pos, null)
+      val node = if (bothSafe) new AsciiSafeStr(pos, null) else new Str(pos, null)
       node._children = Array(left, right)
-      if (left._asciiSafe && right._asciiSafe) node._asciiSafe = true
       node
     }
   }

--- a/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
@@ -84,7 +84,7 @@ object StringModule extends AbstractFunctionModule {
         (x.value match {
           case v: Val.Str =>
             val s = v.str
-            if (v._asciiSafe) s.length
+            if (v.isInstanceOf[Val.AsciiSafeStr]) s.length
             else s.codePointCount(0, s.length)
           case a: Val.Arr  => a.length
           case o: Val.Obj  => o.visibleKeyNames.length
@@ -131,7 +131,7 @@ object StringModule extends AbstractFunctionModule {
     def evalRhs(_s: Eval, from: Eval, len: Eval, ev: EvalScope, pos: Position): Val = {
       val srcVal = _s.value
       val str = srcVal.asString
-      val srcAsciiSafe = srcVal.isInstanceOf[Val.Str] && srcVal.asInstanceOf[Val.Str]._asciiSafe
+      val srcAsciiSafe = srcVal.isInstanceOf[Val.AsciiSafeStr]
       val offset = from.value match {
         case v: Val.Num => v.asPositiveInt
         case _ => Error.fail("Expected a number for offset in substr, got " + from.value.prettyName)
@@ -148,11 +148,8 @@ object StringModule extends AbstractFunctionModule {
         val safeOffset = math.min(offset, strLen)
         val safeLength = math.min(length, strLen - safeOffset)
         if (safeLength <= 0) Val.Str(pos, "")
-        else {
-          val result = Val.Str(pos, str.substring(safeOffset, safeOffset + safeLength))
-          result._asciiSafe = true
-          result
-        }
+        else
+          Val.Str.asciiSafe(pos, str.substring(safeOffset, safeOffset + safeLength))
       } else {
         val requestedEnd = offset.toLong + length.toLong
         if (
@@ -242,8 +239,8 @@ object StringModule extends AbstractFunctionModule {
       val toVal = to.value
       val out = srcVal.asString.replace(fromForce, toVal.asString)
       // Result is asciiSafe iff both src and `to` are asciiSafe (`from` is removed).
-      val srcSafe = srcVal.isInstanceOf[Val.Str] && srcVal.asInstanceOf[Val.Str]._asciiSafe
-      val toSafe = toVal.isInstanceOf[Val.Str] && toVal.asInstanceOf[Val.Str]._asciiSafe
+      val srcSafe = srcVal.isInstanceOf[Val.AsciiSafeStr]
+      val toSafe = toVal.isInstanceOf[Val.AsciiSafeStr]
       if (srcSafe && toSafe) Val.Str.asciiSafe(pos, out) else Val.Str(pos, out)
     }
   }
@@ -386,8 +383,8 @@ object StringModule extends AbstractFunctionModule {
         right = true
       )
       v match {
-        case vs: Val.Str if vs._asciiSafe => Val.Str.asciiSafe(pos, out)
-        case _                            => Val.Str(pos, out)
+        case _: Val.AsciiSafeStr => Val.Str.asciiSafe(pos, out)
+        case _                   => Val.Str(pos, out)
       }
     }
   }
@@ -409,8 +406,8 @@ object StringModule extends AbstractFunctionModule {
         right = false
       )
       v match {
-        case vs: Val.Str if vs._asciiSafe => Val.Str.asciiSafe(pos, out)
-        case _                            => Val.Str(pos, out)
+        case _: Val.AsciiSafeStr => Val.Str.asciiSafe(pos, out)
+        case _                   => Val.Str(pos, out)
       }
     }
   }
@@ -432,8 +429,8 @@ object StringModule extends AbstractFunctionModule {
         right = true
       )
       v match {
-        case vs: Val.Str if vs._asciiSafe => Val.Str.asciiSafe(pos, out)
-        case _                            => Val.Str(pos, out)
+        case _: Val.AsciiSafeStr => Val.Str.asciiSafe(pos, out)
+        case _                   => Val.Str(pos, out)
       }
     }
   }
@@ -461,7 +458,7 @@ object StringModule extends AbstractFunctionModule {
         if (resultLen > Int.MaxValue) Error.fail("String is too large to join")
         if (count == 1) str
         else {
-          val asciiSafe = str._asciiSafe && sep._asciiSafe
+          val asciiSafe = str.isInstanceOf[Val.AsciiSafeStr] && sep.isInstanceOf[Val.AsciiSafeStr]
 
           val b = new java.lang.StringBuilder(resultLen.toInt)
           if (s.length + sepStr.length <= 64) {
@@ -533,12 +530,12 @@ object StringModule extends AbstractFunctionModule {
           case x: Val.Str  =>
             if (added) {
               totalLen += sepLen
-              asciiSafe &&= sep._asciiSafe
+              asciiSafe &&= sep.isInstanceOf[Val.AsciiSafeStr]
             }
             val str = x.str
             totalLen += str.length
             if (totalLen > Int.MaxValue) Error.fail("String is too large to join")
-            asciiSafe &&= x._asciiSafe
+            asciiSafe &&= x.isInstanceOf[Val.AsciiSafeStr]
             added = true
           case x => Error.fail("Cannot join " + x.prettyName)
         }
@@ -583,7 +580,7 @@ object StringModule extends AbstractFunctionModule {
           case x: Val.Str  =>
             totalLen += x.str.length
             if (totalLen > Int.MaxValue) Error.fail("String is too large to join")
-            asciiSafe &&= x._asciiSafe
+            asciiSafe &&= x.isInstanceOf[Val.AsciiSafeStr]
             elemCount += 1
           case _ => return null
         }
@@ -593,7 +590,7 @@ object StringModule extends AbstractFunctionModule {
       if (elemCount > 1) {
         totalLen += sepLen.toLong * (elemCount - 1)
         if (totalLen > Int.MaxValue) Error.fail("String is too large to join")
-        asciiSafe &&= sep._asciiSafe
+        asciiSafe &&= sep.isInstanceOf[Val.AsciiSafeStr]
       }
 
       val b = new java.lang.StringBuilder(totalLen.toInt)
@@ -648,11 +645,11 @@ object StringModule extends AbstractFunctionModule {
               case x: Val.Str  =>
                 if (added) {
                   b.append(s)
-                  asciiSafe &&= sepStr._asciiSafe
+                  asciiSafe &&= sepStr.isInstanceOf[Val.AsciiSafeStr]
                 }
                 added = true
                 b.append(x.str)
-                asciiSafe &&= x._asciiSafe
+                asciiSafe &&= x.isInstanceOf[Val.AsciiSafeStr]
               case x => Error.fail("Cannot join " + x.prettyName)
             }
             i += 1
@@ -864,7 +861,7 @@ object StringModule extends AbstractFunctionModule {
   private object Split extends Val.Builtin2("split", "str", "c") {
     def evalRhs(str: Eval, c: Eval, ev: EvalScope, pos: Position): Val = {
       val v = str.value
-      val safe = v.isInstanceOf[Val.Str] && v.asInstanceOf[Val.Str]._asciiSafe
+      val safe = v.isInstanceOf[Val.AsciiSafeStr]
       Val.Arr(pos, splitLimit(pos, v.asString, c.value.asString, -1, safe))
     }
   }
@@ -882,7 +879,7 @@ object StringModule extends AbstractFunctionModule {
   private object SplitLimit extends Val.Builtin3("splitLimit", "str", "c", "maxsplits") {
     def evalRhs(str: Eval, c: Eval, maxSplits: Eval, ev: EvalScope, pos: Position): Val = {
       val v = str.value
-      val safe = v.isInstanceOf[Val.Str] && v.asInstanceOf[Val.Str]._asciiSafe
+      val safe = v.isInstanceOf[Val.AsciiSafeStr]
       Val.Arr(
         pos,
         splitLimit(pos, v.asString, c.value.asString, maxSplits.value.asInt, safe)
@@ -900,7 +897,7 @@ object StringModule extends AbstractFunctionModule {
   private object SplitLimitR extends Val.Builtin3("splitLimitR", "str", "c", "maxsplits") {
     def evalRhs(str: Eval, c: Eval, maxSplits: Eval, ev: EvalScope, pos: Position): Val = {
       val v = str.value
-      val safe = v.isInstanceOf[Val.Str] && v.asInstanceOf[Val.Str]._asciiSafe
+      val safe = v.isInstanceOf[Val.AsciiSafeStr]
       Val.Arr(
         pos,
         splitLimitR(pos, v.asString, c.value.asString, maxSplits.value.asInt, safe)
@@ -1051,8 +1048,8 @@ object StringModule extends AbstractFunctionModule {
       val s = v.asString
       val out = asciiUpper(s)
       v match {
-        case vs: Val.Str if vs._asciiSafe => Val.Str.asciiSafe(pos, out)
-        case _                            => Val.Str(pos, out)
+        case _: Val.AsciiSafeStr => Val.Str.asciiSafe(pos, out)
+        case _                   => Val.Str(pos, out)
       }
     }
   }
@@ -1070,8 +1067,8 @@ object StringModule extends AbstractFunctionModule {
       val s = v.asString
       val out = asciiLower(s)
       v match {
-        case vs: Val.Str if vs._asciiSafe => Val.Str.asciiSafe(pos, out)
-        case _                            => Val.Str(pos, out)
+        case _: Val.AsciiSafeStr => Val.Str.asciiSafe(pos, out)
+        case _                   => Val.Str(pos, out)
       }
     }
   }

--- a/sjsonnet/test/resources/new_test_suite/format_asciisafe_propagation.jsonnet
+++ b/sjsonnet/test/resources/new_test_suite/format_asciisafe_propagation.jsonnet
@@ -1,5 +1,5 @@
 // Directional coverage for Format ASCII-safety propagation.
-// Ensures format strings preserve correct values across paths that set Val.Str._asciiSafe:
+// Ensures format strings preserve correct values across paths that produce Val.AsciiSafeStr:
 // - simple %(name)s fast path with ASCII / non-ASCII literals and values
 // - general format path with %s / %d / %c / %o / %x conversions
 // - mixed ASCII literals + non-ASCII string interpolations (output must be correct)

--- a/sjsonnet/test/src/sjsonnet/FormatTests.scala
+++ b/sjsonnet/test/src/sjsonnet/FormatTests.scala
@@ -31,7 +31,7 @@ object FormatTests extends TestSuite {
       )
       val result = fmt.evalRhs(obj, scope, pos).asInstanceOf[Val.Str]
       result.str ==> "hello 3"
-      result._asciiSafe ==> true
+      result.isInstanceOf[Val.AsciiSafeStr] ==> true
     }
 
     test("simple named format does not mark unsafe string values ascii-safe") {
@@ -42,7 +42,7 @@ object FormatTests extends TestSuite {
       )
       val result = fmt.evalRhs(obj, scope, pos).asInstanceOf[Val.Str]
       result.str ==> "hello \""
-      result._asciiSafe ==> false
+      result.isInstanceOf[Val.AsciiSafeStr] ==> false
     }
 
     test("simple named format does not mark unsafe static literals ascii-safe") {
@@ -53,7 +53,7 @@ object FormatTests extends TestSuite {
       )
       val result = fmt.evalRhs(obj, scope, pos).asInstanceOf[Val.Str]
       result.str ==> "hello \"3"
-      result._asciiSafe ==> false
+      result.isInstanceOf[Val.AsciiSafeStr] ==> false
     }
 
     test("simple named format combines ascii-safety across multiple keys") {
@@ -67,7 +67,7 @@ object FormatTests extends TestSuite {
       )
       val result = fmt.evalRhs(obj, scope, pos).asInstanceOf[Val.Str]
       result.str ==> "safe \\ safe"
-      result._asciiSafe ==> false
+      result.isInstanceOf[Val.AsciiSafeStr] ==> false
     }
   }
 }


### PR DESCRIPTION
## Motivation

Save memory. Each `Val.Str` instance is allocated for every string literal,
every `ConstMember` key, every parser-produced fragment, every concat result.
On a config-generation workload (`gen_big_object`, `realistic1`) the
benchmark allocates **tens of thousands** of `Val.Str` per run — so per-instance
overhead compounds.

Replace the `Val.Str._asciiSafe: Boolean` flag with an `AsciiSafeStr`
subclass. Encoding the invariant in the type instead of a field shrinks every
plain `Val.Str`, and lets the renderer/format hot paths dispatch on
`case _: AsciiSafeStr` instead of reading a field — the JIT and Scala-Native
CHA can devirtualize this into a direct branch.

This sits directly on `master` (commit `b252b184`) now that #861's C1-C4
incremental wins have landed. Single structural commit.

## Modification

- New `AsciiSafeStr` subclass marks strings statically known to be ASCII
  JSON-safe; plain `Val.Str` is the unknown-safety base case.
- `Val.Str.asciiSafe(pos, s)` factory constructs `AsciiSafeStr` directly.
- `getAsciiSafe()` short-circuits to `true` for `AsciiSafeStr`; for plain
  `Val.Str` it still does the lazy SWAR scan and caches.
- `_asciiSafe: Boolean` field removed from `Val.Str`.
- Hot-path dispatch sites (ByteRenderer, Format, StringModule join paths,
  Parser, Format) now match on the type.

Existing `string_asciisafe_propagation.jsonnet` and full JVM/Native test
suites cover behavior — no semantic change.

## Result

Re-benched on 2026-05-21 against `master @ b252b184`. Apple Silicon, JDK 21,
Scala 3.3.7.

### Memory: `Val.Str` object layout (compressed oops)

```
Field                master         this PR
header                   12              12
pos (ref)                 4               4
_str (ref)                4               4
_children (ref)           4               4
_asciiSafe (boolean)      1               -
padding                   7               -
                       -----           -----
total                  32 B            24 B    (-8 B / -25%)
```

Every plain `Val.Str` instance shrinks from **32 → 24 bytes**.
`AsciiSafeStr` adds no fields, so it's also 24 bytes per instance — class
metadata is one-time, not per-instance.

### Allocation rate (JMH `-prof gc`, full bench corpus)

```
bench                                       master       this PR        Δ
cpp_suite/gen_big_object.jsonnet         3.72 MB/op   3.49 MB/op   -234 KB  (-6.15%)
cpp_suite/realistic1.jsonnet             5.60 MB/op   5.54 MB/op    -63 KB  (-1.09%)
jdk17_suite/split_resolve.jsonnet       586.5 KB/op  562.7 KB/op    -24 KB  (-4.06%)
jdk17_suite/repeat_format.jsonnet       572.3 KB/op  557.5 KB/op    -15 KB  (-2.58%)
bug_suite/assertions.jsonnet            625.4 KB/op  616.6 KB/op   -8.7 KB  (-1.40%)
cpp_suite/realistic2.jsonnet            71.74 MB/op  71.69 MB/op    -50 KB  (-0.07%)
go_suite/manifestYamlDoc.jsonnet        134.0 KB/op  133.4 KB/op   -640 B   (-0.47%)
go_suite/manifestJsonEx.jsonnet         129.7 KB/op  129.5 KB/op   -200 B   (-0.15%)
sjsonnet_suite/lazy_array_compr.        51.66 MB/op  51.66 MB/op    -70 B   (-0.00%)
go_suite/comparison2.jsonnet            52.95 MB/op  52.95 MB/op   -126 B   (-0.00%)
```

The largest absolute saving is the **234 KB/op drop** on `gen_big_object` — a
config-shape benchmark. At ~30K `Val.Str` instances/op × 8 bytes each, the
arithmetic checks out. Object-key-heavy programs are the win profile;
benches that reuse already-parsed strings (`bench.02`, `comparison2`) see
near-zero deltas because they don't allocate fresh `Val.Str` at runtime.

No bench shows an allocation regression > +200 B/op (≈ 1 instance worth of
noise).

### Wall-clock

Hyperfine, Scala-Native release binary, full bench corpus (warmup=2,
min-runs=5). Long benches (process-startup variance is small relative to
work):

```
bench                                    master ms      this PR ms     Δ
cpp_suite/realistic2.jsonnet             89.30 ± 1.91   88.87 ± 2.04   -0.48%
sjsonnet_suite/lazy_array_compr.         80.88 ± 1.51   81.56 ± 1.72   +0.83%
cpp_suite/bench.02.jsonnet               61.25 ± 1.47   60.45 ± 1.41   -1.30%
go_suite/comparison2.jsonnet             40.59 ± 3.02   40.76 ± 1.45   +0.42%
cpp_suite/bench.03.jsonnet               27.15 ± 1.23   27.46 ± 3.70   +1.13%
sjsonnet_suite/lazy_array_sparse_idx     18.43 ± 4.24   18.55 ± 1.17   +0.68%
sjsonnet_suite/lazy_array_reverse_sp.    16.08 ± 3.54   15.48 ± 1.57   -3.76%
go_suite/reverse.jsonnet                 15.02 ± 1.33   15.22 ± 1.20   +1.29%
go_suite/base64DecodeBytes.jsonnet       13.12 ± 1.13   11.80 ± 1.31  -10.06%
sjsonnet_suite/array_copy_views.jsonnet  12.17 ± 1.18   12.56 ± 0.95   +3.20%
cpp_suite/realistic1.jsonnet             11.34 ± 1.21   10.76 ± 2.00   -5.07%
cpp_suite/large_string_template.jsonnet  10.08 ± 1.41   10.87 ± 1.04   +7.88%
```

Net wall-clock impact is a wash on Native (sub-10ms benches dominated by
process-startup variance, ±10–20% run-to-run). The `realistic1` and
`base64DecodeBytes` wins line up with their alloc-rate drops — less GC
pressure → less work.

JMH (JVM steady-state, single 1-iter run):
```
RegressionBenchmark.main              master ms/op    this PR ms/op    Δ
cpp_suite/bench.02.jsonnet            28.062          26.696          -4.87%
cpp_suite/bench.03.jsonnet             7.398           6.902          -6.70%
cpp_suite/realistic2.jsonnet          46.844          46.374          -1.00%
sjsonnet_suite/lazy_array_compr.      20.814          20.258          -2.67%
go_suite/comparison2.jsonnet          18.763          19.416          +3.48%
go_suite/reverse.jsonnet               5.429           5.349          -1.47%
cpp_suite/large_string_join.jsonnet    0.281           0.281           0.00%
cpp_suite/large_string_template.       0.697           0.703          +0.86%
jdk17_suite/repeat_format.jsonnet      0.132           0.138          +4.55%
sjsonnet_suite/setUnion.jsonnet        0.487           0.492          +1.03%
```

### Summary

Memory is the headline:
- `Val.Str` instance: **32 → 24 bytes** (-25%)
- Real workload alloc rate: **up to -6.15%** (`gen_big_object`),
  consistently negative on object-construction benches

Wall-clock is neutral-to-marginally-positive — exactly what you'd expect
for a layout shrink: the JIT was already inlining the field read, so
removing it wins on memory pressure rather than instruction count. The
type-encoded invariant also makes it cheaper for future fast paths to
discriminate on the marker without re-scanning.

## Test plan

- `./mill 'sjsonnet.jvm[3.3.7]'.test` — green
- `./mill 'sjsonnet.native[3.3.7]'.test` — green
- `./mill __.checkFormat` — green
