### PR TITLE
fix: unify assertion message handling in objects

### DIFF
--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -1720,7 +1720,7 @@ class Evaluator(
             case null => Error.fail("Assertion failed", a.value.pos)
             case msg  =>
               Error.fail(
-                "Assertion failed: " + visitExpr(msg)(newScope).cast[Val.Str].str,
+                "Assertion failed: " + materializeError(visitExpr(msg)(newScope)),
                 a.value.pos
               )
           }

--- a/sjsonnet/test/resources/new_test_suite/error.object_assert_non_string_msg.jsonnet
+++ b/sjsonnet/test/resources/new_test_suite/error.object_assert_non_string_msg.jsonnet
@@ -1,0 +1,2 @@
+local obj = { assert false : 42, x: 1 };
+obj.x

--- a/sjsonnet/test/resources/new_test_suite/error.object_assert_non_string_msg.jsonnet.golden
+++ b/sjsonnet/test/resources/new_test_suite/error.object_assert_non_string_msg.jsonnet.golden
@@ -1,0 +1,1 @@
+sjsonnet.Error: Assertion failed: 42


### PR DESCRIPTION
## Summary
- Object assertions used `.cast[Val.Str].str` for the message, producing a confusing "Expected string, found number" error when the assertion message is not a string (e.g., `assert false : 42`)
- Top-level assertions already used `materializeError` which produces the helpful "Assertion failed: 42"
- This fix makes object assertions consistent with top-level assertions

## Verification against go-jsonnet
```
$ echo 'local obj = { assert false : 42, x: 1 }; obj.x' | jsonnet -
RUNTIME ERROR: 42
```
go-jsonnet uses "RUNTIME ERROR: <msg>" without "Assertion failed:" prefix. sjsonnet uses its own "Assertion failed: <msg>" convention for both top-level and object assertions. This fix ensures internal consistency within sjsonnet.

## Test plan
- [x] Added golden error test `error.object_assert_non_string_msg.jsonnet`
- [x] Full test suite passes (all 519 tests)