### PR TITLE
fix: correct std.atan2 parameter names to match spec

### DIFF
--- a/sjsonnet/src/sjsonnet/stdlib/MathModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/MathModule.scala
@@ -448,8 +448,8 @@ object MathModule extends AbstractFunctionModule {
      *
      * The official docs list std.atan2(y, x) as a mathematical function.
      */
-    builtin("atan2", "x", "y") { (pos, ev, x: Double, y: Double) =>
-      math.atan2(x, y)
+    builtin("atan2", "y", "x") { (pos, ev, y: Double, x: Double) =>
+      math.atan2(y, x)
     },
     /**
      * [[https://jsonnet.org/ref/stdlib.html#math std.hypot(a, b)]].

--- a/sjsonnet/test/src/sjsonnet/StdMathTests.scala
+++ b/sjsonnet/test/src/sjsonnet/StdMathTests.scala
@@ -8,5 +8,9 @@ object StdMathTests extends TestSuite {
     test("sign normalizes negative zero") {
       eval("""std.atan2(std.sign(-0), -1)""") ==> ujson.Num(math.Pi)
     }
+    test("atan2 named parameters") {
+      eval("""std.atan2(y=1, x=0)""") ==> ujson.Num(math.Pi / 2)
+      eval("""std.atan2(y=0, x=1)""") ==> ujson.Num(0.0)
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Fix `std.atan2` parameter names from `("x", "y")` to `("y", "x")` matching the Jsonnet spec `std.atan2(y, x)`
- Named argument calls like `std.atan2(y=1, x=0)` now produce correct results

std.atan2(y, x) (available since 0.21.0)

## Verification against go-jsonnet
```
$ echo 'std.atan2(y=1, x=0)' | jsonnet -
1.5707963267948966

$ echo 'std.atan2(y=0, x=1)' | jsonnet -
0
```
sjsonnet now produces identical results.

## Test plan
- [x] Added `StdMathTests.atan2 named parameters` test
- [x] Verified positional call behavior unchanged
- [x] Cross-checked with go-jsonnet binary