### PR TITLE
fix: error on numeric format conversions with null values

### DIFF
--- a/sjsonnet/src/sjsonnet/Format.scala
+++ b/sjsonnet/src/sjsonnet/Format.scala
@@ -752,7 +752,12 @@ object Format {
                   Error.fail("Format required a %s at %d, got string".format(rawVal.prettyName, i))
               }
             case _: Val.Null =>
-              widenRaw(formatted, "null")
+              formatted.conversion match {
+                case 's' => widenRaw(formatted, "null")
+                case 'c' => Error.fail("%c expected number / string, got: null")
+                case _   =>
+                  Error.fail("Format required number at %d, got null".format(i))
+              }
             case _ =>
               // Complex types (Arr, Obj): materialize via Renderer
               val value = rawVal match {

--- a/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
+++ b/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
@@ -613,7 +613,9 @@ object EvaluatorTests extends TestSuite {
 
       // Self-composition identity (g = id): still forced exactly once.
       val (compVal, compTraces) =
-        evalWithTraces("""local g = function(x) x; local f = function(x) g(g(x)); f(std.trace("comp", 9))""")
+        evalWithTraces(
+          """local g = function(x) x; local f = function(x) g(g(x)); f(std.trace("comp", 9))"""
+        )
       compVal ==> ujson.Num(9)
       compTraces ==> Vector("TRACE: (memory) comp")
 
@@ -673,6 +675,30 @@ object EvaluatorTests extends TestSuite {
       // -0.3 truncates to 0, so no minus sign should appear.
       eval("'%5.3d' % -0.3") ==> ujson.Str("  000")
       eval("'%d' % -0.9") ==> ujson.Str("0")
+    }
+    test("formatNullErrors") {
+      evalErr(
+        "'%d' % null"
+      ) ==> "sjsonnet.Error: [std.format] Format required number at 0, got null\nat [<root>].(:1:6)"
+      evalErr(
+        "'%f' % null"
+      ) ==> "sjsonnet.Error: [std.format] Format required number at 0, got null\nat [<root>].(:1:6)"
+      evalErr(
+        "'%e' % null"
+      ) ==> "sjsonnet.Error: [std.format] Format required number at 0, got null\nat [<root>].(:1:6)"
+      evalErr(
+        "'%g' % null"
+      ) ==> "sjsonnet.Error: [std.format] Format required number at 0, got null\nat [<root>].(:1:6)"
+      evalErr(
+        "'%o' % null"
+      ) ==> "sjsonnet.Error: [std.format] Format required number at 0, got null\nat [<root>].(:1:6)"
+      evalErr(
+        "'%x' % null"
+      ) ==> "sjsonnet.Error: [std.format] Format required number at 0, got null\nat [<root>].(:1:6)"
+      evalErr(
+        "'%c' % null"
+      ) ==> "sjsonnet.Error: [std.format] %c expected number / string, got: null\nat [<root>].(:1:6)"
+      eval("'%s' % null") ==> ujson.Str("null")
     }
     test("strict") {
       eval("({ a: 1 } { b: 2 }).a", strict = false) ==> ujson


### PR DESCRIPTION
## Summary

- `std.format` and `%` operator now error on null values for numeric format conversions (`%d`, `%f`, `%e`, `%g`, `%o`, `%x`), matching go-jsonnet behavior
- `%c` with null now errors with "%c expected number / string, got: null"
- `%s` with null still correctly produces "null"

## Motivation

go-jsonnet reports "Format required number at N, got null" for numeric format conversions with null values. sjsonnet silently produced the string "null" for all conversion types, hiding type errors.

## Modification

In `Format.scala`, the `Val.Null` branch now checks the conversion type:
- `'s'` → produces "null" (unchanged)
- `'c'` → errors with "%c expected number / string, got: null"
- all others → errors with "Format required number at N, got null"

## Test Plan

- [x] Added directional tests for `%d`, `%f`, `%e`, `%g`, `%o`, `%x`, `%c` on null (all should error)
- [x] Verified `%s % null` still produces "null"
- [x] All existing tests pass
- [x] Behavior verified against go-jsonnet v0.22.0 and jrsonnet v0.4.2