### PR TITLE
perf: skip UTF-8 encode for clean-ASCII long strings in renderer

### DIFF
--- a/sjsonnet/src/sjsonnet/BaseByteRenderer.scala
+++ b/sjsonnet/src/sjsonnet/BaseByteRenderer.scala
@@ -305,8 +305,18 @@ class BaseByteRenderer[T <: java.io.OutputStream](
   /**
    * SWAR-accelerated path for long strings. Converts to UTF-8 bytes once, then bulk-copies clean
    * chunks and escapes only the bytes that require it.
+   *
+   * Probes the string with a SWAR ASCII-safe scan first. When the string is clean printable ASCII
+   * (no escape chars, no non-ASCII), the entire UTF-8 encode pass (HeapCharBuffer.wrap +
+   * CharsetEncoder.loop + output byte[] allocation) is skipped — bytes are written directly from
+   * the chars via Platform.copyAsciiStringToBytes. This is the dominant case for K8s/JSON output
+   * where long values (descriptions, paths, base64 blobs) are pure ASCII.
    */
   private def visitLongString(str: String): Unit = {
+    if (Platform.isAsciiJsonSafe(str)) {
+      renderAsciiSafeString(str)
+      return
+    }
     val bytes = str.getBytes(java.nio.charset.StandardCharsets.UTF_8)
     val bLen = bytes.length
     val firstEscape = CharSWAR.findFirstEscapeChar(bytes, 0, bLen)


### PR DESCRIPTION
## Motivation

`async-profiler` on the Scala Native kube-prometheus workload shows `HeapCharBuffer.wrap` accounting for **40.3%** of GC-allocation parents (GC itself is ~25–30% of native runtime). The wrap site is `String.getBytes(UTF_8)` called once per long (≥128 char) JSON string inside `BaseByteRenderer.visitLongString`. Each call also allocates an output `byte[]`. In K8s manifest output, the overwhelming majority of these long values (descriptions, annotations, base64 blobs, paths) are pure printable ASCII with no JSON-escape characters.

## Key Design Decision

Use the existing `Platform.isAsciiJsonSafe` SWAR scan (16 chars/Long word, no allocation) as a cheap probe up-front. On positive probe, route to the existing `renderAsciiSafeString` fast path which uses `Platform.copyAsciiStringToBytes` for direct char→byte memcpy. On a negative probe, fall through unchanged to the byte-SWAR path. The extra cost paid by the non-ASCII branch is one SWAR scan over chars (~bLen/16 Long reads), which is dominated by the encode cost that branch already performs.

## Modification

At the top of `visitLongString` in `BaseByteRenderer.scala`, probe with `Platform.isAsciiJsonSafe(str)` and delegate to `renderAsciiSafeString(str)` when clean. Otherwise the original code runs unchanged.

## Benchmark Results

`./mill bench.runRegressions` completes across all cpp/go/sjsonnet suites with no anomalies.

**hyperfine** (Scala Native AOT, kube-prometheus, 60 runs, 8 warmup):

| Binary | Mean | σ | Range |
|---|---|---|---|
| before (master HEAD `fcd444cc`) | 150.7 ms | ±8.3 ms | 140.5 – 177.3 |
| after | 145.9 ms | ±6.2 ms | 138.6 – 168.1 |

**After is 1.03× faster** (−4.8 ms mean, −3.2%). σ ratio = 0.07, improvement is reproducible across runs.

## Analysis

Modest but real. `visitLongString` is one call per long output string, so on a 72k-line kube-prom output we hit it on the order of 10⁴ times. Each spared call avoids two heap allocations and a `CharsetEncoder` dispatch, which directly reduces the `HeapCharBuffer.wrap` GC pressure that profiling identified as the largest single allocation source.

Larger gains require attacking the remaining UTF-8 path itself — follow-up commits target the escape-needing branch and `PlatformBase64` zero-copy.

## References

- async-profiler CPU + allocation-parent analysis on `/tmp/sjsonnet-yaml-fix`
- Existing helpers reused: `Platform.isAsciiJsonSafe`, `renderAsciiSafeString`, `Platform.copyAsciiStringToBytes`
- Related: #863 (base64 ASCII input fast path), #864 (BaseRenderer.escape bulk write)

## Result

- ✅ `./mill 'sjsonnet.jvm[3.3.7]'.test` — 444/444 pass
- ✅ Byte-identical output on kube-prometheus (1.5 MB / 72k lines diff -q clean)
- ✅ +3.2% wall-clock on Scala Native kube-prom
- ✅ No regression on `bench.runRegressions`