### PR TITLE
perf: capture parse Position without boxing the offset Int

### DIFF
--- a/sjsonnet/src/sjsonnet/Parser.scala
+++ b/sjsonnet/src/sjsonnet/Parser.scala
@@ -96,7 +96,16 @@ class Parser(
     throw new ParseError(msg, offset = offset)
   }
 
-  def Pos[$: P]: P[Position] = Index.map(offset => new Position(fileScope, offset))
+  // Capture the current parse offset as a Position directly, rather than `Index.map(...)`.
+  // `Index` stores the offset as an `Int` in fastparse's `successValue: Any`, boxing it, and the
+  // `.map` then unboxes it and allocates a closure — both per AST node (Pos is called for nearly
+  // every node). Writing the Position straight into successValue (a reference) skips the box/unbox
+  // and the lambda. boxToInteger via SharedPackageDefs.Index was a top self-frame in the parse
+  // flamegraph on kube-prometheus.
+  def Pos[$: P]: P[Position] = {
+    val ctx = implicitly[P[$]]
+    ctx.freshSuccess(new Position(fileScope, ctx.index))
+  }
 
   def id[$: P]: P[String] = P(
     CharIn("_a-zA-Z") ~~


### PR DESCRIPTION
## Motivation

`Parser.Pos` is invoked for nearly every AST node to capture the source offset. It was `Index.map(off => new Position(...))`: fastparse's `Index` stores the offset as an `Int` in its `successValue: Any` field (boxing it), and the `.map` then unboxes it and allocates a closure — per node. `boxToInteger` via `SharedPackageDefs.Index` was a top self-frame in the parse flamegraph on kube-prometheus.

## Modification

- Write the `Position` object straight into `successValue` via `ctx.freshSuccess(new Position(fileScope, ctx.index))`, skipping the `Int` box/unbox and the `map` closure. Parse output (positions / error offsets) is unchanged.

## Result

Scala Native `--debug-stats parse_time` on kube-prometheus (148 files), interleaved and cooled:

| | min | mean |
|---|---:|---:|
| master | 92.6 ms | 104.2 ms |
| this PR | 86.9 ms | 96.0 ms |

→ ~**6–8% faster parse**; output byte-identical. (JMH `ParserBenchmark` over the test suite showed +5.4% on JVM.)

## Test plan

- [x] `./mill __.reformat`
- [x] `./mill 'sjsonnet.jvm[3.3.7]'.test` — 518/518 pass
