### PR TITLE
Revert "Upgrade Scala 3 to 3.3.8 with -Yfuture-lazy-vals (#920)"

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -22,7 +22,7 @@ import mill.api.BuildCtx
 
 import java.util.Base64
 
-val scalaVersions: Seq[String] = Seq("3.3.8", "2.13.18")
+val scalaVersions: Seq[String] = Seq("3.3.7", "2.13.18")
 val jvmScalaVersions: Seq[String] = scalaVersions ++ Seq("2.12.21")
 val stackSize = "100m"
 val stackSizekBytes = 100 * 1024
@@ -85,10 +85,7 @@ trait SjsonnetCrossModule extends CrossScalaModule with ScalafmtModule {
       ) ++ (if (scalaVersion().startsWith("2.13"))
               Seq("-Wopt", "-Wconf:origin=scala.collection.compat.*:s")
             else Seq("-Xfatal-warnings", "-Ywarn-unused:-nowarn"))
-    else Seq[String](
-      "-Wconf:origin=scala.collection.compat.*:s",
-      "-Xlint:all"
-    )
+    else Seq[String]("-Wconf:origin=scala.collection.compat.*:s", "-Xlint:all")
   )
   trait CrossTests extends ScalaModule with TestModule.Utest {
     def mvnDeps = Seq(mvn"com.lihaoyi::utest::0.9.5")
@@ -368,8 +365,7 @@ object sjsonnet extends VersionFileModule {
     def forkArgs =
       Seq("-Xss" + stackSize, "--enable-native-access=ALL-UNNAMED")
 
-    def scalacOptions = super.scalacOptions() ++ Seq("-release", "17") ++
-      (if (JvmWorkerUtil.isScala3(scalaVersion())) Seq("-Yfuture-lazy-vals") else Seq.empty)
+    def scalacOptions = super.scalacOptions() ++ Seq("-release", "17")
     def javacOptions = super.javacOptions() ++ Seq("--release", "17")
 
     def mvnDeps = super.mvnDeps() ++ Seq(
@@ -400,8 +396,7 @@ object sjsonnet extends VersionFileModule {
       def artifactName = "sjsonnet-server"
       def scalaVersion = SjsonnnetJvmModule.this.crossValue
       def moduleDeps = Seq(SjsonnnetJvmModule.this, client)
-      def scalacOptions = super.scalacOptions() ++ Seq("-release", "17") ++
-        (if (JvmWorkerUtil.isScala3(scalaVersion())) Seq("-Yfuture-lazy-vals") else Seq.empty)
+      def scalacOptions = super.scalacOptions() ++ Seq("-release", "17")
       def javacOptions = super.javacOptions() ++ Seq("--release", "17")
       def mvnDeps = Seq(
         mvn"org.scala-sbt.ipcsocket:ipcsocket:1.6.3".exclude(

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,10 @@
 val sjsonnetVersion = IO.readLines(new File("sjsonnet/version")).head.trim
 cancelable in Global := true
 
-val options = Seq("-Wconf:origin=scala.collection.compat.*:s", "-Xlint:all", "-release", "17", "-Yfuture-lazy-vals")
+val options = Seq("-Wconf:origin=scala.collection.compat.*:s", "-Xlint:all", "-release", "17")
 
 lazy val commonSettings = Seq(
-  scalaVersion := "3.3.8",
+  scalaVersion := "3.3.7",
   scalacOptions ++= options,
   javacOptions ++= Seq("--release", "17")
 )
@@ -21,7 +21,7 @@ lazy val main = (project in file("sjsonnet"))
     libraryDependencies ++= Seq(
       "com.lihaoyi" %% "fastparse" % "3.1.1",
       "com.lihaoyi" %% "pprint" % "0.9.6",
-      "com.lihaoyi" %% "ujson" % "4.4.3",
+      "com.lihaoyi" %% "ujson" % "4.4.2",
       "com.lihaoyi" %% "scalatags" % "0.13.1",
       "com.lihaoyi" %% "os-lib" % "0.11.8",
       "com.lihaoyi" %% "mainargs" % "0.7.8",


### PR DESCRIPTION
This reverts commit e97b35eca712d4026b002f2e79b25de707be5ceb.

Revert for now - the internal datbricks maven repo waits 7 days before making a dependency available.
I will roll forward next week.