### PR TITLE
fix: std.parseInt("-0") should return 0 instead of -0

### DIFF
--- a/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
@@ -984,8 +984,10 @@ object StringModule extends AbstractFunctionModule {
       if (s.isEmpty || s == "-") {
         Error.fail("Cannot parse '" + s + "' as an integer in base 10")
       }
-      if (s.charAt(0) == '-') Val.cachedNum(pos, -parseNat(s, 1, 10, "base 10"))
-      else Val.cachedNum(pos, parseNat(s, 0, 10, "base 10"))
+      if (s.charAt(0) == '-') {
+        val result = parseNat(s, 1, 10, "base 10")
+        Val.cachedNum(pos, if (result == 0.0) 0.0 else -result)
+      } else Val.cachedNum(pos, parseNat(s, 0, 10, "base 10"))
     }
   }
 

--- a/sjsonnet/test/src/sjsonnet/StdParseTests.scala
+++ b/sjsonnet/test/src/sjsonnet/StdParseTests.scala
@@ -17,5 +17,11 @@ object StdParseTests extends TestSuite {
       eval("""std.parseHex(":")""") ==> ujson.Num(10)
       eval("""std.parseHex("?")""") ==> ujson.Num(15)
     }
+
+    test("parseInt negative zero returns positive zero") {
+      eval("""std.parseInt("-0")""") ==> ujson.Num(0)
+      eval("""std.parseInt("-00")""") ==> ujson.Num(0)
+      eval("""std.atan2(std.parseInt("-0"), -1)""") ==> ujson.Num(math.Pi)
+    }
   }
 }


### PR DESCRIPTION
## Summary

- `std.parseInt("-0")` now returns `0` (positive zero) instead of `-0.0` (negative zero), matching go-jsonnet behavior

## Motivation

go-jsonnet returns `0` for `std.parseInt("-0")`, but sjsonnet was returning `-0.0` due to unconditional negation of the parsed magnitude. While `-0.0 == 0.0` in most contexts, the IEEE 754 sign bit can cause unexpected behavior in edge cases like `std.atan2(-0, -1)` returning `-π` instead of `π`.

## Modification

In `StringModule.scala`, the `parseInt` negative branch now checks if the parsed magnitude is `0.0` before negating. If the result is zero, it returns `0.0` directly to avoid producing IEEE 754 negative zero.

## Test Plan

- [x] `std.parseInt("-0")` returns `0` (verified by direct comparison)
- [x] `std.parseInt("-00")` returns `0`
- [x] `std.atan2(std.parseInt("-0"), -1)` returns `π` (not `-π`), confirming positive zero
- [x] All existing tests pass
- [x] Behavior verified against go-jsonnet v0.22.0