### PR TITLE
perf: memoize import path resolution in CachedImporter

### DIFF
--- a/sjsonnet/src/sjsonnet/Importer.scala
+++ b/sjsonnet/src/sjsonnet/Importer.scala
@@ -201,7 +201,16 @@ class CachedImporter(parent: Importer) extends Importer {
   val cache: mutable.HashMap[(Path, Boolean), ResolvedFile] =
     mutable.HashMap.empty[(Path, Boolean), ResolvedFile]
 
-  def resolve(docBase: Path, importName: String): Option[Path] = parent.resolve(docBase, importName)
+  // Memoize path resolution by (docBase, importName). resolve() runs on every visitImport — before
+  // the evaluator's by-path Val cache is consulted — and each call stats candidate paths
+  // (docBase + every jpath) via os.isFile. Resolution is deterministic within a run, so caching it
+  // turns repeated imports (and re-evaluated import exprs) into a HashMap lookup, eliminating
+  // redundant filesystem stats. Mirrors the existing read cache.
+  private val resolveCache: mutable.HashMap[(Path, String), Option[Path]] =
+    mutable.HashMap.empty[(Path, String), Option[Path]]
+
+  def resolve(docBase: Path, importName: String): Option[Path] =
+    resolveCache.getOrElseUpdate((docBase, importName), parent.resolve(docBase, importName))
 
   def read(path: Path, binaryData: Boolean): Option[ResolvedFile] = {
     val key = (path, binaryData)


### PR DESCRIPTION
## Motivation

`CachedImporter.read` is cached, but `resolve()` was not — it delegated straight to `parent.resolve` on every call. `resolve()` runs on every `visitImport` (before the evaluator's by-path `Val` cache is consulted), and each call stats candidate paths (`docBase` + every `--jpath`) via `os.isFile`. On multi-file configs the same imports resolve repeatedly, re-running those stats.

## Modification

- Memoize resolution by `(docBase, importName)` in `CachedImporter` (mirrors the existing read cache). Resolution is deterministic within a run, so repeated imports / re-evaluated import exprs become a `HashMap` lookup, eliminating redundant filesystem stats. No semantic change.

## Result

Scala Native, kube-prometheus (148 files), 25 interleaved runs, cooled:

| | min | median | mean |
|---|---:|---:|---:|
| master | 152.4 ms | 156.6 ms | 159.1 ms |
| this PR | 149.2 ms | 153.7 ms | 156.3 ms |

→ ~**1.7–2% faster** (all percentiles lower); output byte-identical.

## Test plan

- [x] `./mill __.reformat`
- [x] `./mill 'sjsonnet.jvm[3.3.7]'.test` — 518/518 pass
