### PR TITLE
chore: upgrade Scala Native to 0.5.12

### DIFF
--- a/.github/scripts/fix-build-config.sh
+++ b/.github/scripts/fix-build-config.sh
@@ -5,7 +5,7 @@ JFROG_HOSTNAME="databricks.jfrog.io"
 JFROG_REALM="Artifactory Realm"
 JFROG_USERNAME="gha-service-account"
 JFROG_URL="https://${JFROG_HOSTNAME}/artifactory/db-maven/"
-MAVEN_CENTRAL_URL="https://repo.maven.apache.org/maven2/"
+MAVEN_CENTRAL_URL="https://maven-central.storage.googleapis.com/maven2/"
 
 replace_repo1_in_mill() {
   python3 - "$1" << 'PY'

--- a/.github/scripts/fix-build-config.sh
+++ b/.github/scripts/fix-build-config.sh
@@ -5,22 +5,76 @@ JFROG_HOSTNAME="databricks.jfrog.io"
 JFROG_REALM="Artifactory Realm"
 JFROG_USERNAME="gha-service-account"
 JFROG_URL="https://${JFROG_HOSTNAME}/artifactory/db-maven/"
+MAVEN_CENTRAL_URL="https://maven-central.storage-download.googleapis.com/maven2/"
 
-# Configure sbt repositories
+replace_repo1_in_mill() {
+  python3 - "$1" << 'PY'
+from pathlib import Path
+import sys
+
+path = Path("mill")
+path.write_text(path.read_text().replace("https://repo1.maven.org/maven2", sys.argv[1]))
+PY
+}
+
+force_no_server_in_mill() {
+  python3 - << 'PY'
+from pathlib import Path
+
+path = Path("mill")
+text = path.read_text()
+old = '"${MILL}" $MILL_FIRST_ARG -D "mill.main.cli=${MILL_MAIN_CLI}" "$@"'
+new = '"${MILL}" --no-server $MILL_FIRST_ARG -D "mill.main.cli=${MILL_MAIN_CLI}" "$@"'
+path.write_text(text.replace(old, new))
+PY
+}
+
 mkdir -p ~/.sbt
-cat > ~/.sbt/repositories << EOF
+if [[ "${JFROG_ACCESS_TOKEN}" == "dummy" ]]; then
+  # Fork PRs cannot mint the Databricks JFrog OIDC token. Use public Maven Central directly so new
+  # public dependency versions that have not yet been mirrored to JFrog can still be validated.
+  cat > ~/.sbt/repositories << EOF
+[repositories]
+  local
+  google-maven-central: ${MAVEN_CENTRAL_URL}
+EOF
+  echo "COURSIER_REPOSITORIES=${MAVEN_CENTRAL_URL}" >> "$GITHUB_ENV"
+  mill_version="$(sed -n -E 's#^//\|[[:space:]]*mill-version:[[:space:]]*([^[:space:]]+).*#\1#p' build.mill | head -n 1)"
+  if [[ -z "${mill_version}" ]]; then mill_version="1.1.0"; fi
+  echo "MILL_VERSION=${mill_version%-jvm}-jvm" >> "$GITHUB_ENV"
+  replace_repo1_in_mill "${MAVEN_CENTRAL_URL%/}"
+  force_no_server_in_mill
+  {
+    echo "-Djava.net.preferIPv4Stack=true"
+    echo "-Djdk.tls.client.protocols=TLSv1.2"
+  } >> .mill-jvm-opts
+else
+  # Configure sbt repositories
+  cat > ~/.sbt/repositories << EOF
 [repositories]
   local
   databricks-jfrog: ${JFROG_URL}
 EOF
 
-# Configure sbt credentials
-cat > ~/.sbt/.credentials << EOF
+  # Configure sbt credentials
+  cat > ~/.sbt/.credentials << EOF
 realm=${JFROG_REALM}
 host=${JFROG_HOSTNAME}
 user=${JFROG_USERNAME}
 password=${JFROG_ACCESS_TOKEN}
 EOF
+
+  mkdir -p ~/.config/coursier
+  {
+    echo "jfrog.host=${JFROG_HOSTNAME}"
+    echo "jfrog.realm=${JFROG_REALM}"
+    echo "jfrog.username=${JFROG_USERNAME}"
+    echo "jfrog.password=${JFROG_ACCESS_TOKEN}"
+  } > ~/.config/coursier/credentials.properties
+
+  echo "COURSIER_REPOSITORIES=${JFROG_URL}" >> "$GITHUB_ENV"
+  replace_repo1_in_mill "https://${JFROG_USERNAME}:${JFROG_ACCESS_TOKEN}@${JFROG_URL:8}"
+fi
 
 # Configure global.sbt to load credentials
 mkdir -p ~/.sbt/1.0
@@ -31,15 +85,3 @@ credentials ++= {
   else Nil
 }
 EOF
-
-
-mkdir -p ~/.config/coursier
-{
-  echo "jfrog.host=${JFROG_HOSTNAME}"
-  echo "jfrog.realm=${JFROG_REALM}"
-  echo "jfrog.username=${JFROG_USERNAME}"
-  echo "jfrog.password=${JFROG_ACCESS_TOKEN}"
-} > ~/.config/coursier/credentials.properties
-
-echo "COURSIER_REPOSITORIES=${JFROG_URL}" >> "$GITHUB_ENV"
-sed -i "s|https://repo1.maven.org/maven2|https://${JFROG_USERNAME}:${JFROG_ACCESS_TOKEN}@${JFROG_URL:8}|g" ./mill

--- a/.github/scripts/fix-build-config.sh
+++ b/.github/scripts/fix-build-config.sh
@@ -5,7 +5,7 @@ JFROG_HOSTNAME="databricks.jfrog.io"
 JFROG_REALM="Artifactory Realm"
 JFROG_USERNAME="gha-service-account"
 JFROG_URL="https://${JFROG_HOSTNAME}/artifactory/db-maven/"
-MAVEN_CENTRAL_URL="https://maven-central.storage-download.googleapis.com/maven2/"
+MAVEN_CENTRAL_URL="https://repo.maven.apache.org/maven2/"
 
 replace_repo1_in_mill() {
   python3 - "$1" << 'PY'
@@ -36,12 +36,9 @@ if [[ "${JFROG_ACCESS_TOKEN}" == "dummy" ]]; then
   cat > ~/.sbt/repositories << EOF
 [repositories]
   local
-  google-maven-central: ${MAVEN_CENTRAL_URL}
+  maven-central: ${MAVEN_CENTRAL_URL}
 EOF
   echo "COURSIER_REPOSITORIES=${MAVEN_CENTRAL_URL}" >> "$GITHUB_ENV"
-  mill_version="$(sed -n -E 's#^//\|[[:space:]]*mill-version:[[:space:]]*([^[:space:]]+).*#\1#p' build.mill | head -n 1)"
-  if [[ -z "${mill_version}" ]]; then mill_version="1.1.0"; fi
-  echo "MILL_VERSION=${mill_version%-jvm}-jvm" >> "$GITHUB_ENV"
   replace_repo1_in_mill "${MAVEN_CENTRAL_URL%/}"
   force_no_server_in_mill
   {

--- a/.github/scripts/fix-build-config.sh
+++ b/.github/scripts/fix-build-config.sh
@@ -29,6 +29,18 @@ path.write_text(text.replace(old, new))
 PY
 }
 
+add_curl_retries_in_mill() {
+  python3 - << 'PY'
+from pathlib import Path
+
+path = Path("mill")
+text = path.read_text()
+old = 'curl -f -L -o "${MILL_TEMP_DOWNLOAD_FILE}" "${MILL_DOWNLOAD_URL}"'
+new = 'curl --retry 5 --retry-delay 2 --retry-all-errors -f -L -o "${MILL_TEMP_DOWNLOAD_FILE}" "${MILL_DOWNLOAD_URL}"'
+path.write_text(text.replace(old, new))
+PY
+}
+
 mkdir -p ~/.sbt
 if [[ "${JFROG_ACCESS_TOKEN}" == "dummy" ]]; then
   # Fork PRs cannot mint the Databricks JFrog OIDC token. Use public Maven Central directly so new
@@ -39,8 +51,12 @@ if [[ "${JFROG_ACCESS_TOKEN}" == "dummy" ]]; then
   maven-central: ${MAVEN_CENTRAL_URL}
 EOF
   echo "COURSIER_REPOSITORIES=${MAVEN_CENTRAL_URL}" >> "$GITHUB_ENV"
+  mill_version="$(sed -n -E 's#^//\|[[:space:]]*mill-version:[[:space:]]*([^[:space:]]+).*#\1#p' build.mill | head -n 1)"
+  if [[ -z "${mill_version}" ]]; then mill_version="1.1.0"; fi
+  echo "MILL_VERSION=${mill_version%-jvm}-jvm" >> "$GITHUB_ENV"
   replace_repo1_in_mill "${MAVEN_CENTRAL_URL%/}"
   force_no_server_in_mill
+  add_curl_retries_in_mill
   {
     echo "-Djava.net.preferIPv4Stack=true"
     echo "-Djdk.tls.client.protocols=TLSv1.2"

--- a/build.mill
+++ b/build.mill
@@ -261,7 +261,7 @@ object sjsonnet extends VersionFileModule {
       with SjsonnetPublishModule
       with SjsonnetJvmNative {
     def moduleDir = super.moduleDir / os.up
-    def scalaNativeVersion = "0.5.11"
+    def scalaNativeVersion = "0.5.12"
     val sourceDirs = Seq(
       "src",
       "src-native",

--- a/sjsonnet/src-native/sjsonnet/Platform.scala
+++ b/sjsonnet/src-native/sjsonnet/Platform.scala
@@ -4,6 +4,7 @@ import java.io.{ByteArrayOutputStream, File}
 import java.nio.charset.StandardCharsets.UTF_8
 import java.util
 import java.util.Base64
+import java.util.HexFormat
 import java.util.zip.GZIPOutputStream
 import scala.scalanative.regex.Pattern
 import scala.annotation.nowarn
@@ -11,7 +12,7 @@ import scala.collection.mutable
 import org.virtuslab.yaml.*
 
 object Platform {
-  private val hexChars = "0123456789abcdef".toCharArray
+  private val hexFormat = HexFormat.of()
 
   private def repeatCapacity(s: String, count: Int): Int =
     if (count > 0 && s.length <= Int.MaxValue / count) s.length * count else 0
@@ -172,22 +173,10 @@ object Platform {
     result.mkString("\n")
   }
 
-  private def bytesToHex(bytes: Array[Byte]): String = {
-    val out = new Array[Char](bytes.length * 2)
-    var i = 0
-    var j = 0
-    while (i < bytes.length) {
-      val b = bytes(i) & 0xff
-      out(j) = hexChars(b >>> 4)
-      out(j + 1) = hexChars(b & 0x0f)
-      i += 1
-      j += 2
-    }
-    new String(out)
-  }
-
   private def computeHash(algorithm: String, s: String): String =
-    bytesToHex(java.security.MessageDigest.getInstance(algorithm).digest(s.getBytes(UTF_8)))
+    hexFormat.formatHex(
+      java.security.MessageDigest.getInstance(algorithm).digest(s.getBytes(UTF_8))
+    )
 
   def md5(s: String): String = computeHash("MD5", s)
 


### PR DESCRIPTION
Motivation:
Upgrade the Scala Native baseline to 0.5.12 so follow-up native profiling, async-profiler work, and compatibility work use the latest released 0.5.x toolchain.

Key Design Decision:
Keep this PR focused on the toolchain migration and API cleanup enabled by that migration. The root sbt files were checked: `build.sbt` is JVM-only for this repository and `project/plugins.sbt` only adds JMH, so there is no Scala Native sbt plugin version to update here.

Modification:
- Bump `scalaNativeVersion` from `0.5.11` to `0.5.12` in `build.mill`.
- Use `java.util.HexFormat` in the Scala Native platform hash implementation now that Scala Native 0.5.12 provides it.
- Remove the native-only hand-written byte-to-hex helper.
- Allow fork PR CI to use Google Maven Central mirror fallback when no Databricks JFrog OIDC token is available. This is needed because newly released public artifacts, such as Scala Native 0.5.12 modules, may not be mirrored in JFrog yet, and it avoids the Maven Central repo1 TLS failure seen in CI by switching both coursier and the Mill launcher to maven-central.storage-download.googleapis.com.

Benchmark Results:
Not included for this dependency upgrade. This PR establishes the 0.5.12 baseline; follow-up optimization PRs should benchmark their own performance deltas on top of this version.

Analysis:
Scala Native 0.5.12 includes release GC reliability fixes, codegen/toolchain improvements, and Java 17 `HexFormat` support. The `HexFormat` change makes the native hash path match the JVM implementation more closely and reduces platform-specific code without changing Jsonnet semantics. The CI repository fallback keeps authenticated Databricks JFrog usage for trusted runs. For fork PRs without OIDC credentials, it uses the Google Maven Central mirror fallback and forces the Mill JVM launcher (`MILL_VERSION=<version>-jvm`) because the native Mill launcher failed Java TLS handshakes to HTTPS Maven Central mirrors before reaching project dependency resolution. In dummy-token mode it also injects `--no-server`.

References:
- https://github.com/scala-native/scala-native/releases/tag/v0.5.12

Result:
- `./mill 'sjsonnet.jvm[3.3.7].test'` passed.
- `./mill 'sjsonnet.native[3.3.7].nativeLink'` passed.
- `./mill __.reformat && ./mill --no-server --ticker false --color false -j 1 __.test` passed 444/444 before the HexFormat cleanup.
- `./mill __.reformat && ./mill 'sjsonnet.native[3.3.7].test'` passed 457/457 after the HexFormat cleanup.
- `bash -n .github/scripts/fix-build-config.sh` passed.
- The dummy-token CI path was smoke-tested locally and writes an sbt repository config with `local` + `google-maven-central: https://maven-central.storage-download.googleapis.com/maven2/`, exports `COURSIER_REPOSITORIES=https://maven-central.storage-download.googleapis.com/maven2/`, rewrites the Mill launcher URL to the same mirror, sets `MILL_VERSION=1.1.5-jvm`, injects `--no-server`, and appends Java TLS/IPv4 options for public mirror access.







