### PR TITLE
fix: validate Unicode codepoints in %c format conversion

### DIFF
--- a/sjsonnet/src/sjsonnet/Format.scala
+++ b/sjsonnet/src/sjsonnet/Format.scala
@@ -710,7 +710,13 @@ object Format {
                 case 'f' | 'F'       => formatFloat(formatted, s)
                 case 'g'             => formatGeneric(formatted, s).toLowerCase
                 case 'G'             => formatGeneric(formatted, s)
-                case 'c'             => widenRaw(formatted, Character.toString(s.toInt))
+                case 'c'             =>
+                  val codePoint = s.toInt
+                  if (codePoint < 0)
+                    Error.fail("Codepoints must be >= 0, got " + codePoint)
+                  if (codePoint > 0x10FFFF)
+                    Error.fail("Invalid unicode codepoint, got " + codePoint)
+                  widenRaw(formatted, Character.toString(codePoint))
                 case 's'             =>
                   widenRaw(formatted, RenderUtils.renderDouble(s))
                 case _ =>

--- a/sjsonnet/src/sjsonnet/Format.scala
+++ b/sjsonnet/src/sjsonnet/Format.scala
@@ -714,10 +714,10 @@ object Format {
                   val codePoint = s.toInt
                   if (codePoint < 0)
                     Error.fail("Codepoints must be >= 0, got " + codePoint)
-                  if (codePoint > 0x10FFFF)
+                  if (codePoint > 0x10ffff)
                     Error.fail("Invalid unicode codepoint, got " + codePoint)
                   widenRaw(formatted, Character.toString(codePoint))
-                case 's'             =>
+                case 's' =>
                   widenRaw(formatted, RenderUtils.renderDouble(s))
                 case _ =>
                   Error.fail("Format required a %s at %d, got string".format(rawVal.prettyName, i))

--- a/sjsonnet/test/resources/new_test_suite/error.format_c_invalid_codepoint.jsonnet
+++ b/sjsonnet/test/resources/new_test_suite/error.format_c_invalid_codepoint.jsonnet
@@ -1,0 +1,4 @@
+// %c format conversion must reject codepoints above 0x10FFFF, matching go-jsonnet behavior.
+// go-jsonnet: RUNTIME ERROR: Invalid unicode codepoint, got 1.114112e+06
+// jrsonnet:   RUNTIME ERROR: Invalid unicode codepoint, got: 1114112
+"%c" % 1114112

--- a/sjsonnet/test/resources/new_test_suite/error.format_c_invalid_codepoint.jsonnet.golden
+++ b/sjsonnet/test/resources/new_test_suite/error.format_c_invalid_codepoint.jsonnet.golden
@@ -1,0 +1,3 @@
+sjsonnet.Error: [std.format] Invalid unicode codepoint, got 1114112
+    at [<root>].(error.format_c_invalid_codepoint.jsonnet:4:6)
+

--- a/sjsonnet/test/resources/new_test_suite/error.format_c_negative_codepoint.jsonnet
+++ b/sjsonnet/test/resources/new_test_suite/error.format_c_negative_codepoint.jsonnet
@@ -1,0 +1,4 @@
+// %c format conversion must reject negative codepoints, matching go-jsonnet behavior.
+// go-jsonnet: RUNTIME ERROR: Codepoints must be >= 0, got -1
+// jrsonnet:   RUNTIME ERROR: Codepoints must be >=0, got: -1
+"%c" % -1

--- a/sjsonnet/test/resources/new_test_suite/error.format_c_negative_codepoint.jsonnet.golden
+++ b/sjsonnet/test/resources/new_test_suite/error.format_c_negative_codepoint.jsonnet.golden
@@ -1,0 +1,3 @@
+sjsonnet.Error: [std.format] Codepoints must be >= 0, got -1
+    at [<root>].(error.format_c_negative_codepoint.jsonnet:4:6)
+


### PR DESCRIPTION
## Motivation

`%c` with numeric values outside the valid Unicode range `[0, 0x10FFFF]`
leaked a raw Java `IllegalArgumentException` instead of raising a proper
Jsonnet runtime error. go-jsonnet validates codepoints before conversion.

Cross-implementation behavior:

| Input | go-jsonnet v0.22.0 | C++ jsonnet v0.22.0 | jrsonnet v0.4.2 | sjsonnet before |
|-------|-------------------|---------------------|-----------------|-----------------|
| `"%c" % -1` | `Codepoints must be >= 0, got -1` | `codepoints must be >= 0, got -1` | `"\u0000"` (wraps) | `IllegalArgumentException` |
| `"%c" % 1114112` | `Invalid unicode codepoint, got 1.114112e+06` | `invalid unicode codepoint, got 1114112` | `invalid unicode codepoint: 1114112` | `IllegalArgumentException` |
| `"%c" % 65` | `"A"` | `"A"` | `"A"` | `"A"` |
| `"%c" % 0` | `"\^@"` | `"\^@"` | `"\^@"` | `"\^@"` |
| `"%c" % 1114111` | U+10FFFF | U+10FFFF | U+10FFFF | U+10FFFF |

Note: go-jsonnet renders large numbers in scientific notation (`1.114112e+06`);
C++ jsonnet uses plain integers (`1114112`). sjsonnet follows C++ jsonnet's
plain integer format for the upper-bound error message. Capitalization also
differs: go-jsonnet uses `Codepoints`/`Invalid`, C++ uses `codepoints`/`invalid`.
sjsonnet follows go-jsonnet's capitalization.

## Modification

- `Format.scala`: Add codepoint validation before `Character.toString()`
  in the `Val.Num` → `'c'` conversion path:
  - `codePoint < 0` → `Error.fail("Codepoints must be >= 0, got " + codePoint)`
  - `codePoint > 0x10ffff` → `Error.fail("Invalid unicode codepoint, got " + codePoint)`
- Add directional tests:
  - `error.format_c_negative_codepoint.jsonnet`
  - `error.format_c_invalid_codepoint.jsonnet`

## Result

| Input | sjsonnet after |
|-------|----------------|
| `"%c" % -1` | `[std.format] Codepoints must be >= 0, got -1` |
| `"%c" % 1114112` | `[std.format] Invalid unicode codepoint, got 1114112` |
| `"%c" % 65` | `"A"` (unchanged) |
| `"%c" % 0` | `"\^@"` (unchanged) |
| `"%c" % 1114111` | U+10FFFF (unchanged) |

Tests: `FormatTests` 4/4, `EvaluatorTests` 75/75, existing
`format.jsonnet` suite passes (valid `%c` usage unaffected).