### PR TITLE
fix: correct copy-paste error in format type error messages

### DIFF
--- a/sjsonnet/src/sjsonnet/Format.scala
+++ b/sjsonnet/src/sjsonnet/Format.scala
@@ -714,7 +714,7 @@ object Format {
                 case 's'             =>
                   widenRaw(formatted, RenderUtils.renderDouble(s))
                 case _ =>
-                  Error.fail("Format required a %s at %d, got string".format(rawVal.prettyName, i))
+                  Error.fail("Format required a %s at %d, got number".format(rawVal.prettyName, i))
               }
             case _: Val.True =>
               val b = 1
@@ -732,7 +732,7 @@ object Format {
                   Error.fail("%c expected number / string, got: boolean")
                 case 's' => widenRaw(formatted, "true")
                 case _   =>
-                  Error.fail("Format required a %s at %d, got string".format(rawVal.prettyName, i))
+                  Error.fail("Format required a %s at %d, got boolean".format(rawVal.prettyName, i))
               }
             case _: Val.False =>
               val b = 0
@@ -750,7 +750,7 @@ object Format {
                   Error.fail("%c expected number / string, got: boolean")
                 case 's' => widenRaw(formatted, "false")
                 case _   =>
-                  Error.fail("Format required a %s at %d, got string".format(rawVal.prettyName, i))
+                  Error.fail("Format required a %s at %d, got boolean".format(rawVal.prettyName, i))
               }
             case _: Val.Null =>
               formatted.conversion match {

--- a/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
+++ b/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
@@ -713,6 +713,17 @@ object EvaluatorTests extends TestSuite {
       ) ==> "sjsonnet.Error: [std.format] %c expected number / string, got: null\nat [<root>].(:1:6)"
       eval("'%s' % null") ==> ujson.Str("null")
     }
+    test("formatTypeErrorMessages") {
+      evalErr(
+        "'%a' % 42"
+      ) ==> "sjsonnet.Error: [std.format] Format required a number at 0, got number\nat [<root>].(:1:6)"
+      evalErr(
+        "'%a' % true"
+      ) ==> "sjsonnet.Error: [std.format] Format required a boolean at 0, got boolean\nat [<root>].(:1:6)"
+      evalErr(
+        "'%a' % false"
+      ) ==> "sjsonnet.Error: [std.format] Format required a boolean at 0, got boolean\nat [<root>].(:1:6)"
+    }
     test("strict") {
       eval("({ a: 1 } { b: 2 }).a", strict = false) ==> ujson
         .Num(1)


### PR DESCRIPTION
Motivation:
`Format.scala` had a copy-paste bug where unsupported format specifiers for number and boolean values incorrectly said "got string" in error messages instead of the correct type name. For example, `"%d" % true` produced "Format required a %s at 0, got string" instead of "got boolean".

Modification:
Fixed 3 error messages in `Format.scala` to use correct type names:
- `Val.Num` case: `"got string"` → `"got number"`
- `Val.True` case: `"got string"` → `"got boolean"`
- `Val.False` case: `"got string"` → `"got boolean"`

Added `formatTypeErrorMessages` test verifying correct type names for `%a` with number, true, and false.

Result:
Error messages now correctly report the actual type of the value, matching go-jsonnet behavior. All existing tests pass.