### PR TITLE
perf: precompute json import sorted order

### DIFF
--- a/sjsonnet/src/sjsonnet/Importer.scala
+++ b/sjsonnet/src/sjsonnet/Importer.scala
@@ -378,6 +378,8 @@ object CachedResolver {
             keyArray,
             memberArray
           )
+          if (keyArray.length > 1)
+            obj._sortedInlineOrder = Materializer.computeSortedInlineOrder(keyArray, memberArray)
           obj._skipFieldCache = true
           obj
         }


### PR DESCRIPTION
Motivation:
Strict JSON imports produce immutable object trees with fixed keys. On kube-prometheus rendering, computing sorted inline order lazily for imported JSON objects appeared in profiling as avoidable render-time work.

Key Design Decision:
Only strict `.json` import objects with more than one key eagerly cache `_sortedInlineOrder`. These objects are built from fixed key/member arrays, reject duplicate keys earlier, and are published through the parse cache after construction, so eager sorted-order computation is semantically equivalent to the existing lazy render-time computation.

Modification:
- Precompute `Materializer.computeSortedInlineOrder(keyArray, memberArray)` while constructing strict JSON import objects.
- Preserve the existing single-key/default path.
- No changes to Jsonnet object evaluation semantics or non-JSON imports.

Benchmark Results:
- Scala Native kube-prometheus A/B, same-run against clean baseline:
  - Forward: clean `191.107 ms` mean vs candidate `180.272 ms` mean.
  - Reverse: candidate `218.687 ms` mean vs clean `273.169 ms` mean.
- Local validation: `./mill --no-server --ticker false --color false __.reformat` and `./mill --no-server --ticker false --color false -j 1 __.test` passed; full test run reported passing suites including `444/444`, `511/511`, and `457/457` platform groups.

Analysis:
This moves deterministic sorting work from the hot render path into the strict JSON import construction path, where the object content is already known and immutable. It avoids touching general object evaluation, object comprehensions, or dynamic Jsonnet object behavior.

References:
- Related performance tracking: https://github.com/databricks/sjsonnet/issues/666

Result:
Less render-time work for strict JSON imports while preserving output equality and compatibility.
