### PR TITLE
fix: align strReplace empty-from error message with go-jsonnet

### DIFF
--- a/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
@@ -232,12 +232,29 @@ object StringModule extends AbstractFunctionModule {
   private object StrReplace extends Val.Builtin3("strReplace", "str", "from", "to") {
     def evalRhs(str: Eval, from: Eval, to: Eval, ev: EvalScope, pos: Position): Val = {
       val fromForce = from.value.asString
-      if (fromForce.isEmpty) {
-        Error.fail("Cannot replace empty string in strReplace")
-      }
       val srcVal = str.value
       val toVal = to.value
-      val out = srcVal.asString.replace(fromForce, toVal.asString)
+      val out =
+        if (fromForce.isEmpty) {
+          // Go's strings.ReplaceAll(s, "", to) inserts `to` between every rune and at start/end.
+          val s = srcVal.asString
+          val t = toVal.asString
+          if (s.isEmpty) t
+          else {
+            val sb = new java.lang.StringBuilder(s.length * (t.length + 1) + t.length)
+            sb.append(t)
+            var i = 0
+            while (i < s.length) {
+              val cp = s.codePointAt(i)
+              sb.appendCodePoint(cp)
+              sb.append(t)
+              i += Character.charCount(cp)
+            }
+            sb.toString
+          }
+        } else {
+          srcVal.asString.replace(fromForce, toVal.asString)
+        }
       // Result is asciiSafe iff both src and `to` are asciiSafe (`from` is removed).
       val srcSafe = srcVal.isInstanceOf[Val.AsciiSafeStr]
       val toSafe = toVal.isInstanceOf[Val.AsciiSafeStr]

--- a/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
@@ -232,30 +232,12 @@ object StringModule extends AbstractFunctionModule {
   private object StrReplace extends Val.Builtin3("strReplace", "str", "from", "to") {
     def evalRhs(str: Eval, from: Eval, to: Eval, ev: EvalScope, pos: Position): Val = {
       val fromForce = from.value.asString
+      if (fromForce.isEmpty) {
+        Error.fail("'from' string must not be zero length.", pos)(ev)
+      }
       val srcVal = str.value
       val toVal = to.value
-      val out =
-        if (fromForce.isEmpty) {
-          // Go's strings.ReplaceAll(s, "", to) inserts `to` between every rune and at start/end.
-          val s = srcVal.asString
-          val t = toVal.asString
-          if (s.isEmpty) t
-          else {
-            val sb = new java.lang.StringBuilder(s.length * (t.length + 1) + t.length)
-            sb.append(t)
-            var i = 0
-            while (i < s.length) {
-              val cp = s.codePointAt(i)
-              sb.appendCodePoint(cp)
-              sb.append(t)
-              i += Character.charCount(cp)
-            }
-            sb.toString
-          }
-        } else {
-          srcVal.asString.replace(fromForce, toVal.asString)
-        }
-      // Result is asciiSafe iff both src and `to` are asciiSafe (`from` is removed).
+      val out = srcVal.asString.replace(fromForce, toVal.asString)
       val srcSafe = srcVal.isInstanceOf[Val.AsciiSafeStr]
       val toSafe = toVal.isInstanceOf[Val.AsciiSafeStr]
       if (srcSafe && toSafe) Val.Str.asciiSafe(pos, out) else Val.Str(pos, out)

--- a/sjsonnet/test/resources/go_test_suite/strReplace3.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/strReplace3.jsonnet.golden
@@ -1,3 +1,2 @@
-sjsonnet.Error: [std.strReplace] Cannot replace empty string in strReplace
-    at [<root>].(strReplace3.jsonnet:1:15)
+"blahtblaheblahsblahtblah"
 

--- a/sjsonnet/test/resources/go_test_suite/strReplace3.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/strReplace3.jsonnet.golden
@@ -1,2 +1,2 @@
-"blahtblaheblahsblahtblah"
-
+sjsonnet.Error: [std.strReplace] 'from' string must not be zero length.
+    at [<root>].(strReplace3.jsonnet:1:15)

--- a/sjsonnet/test/src/sjsonnet/StdStringTests.scala
+++ b/sjsonnet/test/src/sjsonnet/StdStringTests.scala
@@ -1,7 +1,7 @@
 package sjsonnet
 
 import utest._
-import TestUtils.eval
+import TestUtils.{eval, evalErr}
 
 object StdStringTests extends TestSuite {
   def tests: Tests = Tests {
@@ -16,14 +16,13 @@ object StdStringTests extends TestSuite {
       eval("""std.equalsIgnoreCase("İ", "i")""") ==> ujson.False
     }
 
-    test("strReplace with empty from inserts between characters") {
-      // go-jsonnet: std.strReplace("abc", "", "-") => "-a-b-c-"
-      eval("""std.strReplace("abc", "", "-")""") ==> ujson.Str("-a-b-c-")
-      eval("""std.strReplace("", "", "-")""") ==> ujson.Str("-")
-      eval("""std.strReplace("a", "", "-")""") ==> ujson.Str("-a-")
-      eval("""std.strReplace("ab", "", "XY")""") ==> ujson.Str("XYaXYbXY")
+    test("strReplace rejects empty from string") {
+      // go-jsonnet: "'from' string must not be zero length."
+      val err = evalErr("""std.strReplace("abc", "", "-")""")
+      assert(err.contains("'from' string must not be zero length."))
       // Normal replacement still works
       eval("""std.strReplace("hello world", "world", "jsonnet")""") ==> ujson.Str("hello jsonnet")
+      eval("""std.strReplace("aaa", "a", "b")""") ==> ujson.Str("bbb")
     }
   }
 }

--- a/sjsonnet/test/src/sjsonnet/StdStringTests.scala
+++ b/sjsonnet/test/src/sjsonnet/StdStringTests.scala
@@ -15,5 +15,15 @@ object StdStringTests extends TestSuite {
       eval("""std.equalsIgnoreCase("É", "é")""") ==> ujson.False
       eval("""std.equalsIgnoreCase("İ", "i")""") ==> ujson.False
     }
+
+    test("strReplace with empty from inserts between characters") {
+      // go-jsonnet: std.strReplace("abc", "", "-") => "-a-b-c-"
+      eval("""std.strReplace("abc", "", "-")""") ==> ujson.Str("-a-b-c-")
+      eval("""std.strReplace("", "", "-")""") ==> ujson.Str("-")
+      eval("""std.strReplace("a", "", "-")""") ==> ujson.Str("-a-")
+      eval("""std.strReplace("ab", "", "XY")""") ==> ujson.Str("XYaXYbXY")
+      // Normal replacement still works
+      eval("""std.strReplace("hello world", "world", "jsonnet")""") ==> ujson.Str("hello jsonnet")
+    }
   }
 }


### PR DESCRIPTION
## Motivation

`std.strReplace` rejected empty `from` strings with a non-standard error
message `"Cannot replace empty string in strReplace"` that diverged from
go-jsonnet's `"'from' string must not be zero length."`.

Note: Both go-jsonnet and sjsonnet reject empty `from` strings. This PR
only aligns the error message text, not the behavior.

Cross-implementation behavior for `std.strReplace("abc", "", "-")`:

| Implementation | Behavior |
|---|---|
| go-jsonnet v0.22.0 | Error: `'from' string must not be zero length.` |
| C++ jsonnet v0.22.0 | Error: `'from' string must not be zero length.` |
| sjsonnet before | Error: `Cannot replace empty string in strReplace` |

## Modification

- `StringModule.scala`: Change error message from
  `"Cannot replace empty string in strReplace"` to
  `"'from' string must not be zero length."` to match go-jsonnet verbatim
- `strReplace3.jsonnet.golden`: Update expected error message
- `StdStringTests.scala`: Add directional test verifying empty `from` is
  rejected with the correct error message, plus happy-path assertions

## Result

| Expression | go-jsonnet | C++ jsonnet | sjsonnet before | sjsonnet after |
|-----------|-----------|-------------|-----------------|----------------|
| `std.strReplace("abc", "", "-")` | `'from' string must not be zero length.` | `'from' string must not be zero length.` | `Cannot replace empty string in strReplace` | `'from' string must not be zero length.` |

Error message now matches go-jsonnet byte-for-byte. Behavior unchanged
(empty `from` is still rejected).