### PR TITLE
perf: numeric fast path for std.member array search

### DIFF
--- a/sjsonnet/src/sjsonnet/stdlib/ArrayModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/ArrayModule.scala
@@ -571,13 +571,29 @@ object ArrayModule extends AbstractFunctionModule {
             }
             str.str.contains(secondArg)
           case a: Val.Arr =>
-            var i = 0
-            var found = false
-            while (i < a.length && !found) {
-              if (ev.equal(a.value(i), x.value)) found = true
-              i += 1
+            val xVal = x.value
+            xVal match {
+              case xNum: Val.Num =>
+                val target = xNum.asDouble
+                var i = 0
+                var found = false
+                while (i < a.length && !found) {
+                  a.value(i) match {
+                    case n: Val.Num => if (n.asDouble == target) found = true
+                    case _          =>
+                  }
+                  i += 1
+                }
+                found
+              case _ =>
+                var i = 0
+                var found = false
+                while (i < a.length && !found) {
+                  if (ev.equal(a.value(i), xVal)) found = true
+                  i += 1
+                }
+                found
             }
-            found
           case arr =>
             Error.fail(
               "std.member first argument must be an array or a string, got " + arr.prettyName


### PR DESCRIPTION
## Motivation

`std.member` on arrays uses `ev.equal()` for every element comparison, which involves virtual dispatch and two pattern matches per element. For numeric arrays (common in Jsonnet — ASCII code arrays, index lists), this overhead is unnecessary since `Val.Num` equality is a simple double comparison.

## Modification

When the search value is `Val.Num`, extract the double once and use direct `asDouble == target` comparison in the loop, bypassing `ev.equal()` entirely. Non-numeric elements are correctly skipped (a number can never equal a non-number). The generic `ev.equal()` path is retained for non-numeric search values.

## Result

**Native A/B** (Scala Native 0.5.12, hyperfine --warmup 10 --min-runs 30):

| Benchmark | Baseline | PR | jrsonnet | Delta |
|-----------|:---:|:---:|:---:|:---:|
| member | 6.7 ms | 6.8 ms | 3.9 ms | +0.4% (noise) |

The benchmark is startup-dominated (internal compute ~1.6ms out of 6.7ms total). On JVM, the JIT already specializes the pattern match, so the improvement is negligible. On Native, the virtual dispatch savings are real but masked by startup overhead in this micro-benchmark. The optimization benefits longer-running workloads where `std.member` is called in loops.

## References

- Tracked in #666 (performance optimization)