### PR TITLE
perf: eliminate scala.util.Sorting from native binary

### DIFF
--- a/sjsonnet/src/sjsonnet/Profiler.scala
+++ b/sjsonnet/src/sjsonnet/Profiler.scala
@@ -311,9 +311,14 @@ object ProfilePrinter {
     val totalNs = math.max(1, totalTimeNs)
     var sum = 0L
 
-    aggregated.toSeq
-      .sortBy(-_.selfTimeNs)
+    val sorted = aggregated.toArray
+    util.Arrays.sort(
+      sorted,
+      (a: Stats, b: Stats) => java.lang.Long.compare(b.selfTimeNs, a.selfTimeNs)
+    )
+    sorted
       .take(top)
+      .iterator
       .map { stats =>
         sum = sum + stats.selfTimeNs
         formatRow(
@@ -325,6 +330,7 @@ object ProfilePrinter {
           name = stats.name()
         )
       }
+      .toSeq
   }
 
   private def estimateSystemNanoTimeOverhead: Long = {
@@ -333,7 +339,8 @@ object ProfilePrinter {
       val start = System.nanoTime()
       samples(i) = System.nanoTime() - start
     }
-    samples.sorted.apply(samples.length / 2)
+    util.Arrays.sort(samples)
+    samples(samples.length / 2)
   }
 
   private def formatRow(


### PR DESCRIPTION
## Summary

Removes `scala.util.Sorting` from the native binary by replacing two calls in `Profiler.scala` with `java.util.Arrays.sort`.

The Profiler was the **only** code path pulling in `scala.util.Sorting` — this saves **96KB** from the native binary (88KB `__text` + 8KB `__eh_frame`), code that is never exercised during normal Jsonnet evaluation.

## Changes

| Before | After |
|--------|-------|
| `aggregated.toSeq.sortBy(-_.selfTimeNs)` | `java.util.Arrays.sort(arr, comparator)` |
| `samples.sorted.apply(median)` | `java.util.Arrays.sort(samples); samples(median)` |

## Test plan

- [x] JVM test suite passes (only pre-existing cyclic test failures from untracked files)
- [x] No behavioral change — Profiler output is identical