### PR TITLE
perf: speed up manifest JSON rendering

### DIFF
--- a/sjsonnet/src/sjsonnet/Renderer.scala
+++ b/sjsonnet/src/sjsonnet/Renderer.scala
@@ -4,6 +4,41 @@ import java.io.{StringWriter, Writer}
 
 import upickle.core.{ArrVisitor, ObjVisitor}
 
+final class StringBuilderWriter(initialCapacity: Int = 16) extends Writer {
+  private[this] val builder = new java.lang.StringBuilder(initialCapacity)
+
+  override def write(c: Int): Unit =
+    builder.append(c.toChar)
+
+  override def write(cbuf: Array[Char], off: Int, len: Int): Unit =
+    builder.append(cbuf, off, len)
+
+  override def write(str: String): Unit =
+    builder.append(str)
+
+  override def write(str: String, off: Int, len: Int): Unit =
+    builder.append(str, off, off + len)
+
+  override def append(c: Char): Writer = {
+    builder.append(c)
+    this
+  }
+
+  override def append(csq: CharSequence): Writer = {
+    builder.append(if (csq == null) "null" else csq)
+    this
+  }
+
+  override def append(csq: CharSequence, start: Int, end: Int): Writer = {
+    builder.append(if (csq == null) "null" else csq, start, end)
+    this
+  }
+
+  override def flush(): Unit = ()
+  override def close(): Unit = ()
+  override def toString: String = builder.toString
+}
+
 /**
  * Custom JSON renderer to try and match the behavior of google/jsonnet's render:
  *
@@ -272,6 +307,93 @@ final case class MaterializeJsonRenderer(
     elemBuilder.append('{')
     depth += 1
     // account for rendering differences of whitespaces in ujson and jsonnet manifestJson
+    if (length == 0 && indent != -1)
+      elemBuilder.appendAll(newLineCharArray, newLineCharArray.length)
+    else renderIndent()
+    reusableObjVisitor
+  }
+}
+
+private[sjsonnet] final class FastMaterializeJsonRenderer(
+    indent: Int = 4,
+    escapeUnicode: Boolean = false,
+    newline: String = "\n",
+    keyValueSeparator: String = ": ",
+    private val outWriter: StringBuilderWriter = new StringBuilderWriter())
+    extends BaseCharRenderer(
+      outWriter,
+      indent,
+      escapeUnicode,
+      newline.toCharArray
+    ) {
+  private val newLineCharArray = newline.toCharArray
+  private val keyValueSeparatorCharArray = keyValueSeparator.toCharArray
+
+  private val reusableArrVisitor: ArrVisitor[StringBuilderWriter, StringBuilderWriter] {
+    def subVisitor: sjsonnet.FastMaterializeJsonRenderer
+  } = new ArrVisitor[StringBuilderWriter, StringBuilderWriter] {
+    def subVisitor: sjsonnet.FastMaterializeJsonRenderer = FastMaterializeJsonRenderer.this
+    def visitValue(v: StringBuilderWriter, index: Int): Unit = {
+      flushBuffer()
+      commaBuffered = true
+    }
+    def visitEnd(index: Int): StringBuilderWriter = {
+      commaBuffered = false
+      depth -= 1
+      renderIndent()
+      elemBuilder.append(']')
+      flushCharBuilder()
+      outWriter
+    }
+  }
+
+  private val reusableObjVisitor: ObjVisitor[StringBuilderWriter, StringBuilderWriter] {
+    def subVisitor: sjsonnet.FastMaterializeJsonRenderer
+    def visitKey(index: Int): sjsonnet.FastMaterializeJsonRenderer
+  } = new ObjVisitor[StringBuilderWriter, StringBuilderWriter] {
+    def subVisitor: sjsonnet.FastMaterializeJsonRenderer = FastMaterializeJsonRenderer.this
+    def visitKey(index: Int): sjsonnet.FastMaterializeJsonRenderer =
+      FastMaterializeJsonRenderer.this
+    def visitKeyValue(s: Any): Unit = {
+      elemBuilder.appendAll(keyValueSeparatorCharArray, keyValueSeparatorCharArray.length)
+    }
+    def visitValue(v: StringBuilderWriter, index: Int): Unit = {
+      commaBuffered = true
+    }
+    def visitEnd(index: Int): StringBuilderWriter = {
+      commaBuffered = false
+      depth -= 1
+      renderIndent()
+      elemBuilder.append('}')
+      flushCharBuilder()
+      outWriter
+    }
+  }
+
+  override def visitArray(
+      length: Int,
+      index: Int): upickle.core.ArrVisitor[StringBuilderWriter, StringBuilderWriter] {
+    def subVisitor: sjsonnet.FastMaterializeJsonRenderer
+  } = {
+    flushBuffer()
+    elemBuilder.append('[')
+
+    depth += 1
+    if (length == 0 && indent != -1)
+      elemBuilder.appendAll(newLineCharArray, newLineCharArray.length)
+    else renderIndent()
+    reusableArrVisitor
+  }
+
+  override def visitObject(
+      length: Int,
+      index: Int): upickle.core.ObjVisitor[StringBuilderWriter, StringBuilderWriter] {
+    def subVisitor: sjsonnet.FastMaterializeJsonRenderer
+    def visitKey(index: Int): sjsonnet.FastMaterializeJsonRenderer
+  } = {
+    flushBuffer()
+    elemBuilder.append('{')
+    depth += 1
     if (length == 0 && indent != -1)
       elemBuilder.appendAll(newLineCharArray, newLineCharArray.length)
     else renderIndent()

--- a/sjsonnet/src/sjsonnet/Util.scala
+++ b/sjsonnet/src/sjsonnet/Util.scala
@@ -128,10 +128,10 @@ object Util {
     while (i1 < n1 && i2 < n2) {
       val c1 = s1.charAt(i1)
       val c2 = s2.charAt(i2)
-      // Fast path: equal chars can be skipped without surrogate checks.
-      // Even for surrogate pairs, equal high surrogates at position i lead to
-      // comparing low surrogates at i+1, producing the correct codepoint ordering.
-      if (c1 == c2) {
+      // Fast path: equal non-surrogates can be skipped without codepoint checks.
+      // Equal surrogates still need codepoint decoding because a raw surrogate and
+      // a valid surrogate pair can share the same leading UTF-16 code unit.
+      if (c1 == c2 && !Character.isSurrogate(c1)) {
         i1 += 1
         i2 += 1
       } else if (!Character.isSurrogate(c1) && !Character.isSurrogate(c2)) {
@@ -155,6 +155,10 @@ object Util {
    */
   val CodepointStringOrdering: Ordering[String] = new Ordering[String] {
     override def compare(x: String, y: String): Int = compareStringsByCodepoint(x, y)
+  }
+
+  def sortStringsByCodepointInPlace(xs: Array[String]): Unit = {
+    java.util.Arrays.sort(xs, CodepointStringOrdering)
   }
 
   def compareJsonnetStd(v1: Val, v2: Val, ev: EvalScope): Int = {

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -1822,7 +1822,8 @@ object Val {
     private[sjsonnet] def sortedVisibleKeyNames: Array[String] = {
       var r = _sortedVisibleKeyNames
       if (r == null) {
-        r = visibleKeyNames.sorted(Util.CodepointStringOrdering)
+        r = visibleKeyNames.clone()
+        Util.sortStringsByCodepointInPlace(r)
         _sortedVisibleKeyNames = r
       }
       r

--- a/sjsonnet/src/sjsonnet/stdlib/ManifestModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/ManifestModule.scala
@@ -39,7 +39,7 @@ object ManifestModule extends AbstractFunctionModule {
    */
   private object ManifestJson extends Val.Builtin1("manifestJson", "v") {
     def evalRhs(v: Eval, ev: EvalScope, pos: Position): Val =
-      Val.Str(pos, Materializer.apply0(v.value, MaterializeJsonRenderer())(ev).toString)
+      Val.Str(pos, Materializer.apply0(v.value, new FastMaterializeJsonRenderer())(ev).toString)
   }
 
   /**
@@ -57,7 +57,7 @@ object ManifestModule extends AbstractFunctionModule {
         Materializer
           .apply0(
             v.value,
-            MaterializeJsonRenderer(indent = -1, newline = "", keyValueSeparator = ":")
+            new FastMaterializeJsonRenderer(indent = -1, newline = "", keyValueSeparator = ":")
           )(ev)
           .toString
       )
@@ -94,7 +94,7 @@ object ManifestModule extends AbstractFunctionModule {
         Materializer
           .apply0(
             v.value,
-            MaterializeJsonRenderer(
+            new FastMaterializeJsonRenderer(
               indent = i.value.asString.length,
               newline = newline.value.asString,
               keyValueSeparator = keyValSep.value.asString

--- a/sjsonnet/src/sjsonnet/stdlib/ObjectModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/ObjectModule.scala
@@ -258,7 +258,12 @@ object ObjectModule extends AbstractFunctionModule {
     maybeSortKeys(ev, v1.allKeyNames)
 
   @inline private def maybeSortKeys(ev: EvalScope, keys: Array[String]): Array[String] =
-    if (ev.settings.preserveOrder) keys else keys.sorted(Util.CodepointStringOrdering)
+    if (ev.settings.preserveOrder) keys
+    else {
+      val sorted = keys.clone()
+      Util.sortStringsByCodepointInPlace(sorted)
+      sorted
+    }
 
   def getObjValuesFromKeys(
       pos: Position,

--- a/sjsonnet/test/src/sjsonnet/UnicodeHandlingTests.scala
+++ b/sjsonnet/test/src/sjsonnet/UnicodeHandlingTests.scala
@@ -109,14 +109,67 @@ object UnicodeHandlingTests extends TestSuite {
       val codepointSorted = testStrings.sorted(sjsonnet.Util.CodepointStringOrdering).toList
       codepointSorted ==> List("\uFFFF", "\uD800\uDC00")
 
+      val inPlaceSorted = testStrings.clone()
+      sjsonnet.Util.sortStringsByCodepointInPlace(inPlaceSorted)
+      inPlaceSorted.toList ==> codepointSorted
+
       // These produce different results, demonstrating the bug that was fixed
       assert(utf16Sorted != codepointSorted)
+    }
+
+    test("codepointInPlaceSortMatchesReferenceOrdering") {
+      val samples = Array(
+        "",
+        "a",
+        "b",
+        "aa",
+        "\u0000",
+        "\uD800\uDC00", // U+10000
+        "\uFFFF",
+        "😀",
+        "🌍",
+        "🚀",
+        "é",
+        "Ω",
+        "中"
+      )
+
+      val cases = Seq(
+        Array.empty[String],
+        Array("a"),
+        Array("b", "a"),
+        Array.fill(20)("same"),
+        samples,
+        samples.reverse,
+        Array.tabulate(64)(i => samples((i * 7 + 3) % samples.length))
+      )
+
+      for (c <- cases) {
+        val actual = c.clone()
+        sjsonnet.Util.sortStringsByCodepointInPlace(actual)
+        actual.toList ==> c.sorted(sjsonnet.Util.CodepointStringOrdering).toList
+      }
     }
 
     test("codepointOrderingInJsonnet") {
       // Verify that Jsonnet operations use Unicode codepoint ordering
       eval("'\\uFFFF' < '\\uD800\\uDC00'") ==> ujson.Bool(true)
       eval("std.sort(['\\uD800\\uDC00', '\\uFFFF'])") ==> ujson.Arr("\uFFFF", "\uD800\uDC00")
+    }
+
+    test("rawSurrogatePrefixOrdering") {
+      val rawSurrogatePrefix = "\uD800\uFFFF" // codepoints [0xD800, 0xFFFF]
+      val validSurrogatePair = "\uD800\uDC00" // codepoint [0x10000]
+
+      assert(sjsonnet.Util.compareStringsByCodepoint(rawSurrogatePrefix, validSurrogatePair) < 0)
+      assert(sjsonnet.Util.compareStringsByCodepoint(validSurrogatePair, rawSurrogatePrefix) > 0)
+
+      eval("(std.char(55296) + std.char(65535)) < (std.char(55296) + std.char(56320))") ==>
+      ujson.Bool(true)
+
+      eval(
+        "std.sort([std.char(55296) + std.char(56320), std.char(55296) + std.char(65535)])"
+      ) ==> ujson.Arr(rawSurrogatePrefix, validSurrogatePair)
     }
 
     // Unpaired surrogate handling - sjsonnet-specific behavior


### PR DESCRIPTION
## Motivation

`std.manifestJson`, `std.manifestJsonMinified`, and `std.manifestJsonEx` routed through `java.io.StringWriter`, paying `StringBuffer` synchronization per `write`/`flush` on the hot manifestation path. Source-built jrsonnet comparisons showed sjsonnet trailing on object-heavy manifest workloads.

## Modification

- Add `StringBuilderWriter`: an unsynchronized `Writer` over a `StringBuilder`.
- Add package-private `FastMaterializeJsonRenderer` backed by `StringBuilderWriter`; route the three `std.manifestJson*` builtins through it. Public `MaterializeJsonRenderer` ABI/shape unchanged.
- Use an in-place codepoint sort for `sortedVisibleKeyNames` / `maybeSortKeys` (avoids `.sorted` boxing).
- Fix codepoint comparison for raw surrogate prefixes; `UnicodeHandlingTests` extended.

## Result

Scala Native hyperfine on kube-prometheus, jrsonnet HEAD `2d7eed05`:

| Workload (native) | Before | After | Δ |
|---|---:|---:|---:|
| kube-prometheus, sjsonnet | 158.4 ± 16.8 ms | 143.7 ± 3.2 ms | **−9.3%** |
| `manifestJsonEx`, sjsonnet | — | 5.09 ± 1.01 ms | new |

## Test plan

- [x] `./mill __.reformat`
- [x] `./mill 'sjsonnet.jvm[3.3.7]'.test` — 518/518 pass

This PR is the base for the stacked follow-ups #875 (TomlRenderer reuses `StringBuilderWriter`), and the independent #876/#877/#878.
