### PR TITLE
perf: buffer json file output

### DIFF
--- a/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMainBase.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMainBase.scala
@@ -22,6 +22,7 @@ object SjsonnetMainBase {
    * Sentinel value returned when output was already written directly to stdout via byte pipeline.
    */
   private val ByteRenderedSentinel = "\u0000"
+  private final val OutputBufferSize = 256 * 1024
 
   class SimpleImporter(
       searchRoots0: Seq[Path], // Evaluated in order, first occurrence wins
@@ -315,14 +316,14 @@ object SjsonnetMainBase {
     config.outputFile match {
       case Some(f) if !config.yamlOut.value && !config.expectString.value =>
         // Byte[] fast path: render directly to OutputStream, bypassing OutputStreamWriter.
-        // ByteBuilder handles buffering internally (8KB threshold), no BufferedOutputStream needed.
         handleWriteFile(
           os.write.over.outputStream(os.Path(f, wd), createFolders = config.createDirs.value)
         ).flatMap { out =>
           try {
-            val renderer = new ByteRenderer(out, indent = config.indent)
+            val buf = new BufferedOutputStream(out, SjsonnetMainBase.OutputBufferSize)
+            val renderer = new ByteRenderer(buf, indent = config.indent)
             val res = interp.interpret0(jsonnetCode, OsPath(path), renderer)
-            out.flush()
+            buf.flush()
             res.map(_ => "")
           } finally out.close()
         }


### PR DESCRIPTION
Motivation:

The Native stdout buffering follow-up showed that downstream buffering can materially reduce large-output write overhead. JSON `-o` output still sent `ByteRenderer` chunks directly to the file output stream, relying only on `ByteBuilder`'s internal flush threshold.

Key Design Decision:

Keep the change local to the JSON output-file fast path. Rather than changing `ByteBuilder` thresholds globally, wrap the file output stream in a `BufferedOutputStream` with the same 256 KiB output buffer size used for the Native stdout buffering follow-up. YAML, expect-string, stdout, and renderer semantics stay unchanged.

Modification:

- Add `OutputBufferSize = 256 * 1024` in `SjsonnetMainBase`.
- Wrap JSON output-file `ByteRenderer` targets in `BufferedOutputStream(out, OutputBufferSize)`.
- Flush the buffered stream at the same completion boundary before closing the underlying file output stream.

Benchmark Results:

Workload: `jrsonnet/tests/realworld/entry-kube-prometheus.jsonnet -J vendor -o /tmp/fileout-*.json`

Candidate was benchmarked on the Scala Native 0.5.12 stacked exploration branch after the Native stdout buffering commit.

| Order | Clean | Candidate | Result |
| --- | ---: | ---: | ---: |
| Forward mean | 217.372 ms | 205.062 ms | -5.7% |
| Forward median | 196.625 ms | 183.491 ms | -6.7% |
| Reverse mean | 210.517 ms | 177.174 ms | -15.8% |
| Reverse median | 193.394 ms | 175.878 ms | -9.1% |

Output equality matched by `cmp`.

Validation:

- `./mill --no-server --ticker false --color false __.reformat`
- `./mill --no-server --ticker false --color false -j 1 __.test` — 444 passed, 0 failed
- `./mill --no-server --ticker false --color false bench.runRegressions`

Analysis:

This preserves the existing rendering pipeline and only changes the buffering layer for file output. It avoids global `ByteBuilder` threshold changes, keeps stdout behavior separate, and does not affect YAML or expect-string paths.

References:

- Native stdout buffering PR: #869
- Scala Native 0.5.12 migration PR: #867
- Related performance stack context: #863, #864, #865, #866, #868

Result:

Large JSON file output writes are buffered more effectively while preserving byte-identical output and the existing flush/close contract.
