### PR TITLE
fix: object equality should ignore hidden fields

### DIFF
--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -2133,7 +2133,7 @@ class Evaluator(
           var i = 0
           while (i < k1len) {
             val k = k1(i)
-            if (!y.containsKey(k)) return false
+            if (!y.containsVisibleKey(k)) return false
             val v1 = x.value(k, emptyMaterializeFileScopePos)
             val v2 = y.value(k, emptyMaterializeFileScopePos)
             if (!equal(v1, v2)) return false

--- a/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
+++ b/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
@@ -430,6 +430,19 @@ object EvaluatorTests extends TestSuite {
         """("%(hello)s" % {hello::"world", bad:: error "lol"})"""
       ) ==> ujson.Str("world")
     }
+    test("objectEqualityIgnoresHiddenFields") {
+      // Hidden field in y should not be matched during equality comparison.
+      // C++ jsonnet and jrsonnet both return false here.
+      eval("{a: 1} == {a:: 1, b: 2}") ==> ujson.False
+      // Different visible key counts: x has {a, b}, y has only {a} visible.
+      eval("{a: 1, b: 2} == {a: 1, b:: 2}") ==> ujson.False
+      // x has no visible keys, y has {a} visible.
+      eval("{a:: 1} == {a: 1}") ==> ujson.False
+      // Hidden field in y does not affect equality when visible keys match.
+      eval("{a: 1} == {a: 1, b:: 2}") ==> ujson.True
+      // Both sides have the same visible key with same value; hidden fields ignored.
+      eval("{a: 1, b:: 3} == {a: 1, c:: 4}") ==> ujson.True
+    }
     test("evaluator2") {
       eval(
         """{local x = 1, [x]: x, for x in ["foo"]}.foo"""


### PR DESCRIPTION
## Motivation

Object equality (`==`) should only compare **visible** fields. When object `y` contains hidden fields (`::`), sjsonnet used `containsKey` (which matches all fields including hidden ones), causing hidden fields to incorrectly participate in equality checks.

Comparison across four implementations:

```
Test: {a: 1} == {a:: 1, b: 2}

C++ jsonnet:       false  ✓
go-jsonnet:        false  ✓
jrsonnet:          false  ✓
sjsonnet (before): true   ✗ — hidden field 'a' matched via containsKey
```

## Modification

One-line change in `Evaluator.scala:2136`: `containsKey` → `containsVisibleKey`

```diff
-  if (!y.containsKey(k)) return false
+  if (!y.containsVisibleKey(k)) return false
```

## Result

All implementations now agree:

```jsonnet
{
  case1: {a: 1} == {a:: 1, b: 2},       // expected: false
  case2: {a: 1, b: 2} == {a: 1, b:: 2}, // expected: false (different visible key counts)
  case3: {a:: 1} == {a: 1},             // expected: false
  case4: {a: 1} == {a: 1, b:: 2},       // expected: true
}
```

| Case | C++ jsonnet | go-jsonnet | jrsonnet | sjsonnet (before) | sjsonnet (after) |
|------|-------------|------------|----------|-------------------|------------------|
| `{a: 1} == {a:: 1, b: 2}` | `false` | `false` | `false` | **`true`** ✗ | `false` ✓ |
| `{a: 1, b: 2} == {a: 1, b:: 2}` | `false` | `false` | `false` | `false` ✓ | `false` ✓ |
| `{a:: 1} == {a: 1}` | `false` | `false` | `false` | `false` ✓ | `false` ✓ |
| `{a: 1} == {a: 1, b:: 2}` | `true` | `true` | `true` | `true` ✓ | `true` ✓ |

All existing tests pass (32 unit + 76 evaluator tests), zero regressions.

## References

- C++ jsonnet `rawEquals`: uses `objectFields(obj, withoutHidden)` for equality comparison
- go-jsonnet `builtins.go:827-918`: same approach with `objectFields(obj, withoutHidden)`