### PR TITLE
perf: skip redundant ASCII-safety checks in format scanner for AsciiSafeStr

### DIFF
--- a/sjsonnet/src/sjsonnet/Format.scala
+++ b/sjsonnet/src/sjsonnet/Format.scala
@@ -309,7 +309,7 @@ object Format {
    * large format strings (e.g. 605KB large_string_template with 256 interpolations), this avoids
    * the overhead of running parser combinators over hundreds of KB of literal text.
    */
-  private def scanFormat(s: String): RuntimeFormat = {
+  private def scanFormat(s: String, sourceAsciiSafe: Boolean = false): RuntimeFormat = {
     val len = s.length
     val specsBuilder = new scala.collection.mutable.ArrayBuilder.ofLong
     var labelsBuilder: java.util.ArrayList[String] = null
@@ -329,7 +329,7 @@ object Format {
     val leadingStart = 0
     val leadingEnd = if (pos < 0) len else pos
     staticChars += leadingEnd - leadingStart
-    if (allLiteralsAscii && !isAsciiJsonSafeRange(s, leadingStart, leadingEnd))
+    if (!sourceAsciiSafe && allLiteralsAscii && !isAsciiJsonSafeRange(s, leadingStart, leadingEnd))
       allLiteralsAscii = false
 
     while (pos >= 0 && pos < len) {
@@ -470,7 +470,7 @@ object Format {
       litStartsBuilder += litStart
       litEndsBuilder += litEnd
       staticChars += litEnd - litStart
-      if (allLiteralsAscii && !isAsciiJsonSafeRange(s, litStart, litEnd))
+      if (!sourceAsciiSafe && allLiteralsAscii && !isAsciiJsonSafeRange(s, litStart, litEnd))
         allLiteralsAscii = false
 
       pos = nextPct
@@ -1120,11 +1120,12 @@ object Format {
    * instance, bypassing [[FormatCache]] since each literal format string is unique and already
    * cached within the AST.
    */
-  class PartialApplyFmt(fmt: String) extends Val.Builtin1("format", "values") {
+  class PartialApplyFmt(fmt: String, sourceAsciiSafe: Boolean = false)
+      extends Val.Builtin1("format", "values") {
     // Pre-parse the format string at construction time (during static optimization).
     // Uses the hand-written scanner instead of fastparse for faster parsing of large format strings.
     // Each PartialApplyFmt instance caches its own parsed format, so no external cache needed.
-    private val parsed = scanFormat(fmt)
+    private val parsed = scanFormat(fmt, sourceAsciiSafe)
     def evalRhs(values0: Eval, ev: EvalScope, pos: Position): Val =
       format(parsed, values0.value, pos)(ev)
   }

--- a/sjsonnet/src/sjsonnet/StaticOptimizer.scala
+++ b/sjsonnet/src/sjsonnet/StaticOptimizer.scala
@@ -59,16 +59,22 @@ class StaticOptimizer(
         InSuper(pos, lhs, selfIdx)
       case b2 @ BinaryOp(pos, lhs: Val.Str, BinaryOp.OP_%, rhs) =>
         try {
+          val asciiSafe = lhs.isInstanceOf[Val.AsciiSafeStr]
           rhs match {
             case r: Val =>
-              val partial = new Format.PartialApplyFmt(lhs.str)
+              val partial = new Format.PartialApplyFmt(lhs.str, asciiSafe)
               try partial.evalRhs(r, ev, pos).asInstanceOf[Expr]
               catch {
                 case _: Exception =>
                   ApplyBuiltin1(pos, partial, rhs, tailstrict = false)
               }
             case _ =>
-              ApplyBuiltin1(pos, new Format.PartialApplyFmt(lhs.str), rhs, tailstrict = false)
+              ApplyBuiltin1(
+                pos,
+                new Format.PartialApplyFmt(lhs.str, asciiSafe),
+                rhs,
+                tailstrict = false
+              )
           }
         } catch { case _: Exception => b2 }
 


### PR DESCRIPTION
## Summary
- Add `sourceAsciiSafe` parameter to `scanFormat` to short-circuit redundant `isAsciiJsonSafeRange` checks when the source string is already known to be ASCII-safe
- Propagate the flag through `PartialApplyFmt` so `StaticOptimizer` passes it when the LHS of `%` is a `Val.AsciiSafeStr`
- Only 2 files changed, 14 insertions, 7 deletions — minimal, focused change

## JMH Benchmark Results

| Benchmark | Master | This PR | Delta |
|---|---|---|---|
| `repeat_format.jsonnet` | 0.244 ms/op | 0.168 ms/op | **-31%** |
| `large_string_template.jsonnet` | 1.352 ms/op | 1.299 ms/op | **-4%** |
| `realistic1.jsonnet` | 2.122 ms/op | 2.149 ms/op | ~noise |
| `realistic2.jsonnet` | 50.520 ms/op | 52.377 ms/op | ~noise |

## Test plan
- [x] `mill sjsonnet.jvm.2_13_18.test` — all pass (go_test_suite failure is pre-existing on master)
- [x] `mill __.reformat` — scalafmt clean
- [ ] CI green

