### PR TITLE
perf: use unsynchronized StringBuilderWriter in std.deepJoin

### DIFF
--- a/sjsonnet/src/sjsonnet/stdlib/ManifestModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/ManifestModule.scala
@@ -337,7 +337,10 @@ object ManifestModule extends AbstractFunctionModule {
    */
   private object DeepJoin extends Val.Builtin1("deepJoin", "arr") {
     def evalRhs(value: Eval, ev: EvalScope, pos: Position): Val = {
-      val out = new StringWriter()
+      // Use the unsynchronized StringBuilderWriter: each Val.Str chunk triggers
+      // out.write(...) in a tight loop, and StringWriter's backing StringBuffer
+      // pays a monitor enter/exit per call. Same swap pattern as TomlRenderer (#875).
+      val out = new StringBuilderWriter()
       val q = new java.util.ArrayDeque[Eval]()
       q.add(value)
       while (!q.isEmpty) {


### PR DESCRIPTION
## Motivation

`std.deepJoin` writes each `Val.Str` chunk into a `java.io.StringWriter` inside a tight loop. `StringWriter`'s backing `StringBuffer` pays a monitor enter/exit on every `write`/`append` call, which on a typical deepJoin walk over a deeply nested array can be hundreds of thousands of synchronized writes — wasted overhead in single-threaded jsonnet evaluation.

`TomlRenderer` and `FastMaterializeJsonRenderer` already use the unsynchronized package-private `StringBuilderWriter` for the same reason (#874, #875). `std.deepJoin` was explicitly left as a follow-up in #875's description (*"std.deepJoin keeps StringWriter (separate concern)"*) — this PR is that follow-up.

## Modification

Single change in `ManifestModule.scala`: swap the `new StringWriter()` in `DeepJoin.evalRhs` for `new StringBuilderWriter()`. No other code changes; output is byte-identical.

## Result

Scala Native, hyperfine A/B against `master` (`fc292fa6`). Workload: a 50,000-row array of 10 pre-allocated strings → 2 MB of `deepJoin` output, render-dominated. Four interleaved-order passes, `--warmup 10 --min-runs 100 --shell=none`:

| pass | order | before mean | after mean | before min | after min | **min ratio** |
|---|---|---:|---:|---:|---:|---:|
| 1 | before → after | 35.1 ± 16.5 ms | 32.2 ± 19.1 ms | 23.1 ms | 18.7 ms | **1.24×** |
| 2 | after → before | 43.7 ± 30.6 ms | 29.9 ± 25.3 ms | 25.7 ms | 20.3 ms | **1.27×** |
| 3 | before → after | 30.3 ±  8.5 ms | 29.5 ±  7.1 ms | 24.6 ms | 20.8 ms | **1.18×** |
| 4 | after → before | 32.6 ±  7.6 ms | 28.0 ±  6.8 ms | 24.0 ms | 20.7 ms | **1.16×** |

After is faster in every one of the 4 passes; mean is noisy on the host but min values are tight at **1.16–1.27× faster** (best observed 18.7 vs 23.1 ms, ~19% reduction). Output byte-identical (2,000,000 bytes both sides).

## Test plan

- [x] `./mill __.reformat`
- [x] `./mill 'sjsonnet.jvm[3.3.7]'.test` — 519/519 pass
- [x] Scala Native A/B hyperfine — 4 interleaved-order passes, all positive; output byte-identical

---

> Independent of #875; can land in either order. After both land, the `import java.io.StringWriter` in `ManifestModule.scala` can be removed in a small cleanup.
