### PR TITLE
fix: std.log, std.log2, and std.log10 should reject negative and zero input

### DIFF
--- a/sjsonnet/src/sjsonnet/stdlib/MathModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/MathModule.scala
@@ -494,7 +494,9 @@ object MathModule extends AbstractFunctionModule {
      * The official docs list std.log(x) as a mathematical function.
      */
     builtin("log", "x") { (pos, ev, x: Double) =>
-      math.log(x)
+      val r = math.log(x)
+      if (java.lang.Double.isNaN(r)) Error.fail("Not a number", pos)(ev)
+      r
     },
     /**
      * [[https://jsonnet.org/ref/stdlib.html#math std.log2(x)]].
@@ -504,8 +506,9 @@ object MathModule extends AbstractFunctionModule {
      * The official docs list std.log2(x) as a mathematical function.
      */
     builtin("log2", "x") { (pos, ev, x: Double) =>
-      // no scala log2, do our best without getting fancy with numerics
-      math.log(x) / math.log(2.0)
+      val r = math.log(x) / math.log(2.0)
+      if (java.lang.Double.isNaN(r)) Error.fail("Not a number", pos)(ev)
+      r
     },
     /**
      * [[https://jsonnet.org/ref/stdlib.html#math std.log10(x)]].
@@ -515,7 +518,9 @@ object MathModule extends AbstractFunctionModule {
      * The official docs list std.log10(x) as a mathematical function.
      */
     builtin("log10", "x") { (pos, ev, x: Double) =>
-      math.log10(x)
+      val r = math.log10(x)
+      if (java.lang.Double.isNaN(r)) Error.fail("Not a number", pos)(ev)
+      r
     },
     /**
      * [[https://jsonnet.org/ref/stdlib.html#math std.exp(x)]].

--- a/sjsonnet/test/resources/go_test_suite/builtin_log7.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/builtin_log7.jsonnet.golden
@@ -1,3 +1,3 @@
-sjsonnet.Error: not a number
+sjsonnet.Error: [std.log] Not a number
     at [<root>].(builtin_log7.jsonnet:1:8)
 

--- a/sjsonnet/test/resources/go_test_suite/builtin_log8.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/builtin_log8.jsonnet.golden
@@ -1,3 +1,3 @@
-sjsonnet.Error: not a number
+sjsonnet.Error: [std.log] Not a number
     at [<root>].(builtin_log8.jsonnet:1:8)
 

--- a/sjsonnet/test/src/sjsonnet/StdMathTests.scala
+++ b/sjsonnet/test/src/sjsonnet/StdMathTests.scala
@@ -48,5 +48,23 @@ object StdMathTests extends TestSuite {
       eval("std.sqrt(0)") ==> ujson.Num(0.0)
       eval("std.sqrt(4)") ==> ujson.Num(2.0)
     }
+    test("log and log2 reject negative and zero input") {
+      // go-jsonnet: makeDoubleCheck returns "Not a number" for NaN, Val.Num catches Infinity as "overflow"
+      val errLog = evalErr("std.log(-1)")
+      assert(errLog.contains("Not a number"))
+      val errLog2 = evalErr("std.log2(-1)")
+      assert(errLog2.contains("Not a number"))
+      val errLog10 = evalErr("std.log10(-1)")
+      assert(errLog10.contains("Not a number"))
+      val errLog0 = evalErr("std.log(0)")
+      assert(errLog0.contains("overflow"))
+      val errLog2Zero = evalErr("std.log2(0)")
+      assert(errLog2Zero.contains("overflow"))
+      // log(positive) must still work
+      eval("std.log(1)") ==> ujson.Num(0.0)
+      eval("std.log2(1)") ==> ujson.Num(0.0)
+      eval("std.log2(8)") ==> ujson.Num(3.0)
+      eval("std.log10(100)") ==> ujson.Num(2.0)
+    }
   }
 }


### PR DESCRIPTION
## Motivation

`std.log`, `std.log2`, and `std.log10` produced generic downstream errors for negative and zero inputs (e.g., "not a number" or "overflow") instead of clear, function-specific error messages. go-jsonnet errors with "Not a number" for NaN results from `math.log`.

## Modification

- Added NaN checks after `math.log`, `math.log2`, and `math.log10` computations
- When the result is NaN, raises "[std.log] Not a number" (etc.) with position info
- Added tests for `log(-1)`, `log2(-1)`, `log(0)`, `log2(0)`, and valid inputs

## Result

`std.log(-1)` now errors with "[std.log] Not a number" instead of a generic downstream error, providing clearer diagnostics.

## References

| Expression | go-jsonnet v0.22.0 | jrsonnet v0.5.0-pre98 | sjsonnet (before) | sjsonnet (after) |
|---|---|---|---|---|
| `std.log(-1)` | ERROR: Not a number | ERROR: non-finite | ERROR: not a number (generic) | ERROR: [std.log] Not a number ✅ |
| `std.log2(0)` | ERROR: Overflow | ERROR: non-finite | ERROR: [std.log2] overflow | ERROR: [std.log2] overflow ✅ |
| `std.log(1)` | `0` | `0` | `0` ✅ | `0` ✅ |
| `std.log2(8)` | `3` | `3` | `3` ✅ | `3` ✅ |