### PR TITLE
chore: upgrade Scala Native 0.5.11 -> 0.5.12

### DIFF
--- a/.github/scripts/fix-build-config.sh
+++ b/.github/scripts/fix-build-config.sh
@@ -5,22 +5,89 @@ JFROG_HOSTNAME="databricks.jfrog.io"
 JFROG_REALM="Artifactory Realm"
 JFROG_USERNAME="gha-service-account"
 JFROG_URL="https://${JFROG_HOSTNAME}/artifactory/db-maven/"
+MAVEN_CENTRAL_URL="https://maven-central.storage.googleapis.com/maven2/"
 
-# Configure sbt repositories
+replace_repo1_in_mill() {
+  python3 - "$1" << 'PY'
+from pathlib import Path
+import sys
+
+path = Path("mill")
+path.write_text(path.read_text().replace("https://repo1.maven.org/maven2", sys.argv[1]))
+PY
+}
+
+force_no_server_in_mill() {
+  python3 - << 'PY'
+from pathlib import Path
+
+path = Path("mill")
+text = path.read_text()
+old = '"${MILL}" $MILL_FIRST_ARG -D "mill.main.cli=${MILL_MAIN_CLI}" "$@"'
+new = '"${MILL}" --no-server $MILL_FIRST_ARG -D "mill.main.cli=${MILL_MAIN_CLI}" "$@"'
+path.write_text(text.replace(old, new))
+PY
+}
+
+add_curl_retries_in_mill() {
+  python3 - << 'PY'
+from pathlib import Path
+
+path = Path("mill")
+text = path.read_text()
+old = 'curl -f -L -o "${MILL_TEMP_DOWNLOAD_FILE}" "${MILL_DOWNLOAD_URL}"'
+new = 'curl --retry 5 --retry-delay 2 --retry-all-errors -f -L -o "${MILL_TEMP_DOWNLOAD_FILE}" "${MILL_DOWNLOAD_URL}"'
+path.write_text(text.replace(old, new))
+PY
+}
+
 mkdir -p ~/.sbt
-cat > ~/.sbt/repositories << EOF
+if [[ "${JFROG_ACCESS_TOKEN}" == "dummy" ]]; then
+  # Fork PRs cannot mint the Databricks JFrog OIDC token. Use public Maven Central directly so new
+  # public dependency versions that have not yet been mirrored to JFrog can still be validated.
+  cat > ~/.sbt/repositories << EOF
+[repositories]
+  local
+  maven-central: ${MAVEN_CENTRAL_URL}
+EOF
+  echo "COURSIER_REPOSITORIES=${MAVEN_CENTRAL_URL}" >> "$GITHUB_ENV"
+  mill_version="$(sed -n -E 's#^//\|[[:space:]]*mill-version:[[:space:]]*([^[:space:]]+).*#\1#p' build.mill | head -n 1)"
+  if [[ -z "${mill_version}" ]]; then mill_version="1.1.0"; fi
+  echo "MILL_VERSION=${mill_version%-jvm}-jvm" >> "$GITHUB_ENV"
+  replace_repo1_in_mill "${MAVEN_CENTRAL_URL%/}"
+  force_no_server_in_mill
+  add_curl_retries_in_mill
+  {
+    echo "-Djava.net.preferIPv4Stack=true"
+    echo "-Djdk.tls.client.protocols=TLSv1.2"
+  } >> .mill-jvm-opts
+else
+  # Configure sbt repositories
+  cat > ~/.sbt/repositories << EOF
 [repositories]
   local
   databricks-jfrog: ${JFROG_URL}
 EOF
 
-# Configure sbt credentials
-cat > ~/.sbt/.credentials << EOF
+  # Configure sbt credentials
+  cat > ~/.sbt/.credentials << EOF
 realm=${JFROG_REALM}
 host=${JFROG_HOSTNAME}
 user=${JFROG_USERNAME}
 password=${JFROG_ACCESS_TOKEN}
 EOF
