### PR TITLE
perf: use unsynchronized StringBuilderWriter in TomlRenderer

### DIFF
--- a/sjsonnet/src/sjsonnet/TomlRenderer.scala
+++ b/sjsonnet/src/sjsonnet/TomlRenderer.scala
@@ -2,22 +2,24 @@ package sjsonnet
 
 import upickle.core.{ArrVisitor, ObjVisitor, SimpleVisitor, Visitor}
 
-import java.io.StringWriter
-
+// Uses the unsynchronized [[StringBuilderWriter]] rather than java.io.StringWriter: the latter is
+// backed by a synchronized StringBuffer, paying a monitor enter/exit on every write/flush on the
+// hot manifestTomlEx path. Output is byte-identical. Same swap as the JSON renderer in #874.
 class TomlRenderer(
-    out: StringWriter = new java.io.StringWriter(),
+    out: StringBuilderWriter = new StringBuilderWriter(),
     cumulatedIndent: String,
     indent: String)
-    extends SimpleVisitor[StringWriter, StringWriter] {
+    extends SimpleVisitor[StringBuilderWriter, StringBuilderWriter] {
   override def expectedMsg: String = "unimplemented type in Materializer"
-  private object objectKeyRenderer extends upickle.core.SimpleVisitor[StringWriter, StringWriter] {
+  private object objectKeyRenderer
+      extends upickle.core.SimpleVisitor[StringBuilderWriter, StringBuilderWriter] {
     override def expectedMsg = "expected string"
 
-    override def visitNull(index: Int): StringWriter = {
+    override def visitNull(index: Int): StringBuilderWriter = {
       TomlRenderer.this.visitNull(index)
     }
 
-    override def visitString(s: CharSequence, index: Int): StringWriter = {
+    override def visitString(s: CharSequence, index: Int): StringBuilderWriter = {
       if (s == null) visitNull(index)
       else {
         TomlRenderer.writeEscapedKey(out, s)
@@ -33,19 +35,19 @@ class TomlRenderer(
     out
   }
 
-  override def visitNull(index: Int): StringWriter = Error.fail("Tried to manifest \"null\"")
+  override def visitNull(index: Int): StringBuilderWriter = Error.fail("Tried to manifest \"null\"")
 
-  override def visitTrue(index: Int): StringWriter = {
+  override def visitTrue(index: Int): StringBuilderWriter = {
     out.write("true")
     flush
   }
 
-  override def visitFalse(index: Int): StringWriter = {
+  override def visitFalse(index: Int): StringBuilderWriter = {
     out.write("false")
     flush
   }
 
-  override def visitString(s: CharSequence, index: Int): StringWriter = {
+  override def visitString(s: CharSequence, index: Int): StringBuilderWriter = {
     if (s == null) {
       visitNull(index)
     } else {
@@ -54,7 +56,7 @@ class TomlRenderer(
     }
   }
 
-  override def visitFloat64(d: Double, index: Int): StringWriter = {
+  override def visitFloat64(d: Double, index: Int): StringBuilderWriter = {
     d match {
       case Double.PositiveInfinity          => out.write("inf")
       case Double.NegativeInfinity          => out.write("-inf")
@@ -65,8 +67,10 @@ class TomlRenderer(
     flush
   }
 
-  override def visitArray(length: Int, index: Int): ArrVisitor[StringWriter, StringWriter] =
-    new ArrVisitor[StringWriter, StringWriter] {
+  override def visitArray(
+      length: Int,
+      index: Int): ArrVisitor[StringBuilderWriter, StringBuilderWriter] =
+    new ArrVisitor[StringBuilderWriter, StringBuilderWriter] {
       private val isInLine = length == 0 || depth > 0
       private val newElementIndent = if (isInLine) "" else cumulatedIndent + indent
       private val separator =
@@ -76,7 +80,7 @@ class TomlRenderer(
       depth += 1
       out.write('[')
       out.write(separator)
-      def subVisitor: Visitor[StringWriter, StringWriter] = {
+      def subVisitor: Visitor[StringBuilderWriter, StringBuilderWriter] = {
         if (addComma) {
           out.write(',')
           out.write(separator)
@@ -84,10 +88,10 @@ class TomlRenderer(
         out.write(newElementIndent)
         TomlRenderer.this
       }
-      def visitValue(v: StringWriter, index: Int): Unit = {
+      def visitValue(v: StringBuilderWriter, index: Int): Unit = {
         addComma = true
       }
-      def visitEnd(index: Int): StringWriter = {
+      def visitEnd(index: Int): StringBuilderWriter = {
         addComma = false
         depth -= 1
         out.write(separator)
@@ -100,23 +104,23 @@ class TomlRenderer(
   override def visitObject(
       length: Int,
       jsonableKeys: Boolean,
-      index: Int): ObjVisitor[StringWriter, StringWriter] =
-    new ObjVisitor[StringWriter, StringWriter] {
+      index: Int): ObjVisitor[StringBuilderWriter, StringBuilderWriter] =
+    new ObjVisitor[StringBuilderWriter, StringBuilderWriter] {
       private var addComma = false
       depth += 1
       out.write("{ ")
-      def subVisitor: Visitor[StringWriter, StringWriter] = TomlRenderer.this
-      def visitKey(index: Int): Visitor[StringWriter, StringWriter] = {
+      def subVisitor: Visitor[StringBuilderWriter, StringBuilderWriter] = TomlRenderer.this
+      def visitKey(index: Int): Visitor[StringBuilderWriter, StringBuilderWriter] = {
         if (addComma) out.write(", ")
         objectKeyRenderer
       }
       def visitKeyValue(s: Any): Unit = {
         out.write(" = ")
       }
-      def visitValue(v: StringWriter, index: Int): Unit = {
+      def visitValue(v: StringBuilderWriter, index: Int): Unit = {
         addComma = true
       }
-      def visitEnd(index: Int): StringWriter = {
+      def visitEnd(index: Int): StringBuilderWriter = {
         addComma = false
         depth -= 1
         out.write(" }")
@@ -146,14 +150,14 @@ object TomlRenderer {
     }
   }
 
-  def writeEscapedKey(out: StringWriter, key: CharSequence): Unit = {
+  def writeEscapedKey(out: StringBuilderWriter, key: CharSequence): Unit = {
     if (isBareKey(key)) out.write(key.toString)
     else BaseRenderer.escape(out, key, unicode = true)
   }
 
   def escapeKey(key: String): String = if (isBareKey(key)) key
   else {
-    val out = new StringWriter()
+    val out = new StringBuilderWriter()
     writeEscapedKey(out, key)
     out.toString
   }

--- a/sjsonnet/src/sjsonnet/stdlib/ManifestModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/ManifestModule.scala
@@ -170,19 +170,6 @@ object ManifestModule extends AbstractFunctionModule {
 
     private def isSection(v: Val) = v.isInstanceOf[Val.Obj] || isTableArray(v)
 
-    private def sortedKeyIndex(keys: Array[String], key: String): Int = {
-      var low = 0
-      var high = keys.length - 1
-      while (low <= high) {
-        val mid = (low + high) >>> 1
-        val comparison = Util.CodepointStringOrdering.compare(keys(mid), key)
-        if (comparison < 0) low = mid + 1
-        else if (comparison > 0) high = mid - 1
-        else return mid
-      }
-      -1
-    }
-
     private def renderTableInternal(
         out: StringBuilderWriter,
         v: Val.Obj,
@@ -195,36 +182,40 @@ object ManifestModule extends AbstractFunctionModule {
         return out
       }
 
+      // Resolve each field once and cache the result: the value is needed twice
+      // (to classify scalars vs sections, then to render). Iterating `keys` directly
+      // also skips the binary search that mapped `visibleKeyNames` back into `keys`.
+      val resolved = new Array[Val](keys.length)
       val sectionFlags = new Array[Boolean](keys.length)
-      val visibleKeys = v.visibleKeyNames
-      var visibleKeyIdx = 0
-      while (visibleKeyIdx < visibleKeys.length) {
-        val k = visibleKeys(visibleKeyIdx)
-        val sortedIdx = sortedKeyIndex(keys, k)
-        sectionFlags(sortedIdx) = isSection(v.value(k, v.pos)(ev))
-        visibleKeyIdx += 1
+      var keyIdx = 0
+      while (keyIdx < keys.length) {
+        val r = v.value(keys(keyIdx), v.pos)(ev)
+        resolved(keyIdx) = r
+        sectionFlags(keyIdx) = isSection(r)
+        keyIdx += 1
       }
 
       val renderer = new TomlRenderer(out, cumulatedIndent, indent)
-      var keyIdx = 0
+      keyIdx = 0
       while (keyIdx < keys.length) {
         if (!sectionFlags(keyIdx)) {
-          val k = keys(keyIdx)
           out.write(cumulatedIndent)
-          TomlRenderer.writeEscapedKey(out, k)
+          TomlRenderer.writeEscapedKey(out, keys(keyIdx))
           out.write(" = ")
-          Materializer.apply0(v.value(k, v.pos)(ev), renderer)(ev)
+          Materializer.apply0(resolved(keyIdx), renderer)(ev)
         }
         keyIdx += 1
       }
       out.write('\n')
 
+      // childIndent depends only on cumulatedIndent + indent, so compute it once
+      // instead of per section iteration.
+      val childIndent = cumulatedIndent + indent
       keyIdx = 0
       while (keyIdx < keys.length) {
         if (sectionFlags(keyIdx)) {
           val k = keys(keyIdx)
-          val v0 = v.value(k, v.pos, v)(ev)
-          val childIndent = cumulatedIndent + indent
+          val v0 = resolved(keyIdx)
           path += k
           v0 match {
             case arr: Val.Arr =>
@@ -285,7 +276,9 @@ object ManifestModule extends AbstractFunctionModule {
     }
 
     def evalRhs(v: Eval, indent: Eval, ev: EvalScope, pos: Position): Val = {
-      val out = new StringBuilderWriter
+      // Pre-size at 1 KiB to skip the first ~6 doublings (16→1024) for typical TOML
+      // outputs without overcommitting memory on small ones.
+      val out = new StringBuilderWriter(1024)
       renderTableInternal(
         out,
         v.value.asObj,

--- a/sjsonnet/src/sjsonnet/stdlib/ManifestModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/ManifestModule.scala
@@ -184,11 +184,11 @@ object ManifestModule extends AbstractFunctionModule {
     }
 
     private def renderTableInternal(
-        out: StringWriter,
+        out: StringBuilderWriter,
         v: Val.Obj,
         cumulatedIndent: String,
         indent: String,
-        path: mutable.ArrayBuffer[String])(implicit ev: EvalScope): StringWriter = {
+        path: mutable.ArrayBuffer[String])(implicit ev: EvalScope): StringBuilderWriter = {
       val keys = v.sortedVisibleKeyNames
       if (keys.length == 0) {
         out.write('\n')
@@ -263,7 +263,7 @@ object ManifestModule extends AbstractFunctionModule {
       out
     }
 
-    private def renderTableHeader(out: StringWriter, path: mutable.ArrayBuffer[String]) = {
+    private def renderTableHeader(out: StringBuilderWriter, path: mutable.ArrayBuffer[String]) = {
       out.write('[')
       var i = 0
       while (i < path.length) {
@@ -275,7 +275,9 @@ object ManifestModule extends AbstractFunctionModule {
       out
     }
 
-    private def renderTableArrayHeader(out: StringWriter, path: mutable.ArrayBuffer[String]) = {
+    private def renderTableArrayHeader(
+        out: StringBuilderWriter,
+        path: mutable.ArrayBuffer[String]) = {
       out.write('[')
       renderTableHeader(out, path)
       out.write(']')
@@ -283,7 +285,7 @@ object ManifestModule extends AbstractFunctionModule {
     }
 
     def evalRhs(v: Eval, indent: Eval, ev: EvalScope, pos: Position): Val = {
-      val out = new StringWriter
+      val out = new StringBuilderWriter
       renderTableInternal(
         out,
         v.value.asObj,


### PR DESCRIPTION
## Motivation

`std.manifestTomlEx` had three sources of avoidable overhead on the hot manifestation path:

1. **Synchronized writer.** `TomlRenderer` and `ManifestModule.evalRhs` rendered into a `java.io.StringWriter`, whose backing `StringBuffer` pays a monitor enter/exit on every `write`/`flush`. The `FastMaterializeJsonRenderer` already uses the unsynchronized `StringBuilderWriter` (#874); TOML did not.
2. **Redundant field lookups in `renderTableInternal`.** Each key's `Val.Obj.value(k)` was resolved twice — once to classify scalar vs section, then again to render or recurse. The cache deduplicates the result, but the lookup itself still costs.
3. **Wasted indexing work.** `visibleKeyNames` was iterated and each key binary-searched back into `sortedVisibleKeyNames` — `sortedVisibleKeyNames` can be iterated directly, skipping `O(n log n)` compares per table.

## Modification

Two commits:

- **`perf: use unsynchronized StringBuilderWriter in TomlRenderer`** — Swap `TomlRenderer` and the `manifestTomlEx` render path in `ManifestModule` from `java.io.StringWriter` to the package-private `StringBuilderWriter`. `std.deepJoin` keeps `StringWriter` (separate concern).
- **`perf: cache resolved field values and skip binary search in renderTableInternal`** — Resolve each field once into a `resolved: Array[Val]` during section classification and reuse it during render/recurse; iterate `sortedVisibleKeyNames` directly (removes the now-unused `sortedKeyIndex` binary search); hoist `childIndent = cumulatedIndent + indent` out of the section loop (was an identical allocation per sibling section); pre-size the output `StringBuilderWriter` to 1 KiB so small/medium outputs skip the first ~6 doublings.

Output is byte-identical (verified at 1,228,186 bytes on the benchmark workload).

## Result

Scala Native, hyperfine A/B against `master` (`fc292fa6`). Workload: object comprehension over 8000 small tables → ~1.2 MB TOML output (render-dominated). Four interleaved-order passes, `--warmup 10 --min-runs 100 --shell=none`:

| pass | order | before mean | after mean | before min | after min | **min ratio** |
|---|---|---:|---:|---:|---:|---:|
| 1 | before → after | 59.4 ±  2.7 ms | 53.2 ± 23.4 ms | 55.4 ms | 43.8 ms | **1.27×** |
| 2 | after → before | 64.1 ±  7.7 ms | 51.8 ± 12.2 ms | 56.4 ms | 43.7 ms | **1.29×** |
| 3 | before → after | 64.1 ±  8.1 ms | 53.2 ± 14.3 ms | 56.4 ms | 42.0 ms | **1.34×** |
| 4 | after → before | 63.3 ± 14.3 ms | 49.2 ±  3.7 ms | 57.2 ms | 42.8 ms | **1.34×** |

Mean is noisy on the host (1.12× – 1.29×), but **after is faster in every one of the 4 passes** and the **min values are tight at ~1.27–1.34× faster** (best observed: 42.0 ms vs 56.4 ms, ~25.5% reduction). Output byte-identical, 1,228,186 bytes both sides.

For comparison, the StringBuilderWriter swap alone (commit 1) measures ~1.08–1.14× min; the cache + binary-search elimination + childIndent hoist (commit 2) lifts that to ~1.27–1.34× min.

## Test plan

- [x] `./mill __.reformat`
- [x] `./mill 'sjsonnet.jvm[3.3.7]'.test` — 519/519 pass
- [x] Scala Native A/B hyperfine — 4 interleaved-order passes, all positive; output byte-identical

---

> Rebased onto current `master` (`fc292fa6`). The companion commit "speed up manifest JSON rendering" was merged separately as #879, so this PR now contains only the TomlRenderer / ManifestModule changes.
