### PR TITLE
fix: reject %c format conversion with boolean values

### DIFF
--- a/sjsonnet/src/sjsonnet/Format.scala
+++ b/sjsonnet/src/sjsonnet/Format.scala
@@ -731,8 +731,8 @@ object Format {
                 case 'G'             => formatGeneric(formatted, b)
                 case 'c'             =>
                   Error.fail("%c expected number / string, got: boolean")
-                case 's'             => widenRaw(formatted, "true")
-                case _               =>
+                case 's' => widenRaw(formatted, "true")
+                case _   =>
                   Error.fail("Format required a %s at %d, got string".format(rawVal.prettyName, i))
               }
             case _: Val.False =>
@@ -749,8 +749,8 @@ object Format {
                 case 'G'             => formatGeneric(formatted, b)
                 case 'c'             =>
                   Error.fail("%c expected number / string, got: boolean")
-                case 's'             => widenRaw(formatted, "false")
-                case _               =>
+                case 's' => widenRaw(formatted, "false")
+                case _   =>
                   Error.fail("Format required a %s at %d, got string".format(rawVal.prettyName, i))
               }
             case _: Val.Null =>

--- a/sjsonnet/src/sjsonnet/Format.scala
+++ b/sjsonnet/src/sjsonnet/Format.scala
@@ -729,7 +729,8 @@ object Format {
                 case 'f' | 'F'       => formatFloat(formatted, b)
                 case 'g'             => formatGeneric(formatted, b).toLowerCase
                 case 'G'             => formatGeneric(formatted, b)
-                case 'c'             => widenRaw(formatted, Character.forDigit(b, 10).toString)
+                case 'c'             =>
+                  Error.fail("%c expected number / string, got: boolean")
                 case 's'             => widenRaw(formatted, "true")
                 case _               =>
                   Error.fail("Format required a %s at %d, got string".format(rawVal.prettyName, i))
@@ -746,7 +747,8 @@ object Format {
                 case 'f' | 'F'       => formatFloat(formatted, b)
                 case 'g'             => formatGeneric(formatted, b).toLowerCase
                 case 'G'             => formatGeneric(formatted, b)
-                case 'c'             => widenRaw(formatted, Character.forDigit(b, 10).toString)
+                case 'c'             =>
+                  Error.fail("%c expected number / string, got: boolean")
                 case 's'             => widenRaw(formatted, "false")
                 case _               =>
                   Error.fail("Format required a %s at %d, got string".format(rawVal.prettyName, i))

--- a/sjsonnet/test/resources/new_test_suite/error.format_c_boolean.jsonnet
+++ b/sjsonnet/test/resources/new_test_suite/error.format_c_boolean.jsonnet
@@ -1,0 +1,4 @@
+// %c format conversion must reject boolean values, matching go-jsonnet behavior.
+// go-jsonnet: RUNTIME ERROR: %c expected number / string, got: boolean
+// jrsonnet:   RUNTIME ERROR: Format required a number, got boolean
+"%c" % true

--- a/sjsonnet/test/resources/new_test_suite/error.format_c_boolean.jsonnet.golden
+++ b/sjsonnet/test/resources/new_test_suite/error.format_c_boolean.jsonnet.golden
@@ -1,0 +1,3 @@
+sjsonnet.Error: [std.format] %c expected number / string, got: boolean
+    at [<root>].(error.format_c_boolean.jsonnet:4:6)
+


### PR DESCRIPTION
## Motivation

`%c` format conversion incorrectly accepts boolean values, converting
`true` → `"1"` and `false` → `"0"` via `Character.forDigit(b, 10)`.
Both go-jsonnet and jrsonnet reject booleans for `%c`.

## Modification

- `Format.scala`: Replace `Character.forDigit(b, 10).toString` with
  `Error.fail("%c expected number / string, got: boolean")` in both
  `Val.True` (line 732) and `Val.False` (line 749) match arms
- Add directional test `error.format_c_boolean.jsonnet`

## Result

| Input | go-jsonnet | jrsonnet | sjsonnet before | sjsonnet after |
|-------|-----------|----------|-----------------|----------------|
| `"%c" % true` | `%c expected number / string, got: boolean` | `type mismatch: expected number, string, got boolean` | `"1"` | Error: `%c expected number / string, got: boolean` |
| `"%c" % false` | `%c expected number / string, got: boolean` | `type mismatch: expected number, string, got boolean` | `"0"` | Error: `%c expected number / string, got: boolean` |
| `"%c" % 65` | `"A"` | `"A"` | `"A"` | `"A"` (unchanged) |
| `"%c" % "A"` | `"A"` | `"A"` | `"A"` | `"A"` (unchanged) |

Tests: `FormatTests` 4/4, `EvaluatorTests` 75/75.

## References

- go-jsonnet v0.22.0 `std.jsonnet:719` — rejects `%c` with boolean
- jrsonnet v0.4.2 `std.jsonnet:1:0` — rejects `%c` with boolean