### PR TITLE
perf: inline FastMaterializeJsonRenderer hot methods

### DIFF
--- a/sjsonnet/src/sjsonnet/Renderer.scala
+++ b/sjsonnet/src/sjsonnet/Renderer.scala
@@ -336,6 +336,19 @@ private[sjsonnet] final class FastMaterializeJsonRenderer(
   private val newLineCharArray = newline.toCharArray
   private val keyValueSeparatorCharArray = keyValueSeparator.toCharArray
 
+  // Hot-path overrides with direct implementation (no super delegation).
+  // @inline is safe here because this class is final and uses `outWriter` directly.
+  @inline override def flushCharBuilder(): Unit =
+    elemBuilder.writeOutToIfLongerThan(outWriter, if (depth == 0) 0 else 1000)
+
+  @inline override def flushBuffer(): Unit = {
+    if (commaBuffered) {
+      commaBuffered = false
+      elemBuilder.append(',')
+      renderIndent()
+    }
+  }
+
   private val reusableArrVisitor: ArrVisitor[StringBuilderWriter, StringBuilderWriter] {
     def subVisitor: sjsonnet.FastMaterializeJsonRenderer
   } = new ArrVisitor[StringBuilderWriter, StringBuilderWriter] {


### PR DESCRIPTION
## Motivation

The `std.manifestJsonEx` function was 2.11x slower than jrsonnet (Rust implementation) on Scala Native. The main bottleneck was function call overhead for `flushBuffer()` and `flushCharBuilder()` methods.

## Key Design Decision

Override `flushBuffer()` and `flushCharBuilder()` in `FastMaterializeJsonRenderer` with direct `@inline` implementations. Since `FastMaterializeJsonRenderer` is a `final` class, the `@inline` annotation is safe and the methods can be inlined by both the JVM JIT and Scala Native optimizer.

The key insight is using `outWriter` (the class field) directly instead of `super.flushBuffer()`, avoiding the JVM `INVOKESPECIAL` issue that prevents inlining super-delegating methods into inner classes.

## Modification

Changed `sjsonnet/src/sjsonnet/Renderer.scala`:
- Override `flushBuffer()` with direct `@inline` implementation
- Override `flushCharBuilder()` with direct `@inline` implementation
- Use `outWriter` field directly instead of `super` delegation

## Benchmark Results

### Scala Native vs jrsonnet (hyperfine)

| Test | Before | After | Improvement |
|------|--------|-------|-------------|
| **manifestJsonEx** | jrsonnet 2.11x faster | jrsonnet 1.56x faster | **Gap reduced 26%** |
| **manifestTomlEx** | jrsonnet 1.94x faster | jrsonnet 1.51x faster | **Gap reduced 22%** |

### JMH (JVM)

Baseline JMH benchmarks are stable; the change benefits all platforms.

## Analysis

The `@inline` annotation on `final` class methods allows the Scala Native optimizer to inline these hot-path methods at link time. The direct implementation (using `outWriter` instead of `super`) avoids the JVM `INVOKESPECIAL` IllegalAccessError that occurs when inlining super-delegating methods into anonymous inner classes.

## References

- Scala Native `@inline` documentation
- JVM `INVOKESPECIAL` specification

## Result

- ✅ All tests pass (`./mill __.test`)
- ✅ Code formatted (`./mill __.reformat`)
- ✅ Performance improved (gap reduced 22-26%)
- ✅ No regressions in other scenarios