### PR TITLE
fix: error on super[key] when there is no superclass

### DIFF
--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -1231,10 +1231,10 @@ class Evaluator(
   // mirror `visitSelectSuper` (`super.name`) so static-key and computed-key
   // super lookups agree, matching google/jsonnet, go-jsonnet, and jrsonnet.
   def visitLookupSuper(e: LookupSuper)(implicit scope: ValScope): Val = {
-    var sup = scope.bindings(e.selfIdx + 1).asInstanceOf[Val.Obj]
+    val sup = scope.bindings(e.selfIdx + 1).asInstanceOf[Val.Obj]
     val key = visitExpr(e.index).cast[Val.Str]
     val self = scope.bindings(e.selfIdx).asInstanceOf[Val.Obj]
-    if (sup == null) sup = self
+    if (sup == null) Error.fail("Attempt to use `super` when there is no super class", e.pos)
     sup.value(key.str, e.pos, self)
   }
 


### PR DESCRIPTION
## Summary

- Fix `visitLookupSuper` (`super[key]`) to error when there is no superclass, matching the existing `visitSelectSuper` (`super.name`) behavior.

## Motivation

`visitLookupSuper` (`super[key]`) silently fell back to `self` when no superclass existed, while `visitSelectSuper` (`super.name`) correctly reported `"Attempt to use \`super\` when there is no super class"`. This inconsistency could mask bugs in Jsonnet programs and diverged from go-jsonnet and jrsonnet which both error in this case.

## Modification

Replace the silent `sup = self` fallback in `visitLookupSuper` with the same error that `visitSelectSuper` uses. Change `var sup` to `val sup` since it is no longer reassigned.

## Result

`super[key]` and `super.name` now behave identically when there is no superclass, both reporting the same error. This matches go-jsonnet and jrsonnet semantics.

## Test plan

- [x] All 143 existing test suites pass
- [x] Formatting clean