### PR TITLE
perf: use StringBuilderWriter across renderers and stdlib escape paths

### DIFF
--- a/bench/src/sjsonnet/bench/MaterializerBenchmark.scala
+++ b/bench/src/sjsonnet/bench/MaterializerBenchmark.scala
@@ -5,7 +5,7 @@ import org.openjdk.jmh.infra.*
 import sjsonnet.*
 import ujson.JsVisitor
 
-import java.io.{StringWriter, Writer}
+import java.io.Writer
 import java.util.concurrent.TimeUnit
 
 @BenchmarkMode(Array(Mode.AverageTime))
@@ -59,8 +59,8 @@ class MaterializerBenchmark {
     new PrettyYamlRenderer(_, indent = 3, getCurrentPosition = () => null)
   )
 
-  private def renderWith[T <: Writer](r: StringWriter => JsVisitor[T, T]): String = {
-    val writer = new StringWriter
+  private def renderWith[T <: Writer](r: StringBuilderWriter => JsVisitor[T, T]): String = {
+    val writer = new StringBuilderWriter
     val renderer = r(writer)
     interp.materialize(value, renderer)
     writer.toString

--- a/sjsonnet/src/sjsonnet/PrettyYamlRenderer.scala
+++ b/sjsonnet/src/sjsonnet/PrettyYamlRenderer.scala
@@ -1,6 +1,6 @@
 package sjsonnet
 
-import java.io.{StringWriter, Writer}
+import java.io.Writer
 
 import upickle.core.{ArrVisitor, ObjVisitor}
 
@@ -12,7 +12,7 @@ import scala.collection.mutable
  * writes to a generic `Writer`.
  */
 class PrettyYamlRenderer(
-    out: Writer = new java.io.StringWriter(),
+    out: Writer = new StringBuilderWriter(),
     indentArrayInObject: Boolean = false,
     indent: Int,
     idealWidth: Int = 80,
@@ -78,8 +78,6 @@ class PrettyYamlRenderer(
     // Strings which look like booleans/nulls/numbers/dates/etc.,
     // or have leading/trailing spaces, are rendered single-quoted
     else if (PrettyYamlRenderer.stringNeedsToBeQuoted(str)) {
-      val strWriter = new StringWriter
-      BaseRenderer.escape(strWriter, s, unicode = true)
       val quotedStr = "'" + str.replace("'", "''") + "'"
       PrettyYamlRenderer.writeWrappedString(
         quotedStr,

--- a/sjsonnet/src/sjsonnet/Renderer.scala
+++ b/sjsonnet/src/sjsonnet/Renderer.scala
@@ -7,6 +7,13 @@ import upickle.core.{ArrVisitor, ObjVisitor}
 final class StringBuilderWriter(initialCapacity: Int = 16) extends Writer {
   private[this] val builder = new java.lang.StringBuilder(initialCapacity)
 
+  /**
+   * Exposes the underlying [[java.lang.StringBuilder]] for callers that need direct
+   * length/charAt/setLength operations (e.g. [[YamlRenderer]] trims trailing spaces).
+   * Single-threaded use only; the writer is not thread-safe.
+   */
+  def getBuilder: java.lang.StringBuilder = builder
+
   override def write(c: Int): Unit =
     builder.append(c.toChar)
 
@@ -45,7 +52,7 @@ final class StringBuilderWriter(initialCapacity: Int = 16) extends Writer {
  *   - Custom printing of Doubles
  *   - Custom printing of empty dictionaries and arrays
  */
-class Renderer(out: Writer = new java.io.StringWriter(), indent: Int = -1)
+class Renderer(out: Writer = new StringBuilderWriter(), indent: Int = -1)
     extends BaseCharRenderer(out, indent) {
   var newlineBuffered = false
   override def visitFloat64(d: Double, index: Int): Writer = {
@@ -153,7 +160,7 @@ class Renderer(out: Writer = new java.io.StringWriter(), indent: Int = -1)
   }
 }
 
-class PythonRenderer(out: Writer = new java.io.StringWriter(), indent: Int = -1)
+class PythonRenderer(out: Writer = new StringBuilderWriter(), indent: Int = -1)
     extends BaseCharRenderer(out, indent) {
 
   override def visitNull(index: Int): Writer = {

--- a/sjsonnet/src/sjsonnet/YamlRenderer.scala
+++ b/sjsonnet/src/sjsonnet/YamlRenderer.scala
@@ -1,10 +1,9 @@
 package sjsonnet
 
-import java.io.StringWriter
 import upickle.core.{ArrVisitor, ObjVisitor, SimpleVisitor, Visitor}
 
 class YamlRenderer(
-    _out: StringWriter = new java.io.StringWriter(),
+    _out: StringBuilderWriter = new StringBuilderWriter(),
     indentArrayInObject: Boolean = false,
     quoteKeys: Boolean = true,
     indent: Int = 2)
@@ -13,11 +12,11 @@ class YamlRenderer(
   var dashBuffered = false
   var afterKey = false
   private var topLevel = true
-  private val outBuffer = _out.getBuffer
+  private val outBuffer = _out.getBuilder
 
-  private val yamlKeyVisitor = new SimpleVisitor[StringWriter, StringWriter]() {
+  private val yamlKeyVisitor = new SimpleVisitor[StringBuilderWriter, StringBuilderWriter]() {
     override def expectedMsg = "Expected a string key"
-    override def visitString(s: CharSequence, index: Int): StringWriter = {
+    override def visitString(s: CharSequence, index: Int): StringBuilderWriter = {
       YamlRenderer.this.flushBuffer()
       if (quoteKeys || !YamlRenderer.isSafeBareKey(s.toString)) {
         upickle.core.RenderUtils.escapeChar(
@@ -39,7 +38,7 @@ class YamlRenderer(
     elemBuilder.writeOutToIfLongerThan(_out, if (depth <= 0 || topLevel) 0 else 1000)
   }
 
-  override def visitString(s: CharSequence, index: Int): StringWriter = {
+  override def visitString(s: CharSequence, index: Int): StringBuilderWriter = {
     flushBuffer()
     val len = s.length()
     if (len == 0) {
@@ -69,7 +68,7 @@ class YamlRenderer(
     _out
   }
 
-  override def visitFloat64(d: Double, index: Int): StringWriter = {
+  override def visitFloat64(d: Double, index: Int): StringBuilderWriter = {
     flushBuffer()
     appendString(RenderUtils.renderDouble(d))
     flushCharBuilder()
@@ -99,8 +98,10 @@ class YamlRenderer(
     dashBuffered = false
   }
 
-  override def visitArray(length: Int, index: Int): ArrVisitor[StringWriter, StringWriter] =
-    new ArrVisitor[StringWriter, StringWriter] {
+  override def visitArray(
+      length: Int,
+      index: Int): ArrVisitor[StringBuilderWriter, StringBuilderWriter] =
+    new ArrVisitor[StringBuilderWriter, StringBuilderWriter] {
       var empty = true
       flushBuffer()
 
@@ -115,14 +116,14 @@ class YamlRenderer(
       if (dedentInObject) depth -= 1
       dashBuffered = true
 
-      def subVisitor: Visitor[StringWriter, StringWriter] = YamlRenderer.this
-      def visitValue(v: StringWriter, index: Int): Unit = {
+      def subVisitor: Visitor[StringBuilderWriter, StringBuilderWriter] = YamlRenderer.this
+      def visitValue(v: StringBuilderWriter, index: Int): Unit = {
         empty = false
         flushBuffer()
         newlineBuffered = true
         dashBuffered = true
       }
-      def visitEnd(index: Int): StringWriter = {
+      def visitEnd(index: Int): StringBuilderWriter = {
         if (!dedentInObject) depth -= 1
         if (empty) {
           elemBuilder.ensureLength(2)
@@ -136,8 +137,10 @@ class YamlRenderer(
       }
     }
 
-  override def visitObject(length: Int, index: Int): ObjVisitor[StringWriter, StringWriter] =
-    new ObjVisitor[StringWriter, StringWriter] {
+  override def visitObject(
+      length: Int,
+      index: Int): ObjVisitor[StringBuilderWriter, StringBuilderWriter] =
+    new ObjVisitor[StringBuilderWriter, StringBuilderWriter] {
       var empty = true
       flushBuffer()
       if (!topLevel) depth += 1
@@ -145,9 +148,9 @@ class YamlRenderer(
 
       if (afterKey) newlineBuffered = true
 
-      def subVisitor: Visitor[StringWriter, StringWriter] = YamlRenderer.this
+      def subVisitor: Visitor[StringBuilderWriter, StringBuilderWriter] = YamlRenderer.this
 
-      def visitKey(index: Int): Visitor[StringWriter, StringWriter] = yamlKeyVisitor
+      def visitKey(index: Int): Visitor[StringBuilderWriter, StringBuilderWriter] = yamlKeyVisitor
 
       def visitKeyValue(s: Any): Unit = {
         empty = false
@@ -160,12 +163,12 @@ class YamlRenderer(
         newlineBuffered = false
       }
 
-      def visitValue(v: StringWriter, index: Int): Unit = {
+      def visitValue(v: StringBuilderWriter, index: Int): Unit = {
         newlineBuffered = true
         afterKey = false
       }
 
-      def visitEnd(index: Int): StringWriter = {
+      def visitEnd(index: Int): StringBuilderWriter = {
         if (empty) {
           elemBuilder.ensureLength(2)
           elemBuilder.append('{')

--- a/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
@@ -1355,7 +1355,7 @@ object StringModule extends AbstractFunctionModule {
      */
     builtin("escapeStringXML", "str") { (_, ev, str: Val) =>
       val string = stdToString(str)(ev)
-      val out = new java.io.StringWriter()
+      val out = new StringBuilderWriter(string.length + 16)
       var i = 0
       while (i < string.length) {
         string.charAt(i) match {

--- a/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
@@ -1320,12 +1320,16 @@ object StringModule extends AbstractFunctionModule {
      * quotes, escapes backslashes, and escapes unprintable characters.
      */
     builtin("escapeStringJson", "str_") { (pos, ev, str: Val) =>
-      if (str.value.isInstanceOf[Val.Str]) {
-        Materializer.stringify(str)(ev)
-      } else {
-        val out = new java.io.StringWriter()
-        BaseRenderer.escape(out, Materializer.stringify(str)(ev), unicode = true)
-        out.toString
+      val v = str.value
+      v match {
+        case s: Val.Str =>
+          val out = new StringBuilderWriter(s.str.length + 16)
+          BaseRenderer.escape(out, s.str, unicode = true)
+          out.toString
+        case _ =>
+          val out = new StringBuilderWriter(64)
+          BaseRenderer.escape(out, Materializer.stringify(v)(ev), unicode = true)
+          out.toString
       }
     },
     /**
@@ -1336,8 +1340,9 @@ object StringModule extends AbstractFunctionModule {
      * Convert str to allow it to be embedded in Python. This is an alias for std.escapeStringJson.
      */
     builtin("escapeStringPython", "str") { (pos, ev, str: Val) =>
-      val out = new java.io.StringWriter()
-      BaseRenderer.escape(out, stdToString(str)(ev), unicode = true)
+      val s = stdToString(str)(ev)
+      val out = new StringBuilderWriter(s.length + 16)
+      BaseRenderer.escape(out, s, unicode = true)
       out.toString
     },
     /**


### PR DESCRIPTION
## Motivation

Continues the synchronous `java.io.StringWriter` elimination started by PRs #875 (TomlRenderer) and #889 (`std.deepJoin`). Each `StringWriter` write goes through `StringBuffer`'s `synchronized` monitor — pure overhead for the single-threaded code paths every renderer takes.

This PR landed in two parts:
1. The original commit covers `std.escapeStringJson` / `std.escapeStringPython`.
2. A follow-up commit extends the same `StringBuilderWriter` substitution across the remaining stdlib escape path (`std.escapeStringXML`), the YAML / PrettyYAML / Python / JSON renderers, and `Renderer` / `PythonRenderer` default `out` parameters (which transitively benefit `Val.Obj.renderString`, `Format.scala`'s `%r` complex-type path, etc.).

## Modification

### Part 1: stdlib escape entry points

- `std.escapeStringJson`: for `Val.Str` input, call `BaseRenderer.escape` directly with a `StringBuilderWriter`, bypassing `Materializer.stringify` dispatch, `Renderer` allocation, and `CharBuilder` allocation. For non-string input, use `StringBuilderWriter` instead of `java.io.StringWriter`.
- `std.escapeStringPython`: same `StringBuilderWriter` substitution.

### Part 2: rest of the renderer surface

- `std.escapeStringXML`: replace internal `StringWriter` with a pre-sized `StringBuilderWriter`.
- `Renderer` / `PythonRenderer`: default `out` parameter changes from `java.io.StringWriter` to `StringBuilderWriter`. Call sites that rely on the default (`Val.Obj.renderString` in `Val.scala`, `Format.scala`'s complex-type `%r` path) inherit the optimization with no signature change.
- `YamlRenderer`: full visitor type-parameter migration from `StringWriter` to `StringBuilderWriter`; `outBuffer` switches from `StringBuffer` to `StringBuilder` (same `length` / `setLength` / `charAt` interface). `StringBuilderWriter` gains a small `getBuilder` accessor so `YamlRenderer`'s trailing-space trim can still reach into the buffer.
- `PrettyYamlRenderer`: default `out` parameter to `StringBuilderWriter`. Also drops a dead `StringWriter` allocation in the quoted-string branch — the writer's result was never consumed (`quotedStr` is used instead).
- `bench`: `MaterializerBenchmark.renderWith` updated to construct a `StringBuilderWriter` to match the new constructor signatures.

## Result

- Eliminates `StringBuffer` monitor acquisition on every char / string write across all remaining renderers (YAML / PrettyYAML / Python / default-JSON) and all three `std.escapeString*` entry points.
- Removes one dead `StringWriter` allocation per quoted-string in `PrettyYamlRenderer`.

### Benchmarks (Scala Native, Apple M3 Pro)

`std.escapeStringJson` micro-benchmark via hyperfine:

| Benchmark | Before (ms) | After (ms) | jrsonnet (ms) | Gap |
|---|---:|---:|---:|---:|
| std.escapeStringJson | 7.0 ± 3.1 | 6.9 ± 0.7 | 4.6 ± 1.6 | 1.48× |

### Tests

- All 465 native tests + 48 JVM tests pass.