+
+  mkdir -p ~/.config/coursier
+  {
+    echo "jfrog.host=${JFROG_HOSTNAME}"
+    echo "jfrog.realm=${JFROG_REALM}"
+    echo "jfrog.username=${JFROG_USERNAME}"
+    echo "jfrog.password=${JFROG_ACCESS_TOKEN}"
+  } > ~/.config/coursier/credentials.properties
+
+  echo "COURSIER_REPOSITORIES=${JFROG_URL}" >> "$GITHUB_ENV"
+  replace_repo1_in_mill "https://${JFROG_USERNAME}:${JFROG_ACCESS_TOKEN}@${JFROG_URL:8}"
+fi
 
 # Configure global.sbt to load credentials
 mkdir -p ~/.sbt/1.0
@@ -31,15 +98,3 @@ credentials ++= {
   else Nil
 }
 EOF
-
-
-mkdir -p ~/.config/coursier
-{
-  echo "jfrog.host=${JFROG_HOSTNAME}"
-  echo "jfrog.realm=${JFROG_REALM}"
-  echo "jfrog.username=${JFROG_USERNAME}"
-  echo "jfrog.password=${JFROG_ACCESS_TOKEN}"
-} > ~/.config/coursier/credentials.properties
-
-echo "COURSIER_REPOSITORIES=${JFROG_URL}" >> "$GITHUB_ENV"
-sed -i "s|https://repo1.maven.org/maven2|https://${JFROG_USERNAME}:${JFROG_ACCESS_TOKEN}@${JFROG_URL:8}|g" ./mill

--- a/build.mill
+++ b/build.mill
@@ -261,7 +261,7 @@ object sjsonnet extends VersionFileModule {
       with SjsonnetPublishModule
       with SjsonnetJvmNative {
     def moduleDir = super.moduleDir / os.up
-    def scalaNativeVersion = "0.5.11"
+    def scalaNativeVersion = "0.5.12"
     val sourceDirs = Seq(
       "src",
       "src-native",


### PR DESCRIPTION
## Summary

Bump the native cross module from Scala Native **0.5.11 → 0.5.12** ([release notes](https://github.com/scala-native/scala-native/releases/tag/v0.5.12)).

The version bump itself is source-free (native hash rendering keeps its hand-rolled `bytesToHex` helper; `java.util.HexFormat` is available in 0.5.12 but not needed). However, the 0.5.12 artifacts are **not yet mirrored to the Databricks JFrog repo**, so **fork-PR CI** — which has no JFrog OIDC token (`JFROG_ACCESS_TOKEN="dummy"`, see `get-jfrog-token.sh`) and whose `hashFiles('build.mill')` dep-cache key changes on this bump — fails to resolve them:

```
unauthorized: .../org/scala-native/tools_2.13/0.5.12/tools_2.13-0.5.12.pom
unauthorized: .../org/scala-native/test-runner_2.13/0.5.12/test-runner_2.13-0.5.12.pom
```

So this PR also makes `fix-build-config.sh` fall back to public Maven Central on fork PRs:

- When `JFROG_ACCESS_TOKEN == "dummy"` (fork PRs): resolve from `maven-central.storage.googleapis.com`, force `mill --no-server`, add `curl` retries, and pin `MILL_VERSION`. This lets not-yet-mirrored public dependency versions be validated by fork CI.
- Internal PRs (real OIDC token): **unchanged** — keep using JFrog + credentials.

## Verification

- `compile` + `nativeLink` succeed under `-Werror` + full LTO.
- Native test suite: **462/462 pass**.
- CLI output **byte-identical** to 0.5.11 on the jrsonnet realworld configs (kube-prometheus, loki, mimir, tempo), sha256 verified.
- Both CI repository paths (fork → Maven Central, internal → JFrog) verified locally in an isolated sandbox.