### PR TITLE
fix: std.sqrt should reject negative input with clear error

### DIFF
--- a/sjsonnet/src/sjsonnet/stdlib/MathModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/MathModule.scala
@@ -219,8 +219,9 @@ object MathModule extends AbstractFunctionModule {
      * The official docs list std.sqrt(x) as a mathematical function.
      */
     builtin("sqrt", "x") { (pos, ev, x: Double) =>
-      if (x < 0) Error.fail("sqrt input is negative", pos)(ev)
-      math.sqrt(x)
+      val r = math.sqrt(x)
+      if (java.lang.Double.isNaN(r)) Error.fail("Not a number", pos)(ev)
+      r
     },
     /**
      * [[https://jsonnet.org/ref/stdlib.html#math std.max(a, b)]].

--- a/sjsonnet/src/sjsonnet/stdlib/MathModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/MathModule.scala
@@ -219,6 +219,7 @@ object MathModule extends AbstractFunctionModule {
      * The official docs list std.sqrt(x) as a mathematical function.
      */
     builtin("sqrt", "x") { (pos, ev, x: Double) =>
+      if (x < 0) Error.fail("sqrt input is negative", pos)(ev)
       math.sqrt(x)
     },
     /**

--- a/sjsonnet/test/src/sjsonnet/StdMathTests.scala
+++ b/sjsonnet/test/src/sjsonnet/StdMathTests.scala
@@ -38,5 +38,15 @@ object StdMathTests extends TestSuite {
       evalErr("std.exponent(std.sqrt(-1))")
       evalErr("std.exponent(std.pow(2, 1024))")
     }
+    test("sqrt rejects negative input") {
+      // go-jsonnet: "RUNTIME ERROR: sqrt input is negative"
+      val err = evalErr("std.sqrt(-1)")
+      assert(err.contains("sqrt input is negative"))
+      val err2 = evalErr("std.sqrt(-0.001)")
+      assert(err2.contains("sqrt input is negative"))
+      // sqrt(0) and sqrt(positive) must still work
+      eval("std.sqrt(0)") ==> ujson.Num(0.0)
+      eval("std.sqrt(4)") ==> ujson.Num(2.0)
+    }
   }
 }

--- a/sjsonnet/test/src/sjsonnet/StdMathTests.scala
+++ b/sjsonnet/test/src/sjsonnet/StdMathTests.scala
@@ -39,11 +39,11 @@ object StdMathTests extends TestSuite {
       evalErr("std.exponent(std.pow(2, 1024))")
     }
     test("sqrt rejects negative input") {
-      // go-jsonnet: "RUNTIME ERROR: sqrt input is negative"
+      // go-jsonnet: makeDoubleCheck returns "Not a number" for NaN results
       val err = evalErr("std.sqrt(-1)")
-      assert(err.contains("sqrt input is negative"))
+      assert(err.contains("Not a number"))
       val err2 = evalErr("std.sqrt(-0.001)")
-      assert(err2.contains("sqrt input is negative"))
+      assert(err2.contains("Not a number"))
       // sqrt(0) and sqrt(positive) must still work
       eval("std.sqrt(0)") ==> ujson.Num(0.0)
       eval("std.sqrt(4)") ==> ujson.Num(2.0)


### PR DESCRIPTION
## Motivation

`std.sqrt(-1)` silently produced `NaN` instead of raising a runtime error.
go-jsonnet rejects negative inputs with `"Not a number"` (via `makeDoubleCheck`
on NaN results from `math.Sqrt`). The existing `Val.Num` guard only catches
`Infinity`, not `NaN`, so negative inputs propagated silently through
downstream computations.

Cross-implementation behavior for `std.sqrt(-1)`:

| Implementation | Error message |
|---|---|
| go-jsonnet v0.22.0 | `Not a number` |
| C++ jsonnet v0.22.0 | `not a number` |
| jrsonnet v0.4.2 | `type error: number out of bounds: -1 not in 0..` |
| sjsonnet before | `NaN` (silent, no error) |

## Modification

- `MathModule.scala`: Add post-computation NaN check to `std.sqrt`.
  When the result is `NaN`, fail with `"Not a number"` (matching
  go-jsonnet's `makeDoubleCheck` behavior)
- `StdMathTests.scala`: Add directional tests verifying negative inputs
  error, and zero/positive inputs succeed

## Result

| Input | go-jsonnet | C++ jsonnet | jrsonnet | sjsonnet before | sjsonnet after |
|-------|-----------|-------------|----------|-----------------|----------------|
| `std.sqrt(-1)` | `Not a number` | `not a number` | `number out of bounds` | `NaN` (silent) | `[std.sqrt] Not a number` |
| `std.sqrt(-0)` | `-0.0` | `-0.0` | `-0.0` | `-0.0` | `-0.0` (unchanged) |
| `std.sqrt(0)` | `0` | `0` | `0` | `0.0` | `0.0` (unchanged) |
| `std.sqrt(4)` | `2` | `2` | `2` | `2.0` | `2.0` (unchanged) |

Note: go-jsonnet and C++ jsonnet differ in capitalization ("Not a number"
vs "not a number"). sjsonnet follows go-jsonnet's capitalization.
jrsonnet uses a different approach (range validation at the stdlib level).