### PR TITLE
perf: buffer native stdout writes

### DIFF
--- a/sjsonnet/src-native/sjsonnet/NativeOutputStream.scala
+++ b/sjsonnet/src-native/sjsonnet/NativeOutputStream.scala
@@ -13,6 +13,8 @@ import scala.scalanative.unsigned._
  * Uses stdio.fwrite which has internal C library buffering, avoiding per-call syscall overhead.
  */
 class NativeOutputStream(file: Ptr[FILE]) extends OutputStream {
+  stdio.setvbuf(file, null, stdio._IOFBF, NativeOutputStream.BufferSize.toUSize)
+
   override def write(b: Int): Unit =
     stdio.fputc(b, file)
 
@@ -26,4 +28,8 @@ class NativeOutputStream(file: Ptr[FILE]) extends OutputStream {
 
   override def close(): Unit =
     flush()
+}
+
+object NativeOutputStream {
+  private final val BufferSize = 256 * 1024
 }


### PR DESCRIPTION
Motivation:

Scala Native kube-prometheus rendering still showed write/output overhead after the renderer and strict JSON import stack. `NativeOutputStream` already bypasses the JVM-compatible `PrintStream` path by writing through C `fwrite`, but stdout still used the platform default stdio buffering.

Key Design Decision:

Keep this optimization Native-only and local to stdout buffering. Instead of changing renderer flush thresholds or `ByteBuilder` behavior globally, configure the C stdio stream with full buffering before any `NativeOutputStream` writes occur. Passing a null buffer lets libc own the buffer lifetime, so the Scala object does not need to retain native memory.

Modification:

- Configure `NativeOutputStream` with `setvbuf(file, null, _IOFBF, 256 KiB)` during construction.
- Leave JVM, JS, YAML, expect-string, and file-output code paths unchanged.
- Preserve existing explicit `flush()` behavior for trailing newline and close handling.

Benchmark Results:

Workload: `jrsonnet/tests/realworld/entry-kube-prometheus.jsonnet -J vendor`

Candidate was benchmarked on the Scala Native 0.5.12 stacked exploration branch against clean `cf7b8af9`.

| Order | Clean | Candidate | Result |
| --- | ---: | ---: | ---: |
| Forward mean | 218.848 ms | 188.528 ms | -13.9% |
| Forward median | 215.517 ms | 187.368 ms | -13.1% |
| Reverse mean | 224.045 ms | 183.701 ms | -18.0% |
| Reverse median | 224.281 ms | 182.914 ms | -18.4% |

Output equality matched by `cmp`.

Validation:

- `./mill --no-server --ticker false --color false __.reformat`
- `./mill --no-server --ticker false --color false -j 1 __.test` — 444 passed, 0 failed
- `./mill --no-server --ticker false --color false bench.runRegressions`

Analysis:

This is a lower-risk write/flush optimization than increasing `ByteBuilder` thresholds: it does not alter rendering order, JSON escaping, object materialization, or JVM/JS behavior. It only changes the buffering policy of the Native stdout `FILE*`, and explicit flushes still happen at the same public boundaries.

References:

- Scala Native 0.5.12 migration PR: #867
- Related performance stack context: #863, #864, #865, #866, #868

Result:

Native stdout rendering writes fewer/smoother buffered chunks for large JSON output while preserving byte-identical output and the existing flush contract.
