### PR TITLE
fix: use IEEE 754 Frexp for std.mantissa and std.exponent

### DIFF
--- a/sjsonnet/src/sjsonnet/stdlib/MathModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/MathModule.scala
@@ -533,10 +533,18 @@ object MathModule extends AbstractFunctionModule {
      * The official docs list std.mantissa(x) as a mathematical function.
      */
     builtin("mantissa", "x") { (pos, ev, x: Double) =>
-      if (x == 0) 0
+      if (x == 0) 0.0
       else {
-        val exponent = Math.floor((Math.log(Math.abs(x)) / Math.log(2)) + 1).toLong
-        x * Math.pow(2.0, (-exponent).toDouble)
+        val bits = java.lang.Double.doubleToRawLongBits(x)
+        val absBits = bits & 0x7fffffffffffffffL
+        val expField = (absBits >>> 52).toInt
+        val sign = if (bits < 0) -1.0 else 1.0
+        if (expField != 0) {
+          sign * java.lang.Double.longBitsToDouble((0x3feL << 52) | (absBits & 0x000fffffffffffffL))
+        } else {
+          val scaled = java.lang.Double.longBitsToDouble(absBits) * (1L << 52).toDouble
+          if (scaled == 0) 0.0 else sign * 0.5
+        }
       }
     },
     /**
@@ -549,7 +557,15 @@ object MathModule extends AbstractFunctionModule {
     builtin("exponent", "x") { (pos, ev, x: Double) =>
       if (x == 0) 0L
       else {
-        Math.floor((Math.log(Math.abs(x)) / Math.log(2)) + 1).toLong
+        val bits = java.lang.Double.doubleToRawLongBits(x)
+        val absBits = bits & 0x7fffffffffffffffL
+        val expField = (absBits >>> 52).toInt
+        if (expField != 0) {
+          (expField - 1022).toLong
+        } else {
+          val scaled = java.lang.Double.longBitsToDouble(absBits) * (1L << 52).toDouble
+          if (scaled == 0) 0L else -1073L
+        }
       }
     },
     /**

--- a/sjsonnet/src/sjsonnet/stdlib/MathModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/MathModule.scala
@@ -547,7 +547,9 @@ object MathModule extends AbstractFunctionModule {
           else {
             val nBits = java.lang.Double.doubleToRawLongBits(normalized)
             val nAbsBits = nBits & 0x7fffffffffffffffL
-            sign * java.lang.Double.longBitsToDouble((0x3feL << 52) | (nAbsBits & 0x000fffffffffffffL))
+            sign * java.lang.Double.longBitsToDouble(
+              (0x3feL << 52) | (nAbsBits & 0x000fffffffffffffL)
+            )
           }
         }
       }

--- a/sjsonnet/src/sjsonnet/stdlib/MathModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/MathModule.scala
@@ -537,13 +537,18 @@ object MathModule extends AbstractFunctionModule {
       else {
         val bits = java.lang.Double.doubleToRawLongBits(x)
         val absBits = bits & 0x7fffffffffffffffL
-        val expField = (absBits >>> 52).toInt
         val sign = if (bits < 0) -1.0 else 1.0
+        val expField = (absBits >>> 52).toInt
         if (expField != 0) {
           sign * java.lang.Double.longBitsToDouble((0x3feL << 52) | (absBits & 0x000fffffffffffffL))
         } else {
-          val scaled = java.lang.Double.longBitsToDouble(absBits) * (1L << 52).toDouble
-          if (scaled == 0) 0.0 else sign * 0.5
+          val normalized = java.lang.Double.longBitsToDouble(absBits) * (1L << 52).toDouble
+          if (normalized == 0) 0.0
+          else {
+            val nBits = java.lang.Double.doubleToRawLongBits(normalized)
+            val nAbsBits = nBits & 0x7fffffffffffffffL
+            sign * java.lang.Double.longBitsToDouble((0x3feL << 52) | (nAbsBits & 0x000fffffffffffffL))
+          }
         }
       }
     },
@@ -563,8 +568,13 @@ object MathModule extends AbstractFunctionModule {
         if (expField != 0) {
           (expField - 1022).toLong
         } else {
-          val scaled = java.lang.Double.longBitsToDouble(absBits) * (1L << 52).toDouble
-          if (scaled == 0) 0L else -1073L
+          val normalized = java.lang.Double.longBitsToDouble(absBits) * (1L << 52).toDouble
+          if (normalized == 0) 0L
+          else {
+            val nBits = java.lang.Double.doubleToRawLongBits(normalized)
+            val nExpField = ((nBits & 0x7fffffffffffffffL) >>> 52).toInt
+            (nExpField - 1022 - 52).toLong
+          }
         }
       }
     },

--- a/sjsonnet/test/src/sjsonnet/StdMathTests.scala
+++ b/sjsonnet/test/src/sjsonnet/StdMathTests.scala
@@ -1,7 +1,7 @@
 package sjsonnet
 
 import utest._
-import TestUtils.eval
+import TestUtils.{eval, evalErr}
 
 object StdMathTests extends TestSuite {
   def tests: Tests = Tests {
@@ -11,6 +11,26 @@ object StdMathTests extends TestSuite {
     test("atan2 named parameters") {
       eval("""std.atan2(y=1, x=0)""") ==> ujson.Num(math.Pi / 2)
       eval("""std.atan2(y=0, x=1)""") ==> ujson.Num(0.0)
+    }
+    test("mantissa and exponent for normal values") {
+      eval("std.mantissa(0)") ==> ujson.Num(0)
+      eval("std.mantissa(1.0)") ==> ujson.Num(0.5)
+      eval("std.mantissa(-8.0)") ==> ujson.Num(-0.5)
+      eval("std.mantissa(std.pow(2, 53))") ==> ujson.Num(0.5)
+      eval("std.exponent(0)") ==> ujson.Num(0)
+      eval("std.exponent(1.0)") ==> ujson.Num(1)
+      eval("std.exponent(-8.0)") ==> ujson.Num(4)
+      eval("std.exponent(std.pow(2, 53))") ==> ujson.Num(54)
+    }
+    test("mantissa and exponent for subnormal values") {
+      eval("std.mantissa(std.pow(2, -1074))") ==> ujson.Num(0.5)
+      eval("std.exponent(std.pow(2, -1074))") ==> ujson.Num(-1073)
+    }
+    test("mantissa and exponent for NaN and Infinity") {
+      evalErr("std.mantissa(std.sqrt(-1))")
+      evalErr("std.mantissa(std.pow(2, 1024))")
+      evalErr("std.exponent(std.sqrt(-1))")
+      evalErr("std.exponent(std.pow(2, 1024))")
     }
   }
 }

--- a/sjsonnet/test/src/sjsonnet/StdMathTests.scala
+++ b/sjsonnet/test/src/sjsonnet/StdMathTests.scala
@@ -25,6 +25,12 @@ object StdMathTests extends TestSuite {
     test("mantissa and exponent for subnormal values") {
       eval("std.mantissa(std.pow(2, -1074))") ==> ujson.Num(0.5)
       eval("std.exponent(std.pow(2, -1074))") ==> ujson.Num(-1073)
+      eval("std.mantissa(3 * std.pow(2, -1074))") ==> ujson.Num(0.75)
+      eval("std.exponent(3 * std.pow(2, -1074))") ==> ujson.Num(-1072)
+      eval("std.mantissa(std.pow(2, -1023))") ==> ujson.Num(0.5)
+      eval("std.exponent(std.pow(2, -1023))") ==> ujson.Num(-1022)
+      eval("std.mantissa(-std.pow(2, -1074))") ==> ujson.Num(-0.5)
+      eval("std.exponent(-std.pow(2, -1074))") ==> ujson.Num(-1073)
     }
     test("mantissa and exponent for NaN and Infinity") {
       evalErr("std.mantissa(std.sqrt(-1))")


### PR DESCRIPTION
## Summary

- `std.mantissa` and `std.exponent` now use IEEE 754 bit manipulation (equivalent to Go's `math.Frexp`) instead of manual log-based calculation
- Subnormal doubles (e.g. `std.pow(2, -1074)`) are now handled correctly instead of causing overflow
- NaN and Infinity still produce appropriate errors

## Motivation

The previous implementation used `Math.floor(Math.log(Math.abs(x)) / Math.log(2) + 1)` which:
1. Overflowed for subnormal doubles because `Math.pow(2, n)` for large `n` exceeds `Double.MAX_VALUE`
2. Was less precise than the standard IEEE 754 Frexp decomposition used by go-jsonnet

## Modification

Replace the log-based formula with IEEE 754 bit manipulation:
- Extract the exponent field directly from the double's bit representation
- Reconstruct the mantissa by replacing the exponent bits with `0x3fe` (biased -1, yielding values in [0.5, 1.0))
- Handle subnormals by scaling the fraction bits into the normal range before extraction

## Test Plan

- [x] Normal values: `mantissa(1.0) = 0.5`, `mantissa(-8.0) = -0.5`, `exponent(1.0) = 1`, `exponent(-8.0) = 4`
- [x] Subnormal: `mantissa(2^-1074) = 0.5`, `exponent(2^-1074) = -1073`
- [x] NaN → error, Infinity → error
- [x] All existing tests pass
- [x] Behavior verified against go-jsonnet v0.22.0