### PR TITLE
perf: collapse importer exists+isDir into single isFile stat

### DIFF
--- a/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMainBase.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMainBase.scala
@@ -50,7 +50,7 @@ object SjsonnetMainBase {
           }
           allowed
         })
-        .find(f => os.exists(f) && !os.isDir(f))
+        .find(os.isFile(_))
         .orElse({
           if (debugImporter) {
             System.err.println(s"[import $importName] none of the candidates exist")
@@ -553,7 +553,7 @@ object SjsonnetMainBase {
       binaryData: Boolean,
       debugImporter: Boolean): Option[ResolvedFile] = {
     val osPath = path.asInstanceOf[OsPath].p
-    if (os.exists(osPath) && !os.isDir(osPath)) {
+    if (os.isFile(osPath)) {
       Some(
         new CachedResolvedFile(
           path.asInstanceOf[OsPath],


### PR DESCRIPTION
## Motivation

async-profiler on kube-prometheus shows file-I/O syscalls account for ~15% of CPU (top leaf frames: `__open` 294, `stat64` 210, `access` 167, `close` 102, `read` 92). The `SimpleImporter.resolve` chain does `os.exists(f) && !os.isDir(f)` per candidate — `os.exists` backs onto `Files.exists` (POSIX `access(F_OK)`) and `os.isDir` backs onto `Files.isDirectory` (POSIX `stat`). For an existent candidate that is two syscalls. The same check is repeated again in `readPath`, so the success path pays four syscalls just for the resolve+read gate before the real read happens.

## Modification

Replace `os.exists(f) && !os.isDir(f)` with `os.isFile(_)` in both `SimpleImporter.resolve` and `readPath`. `os.isFile` delegates to `Files.isRegularFile`, which is one `stat` call and catches `IOException` internally — so it returns `false` for non-existent paths without throwing. Semantics are preserved for any path a Jsonnet import would care about (regular files, including those reached through symlinks).

## Result

async-profiler confirms `access` leaf samples eliminated entirely (167 → 0). 3-run × 200-iter A/B on kube-prometheus (JVM build, fresh `Interpreter` per run, no asprof attached):

|        | baseline | after   | delta             |
|--------|----------|---------|-------------------|
| min    | 54.5 ms  | 52.6 ms | −1.9 ms (−3.5%)   |
| p50    | 58.1 ms  | 55.8 ms | −2.3 ms (−4.0%)   |
| mean   | 61.9 ms  | 59.2 ms | −2.7 ms (−4.4%)   |

`stat64` count goes slightly up (210 → 305) because `Files.isRegularFile` uses `stat` instead of `access`, but the net syscall count drops ~72 per run. Scala.js importer is user-provided JS closures so it is unaffected; Scala Native picks up the same benefit since the file lives under `src-jvm-native`.

## Test plan

- [x] `./mill 'sjsonnet.jvm[3.3.7]'.compile`
- [x] `./mill 'sjsonnet.native[3.3.7]'.compile`
- [x] `./mill __.checkFormat`
- [x] `./mill 'sjsonnet.jvm[3.3.7]'.test` (full JVM suite passes)