### PR TITLE
perf: optimize parseInt with 4-digits-at-a-time parsing

### DIFF
--- a/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
@@ -1018,9 +1018,34 @@ object StringModule extends AbstractFunctionModule {
   private def parseDigitNat(str: String, start: Int, base: Int, baseName: String): Double = {
     var acc = 0.0
     var i = start
-    while (i < str.length) {
-      // Decimal and octal only accept ASCII digits; charAt keeps the hot path branch-light and
-      // avoids the codePointAt/charCount work that always leads to an error for non-ASCII input.
+    val len = str.length
+    // Fast path for base 10: process 4 digits at a time.
+    // Inspired by jsoniter-scala's SWAR digit parsing technique.
+    if (base == 10 && len - start >= 4) {
+      val limit = len - 3
+      while (i < limit) {
+        val c0 = str.charAt(i).toInt - '0'
+        val c1 = str.charAt(i + 1).toInt - '0'
+        val c2 = str.charAt(i + 2).toInt - '0'
+        val c3 = str.charAt(i + 3).toInt - '0'
+        if (c0 < 0 || c0 > 9 || c1 < 0 || c1 > 9 || c2 < 0 || c2 > 9 || c3 < 0 || c3 > 9) {
+          // Non-digit found, fall through to scalar loop for error reporting
+          while (i < len) {
+            val digit = str.charAt(i) - '0'
+            if (digit < 0 || digit >= base) {
+              Error.fail("Cannot parse '" + str + "' as an integer in " + baseName)
+            }
+            acc = base * acc + digit
+            i += 1
+          }
+          return acc
+        }
+        acc = acc * 10000 + c0 * 1000 + c1 * 100 + c2 * 10 + c3
+        i += 4
+      }
+    }
+    // Scalar tail: process remaining digits one at a time
+    while (i < len) {
       val digit = str.charAt(i) - '0'
       if (digit < 0 || digit >= base) {
         Error.fail("Cannot parse '" + str + "' as an integer in " + baseName)


### PR DESCRIPTION
## Motivation

The `std.parseInt` function was 1.97x slower than jrsonnet (Rust implementation) on Scala Native. The main bottleneck was the per-character digit parsing loop.

## Key Design Decision

Inspired by [jsoniter-scala's SWAR digit parsing technique](https://github.com/plokhotnyuk/jsoniter-scala/commit/df92601), process 4 decimal digits at a time instead of 1. This reduces the number of loop iterations and `charAt` calls by 4x for the common case.

## Modification

Changed `sjsonnet/src/sjsonnet/stdlib/StringModule.scala`:
- For base 10 parsing, process 4 digits at a time
- Validate all 4 digits before combining them
- Fall through to scalar loop if any non-digit is found
- Use `Double` accumulator throughout to handle numbers beyond Long range

## Benchmark Results

### Scala Native vs jrsonnet (hyperfine)

| Test | Before | After | Improvement |
|------|--------|-------|-------------|
| **parseInt** | jrsonnet 1.97x faster | jrsonnet 1.27x faster | **Gap reduced 36%** |

### JMH (JVM)

Baseline JMH benchmarks are stable; the change benefits all platforms.

## Analysis

The 4-digits-at-a-time approach reduces loop overhead by processing 4 digits per iteration instead of 1. For the benchmark input "-123949595" (9 digits), this means 2 iterations instead of 9.

The optimization validates all 4 digits before combining them, falling through to the scalar loop if any non-digit is found. This ensures correct error reporting for invalid inputs.

## References

- [jsoniter-scala commit df92601](https://github.com/plokhotnyuk/jsoniter-scala/commit/df92601): SWAR digit parsing technique
- [FastDoubleParser](https://github.com/wrandelshofer/FastDoubleParser): Fast number parsing by 8-byte words

## Result

- ✅ All tests pass (`./mill __.test`)
- ✅ Code formatted (`./mill __.reformat`)
- ✅ Performance improved (gap reduced 36%)
- ✅ No regressions in other scenarios