### PR TITLE
fix: correct scientific notation rounding in std.format %e

### DIFF
--- a/sjsonnet/src/sjsonnet/DecimalFormat.scala
+++ b/sjsonnet/src/sjsonnet/DecimalFormat.scala
@@ -7,33 +7,11 @@ package sjsonnet
  */
 object DecimalFormat {
 
-  private def trailingZeroes(n: Long): Int = {
-    var count = 0
-    var current = n
-    var done = false
-    while (!done && current > 0) {
-      if (current % 10 == 0) count += 1
-      else done = true
-      current /= 10
-    }
-    count
-  }
-
   private def leftPad(n: Long, targetWidth: Int): String = {
     val sign = if (n < 0) "-" else ""
     val absN = math.abs(n)
     val nWidth = if (absN == 0) 1 else Math.log10(absN.toDouble).toInt + 1
     sign + Platform.repeatString("0", targetWidth - nWidth) + absN
-  }
-
-  private def rightPad(n0: Long, minWidth: Int, maxWidth: Int): String = {
-    if (n0 == 0 && minWidth == 0) ""
-    else {
-      val n = (n0 / Math.pow(10, trailingZeroes(n0))).toInt
-      assert(n == math.abs(n))
-      val nWidth = if (n == 0) 1 else Math.log10(n).toInt + 1
-      ("" + n + Platform.repeatString("0", minWidth - nWidth)).take(maxWidth)
-    }
   }
 
   def format(
@@ -46,25 +24,37 @@ object DecimalFormat {
       case Some(expLength) =>
         val expNum =
           if (number == 0.0) 0L else Math.floor(Math.log10(math.abs(number))).toLong
-        val scaled = number / math.pow(10, expNum.toDouble)
-        val prefix = scaled.toLong.toString
+        val precision = zeroes + hashes
+        // Scale so mantissa * 10^precision becomes a roundable integer
+        val divided = number / Math.pow(10, (expNum - precision).toDouble)
+        val rounded = Math.round(divided)
+        val tenPowPrec = Math.pow(10, precision).toLong
+        val intPart = rounded / tenPowPrec
+        val fracNum = math.abs(rounded % tenPowPrec)
+        val prefix = intPart.toString
         val expSign = if (expNum >= 0) "+" else ""
         val expFrag = expSign + leftPad(expNum, expLength)
-        val precision = zeroes + hashes
+        // Left-pad fractional digits with zeros to exact precision width
+        val fracDigits = leftPad(fracNum, precision)
 
         (precision, alternate) match {
           case (0, false) => prefix + "E" + expFrag
           case (0, true)  => prefix + ".E" + expFrag
           case (_, _)     =>
-            val divided = number / Math.pow(10, (expNum - precision).toDouble)
-            val scaledFrac = divided % Math.pow(10, precision)
-            val frac = rightPad(Math.abs(Math.round(scaledFrac)), zeroes, precision)
-            if (frac.isEmpty) {
-              prefix + "E" + expFrag
-            } else {
-              prefix + "." + frac + "E" + expFrag
-            }
-
+            // Strip trailing zeros only for '#' (hash) positions, not '0' positions
+            val stripped =
+              if (hashes == 0) fracDigits
+              else {
+                var end = fracDigits.length
+                var hashesLeft = hashes
+                while (end > 0 && hashesLeft > 0 && fracDigits.charAt(end - 1) == '0') {
+                  end -= 1
+                  hashesLeft -= 1
+                }
+                fracDigits.substring(0, end)
+              }
+            if (stripped.isEmpty) prefix + "E" + expFrag
+            else prefix + "." + stripped + "E" + expFrag
         }
 
       case None =>

--- a/sjsonnet/test/resources/new_test_suite/format_scientific_notation.jsonnet
+++ b/sjsonnet/test/resources/new_test_suite/format_scientific_notation.jsonnet
@@ -1,9 +1,30 @@
-// Regression test: scientific notation for exact powers of 10 and numbers < 1
-// Previously produced wrong output like "10.000000e+-04" for 0.001
-std.assertEqual(std.format("%e", 0.001), "1.000000e-03") &&
-std.assertEqual(std.format("%e", 1.0), "1.000000e+00") &&
-std.assertEqual(std.format("%e", 100.0), "1.000000e+02") &&
-std.assertEqual(std.format("%e", 0.1), "1.000000e-01") &&
-std.assertEqual(std.format("%E", 1234.5), "1.234500E+03") &&
-std.assertEqual(std.format("%e", 0), "0.000000e+00") &&
-true
+// Directional tests for std.format scientific notation (%e).
+// Verifies correct rounding and high-precision formatting against go-jsonnet.
+
+// Basic scientific notation
+local b1 = std.assertEqual(std.format("%e", 0.001), "1.000000e-03");
+local b2 = std.assertEqual(std.format("%e", 1.0), "1.000000e+00");
+local b3 = std.assertEqual(std.format("%e", 100.0), "1.000000e+02");
+local b4 = std.assertEqual(std.format("%e", 0.1), "1.000000e-01");
+local b5 = std.assertEqual(std.format("%E", 1234.5), "1.234500E+03");
+local b6 = std.assertEqual(std.format("%e", 0), "0.000000e+00");
+
+// Rounding cases (previously truncated instead of rounding)
+local r1 = std.assertEqual("%.0e" % 1.5e10, "2e+10");
+local r2 = std.assertEqual("%.0e" % 2.5e10, "3e+10");
+local r3 = std.assertEqual("%.0e" % 9.5e10, "10e+10");
+local r4 = std.assertEqual("%.1e" % 1.55e10, "1.6e+10");
+local r5 = std.assertEqual("%.0e" % 1.4e10, "1e+10");
+local r6 = std.assertEqual("%.0e" % 1.6e10, "2e+10");
+
+// Edge cases
+local e1 = std.assertEqual("%.0e" % 0, "0e+00");
+local e2 = std.assertEqual("%.2e" % 0, "0.00e+00");
+local e3 = std.assertEqual("%.0e" % (-1.5e10), "-2e+10");
+local e4 = std.assertEqual("%.10e" % 1.23456789012e10, "1.2345678901e+10");
+local e5 = std.assertEqual("%e" % 1.5e10, "1.500000e+10");
+local e6 = std.assertEqual("%.2e" % 1.5e10, "1.50e+10");
+
+b1 && b2 && b3 && b4 && b5 && b6 &&
+r1 && r2 && r3 && r4 && r5 && r6 &&
+e1 && e2 && e3 && e4 && e5 && e6


### PR DESCRIPTION
## Motivation

`std.format` with `%e` (scientific notation) truncated the mantissa instead of rounding it, and produced garbage digits for high precision values.

| Expression | Before | After (go-jsonnet) |
|-----------|--------|-------------------|
| `"%.0e" % 1.5e10` | `1e+10` | `2e+10` |
| `"%.0e" % 9.5e10` | `9e+10` | `10e+10` |
| `"%.10e" % 1.23456789012e10` | `1.2147483647e+10` | `1.2345678901e+10` |

Root cause: `scaled.toLong` truncated the mantissa (1.5 → 1), and the `rightPad` helper stripped significant trailing zeros from the fractional part.

## Modification

Rewrite scientific notation in `DecimalFormat.format`:
- Scale `number / 10^(expNum - precision)` to get an integer
- Round with `Math.round` at Long level (avoids Double precision loss)
- Split into integer part and zero-padded fractional part
- Strip trailing zeros only for `#` (hash) positions, not `0` (zero) positions
- Remove unused `rightPad` and `trailingZeroes` helpers

## Result

All `%e` format specifiers now match go-jsonnet byte-for-byte. Extended `format_scientific_notation.jsonnet` with 18 test cases covering basic notation, rounding, and edge cases. All test suites pass.

## References

- go-jsonnet uses Go's `strconv.FormatFloat` which rounds correctly
- Jsonnet `%` formatting follows Python's `%` semantics