### PR TITLE
fix: correct error messages in manifestYamlDoc/Stream parameter validation

### DIFF
--- a/sjsonnet/src/sjsonnet/stdlib/ManifestModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/ManifestModule.scala
@@ -401,12 +401,17 @@ object ManifestModule extends AbstractFunctionModule {
       val indentArrayInObject = args(1) match {
         case Val.False(_) => false
         case Val.True(_)  => true
-        case _ => Error.fail("indent_array_in_object has to be a boolean, got" + v.getClass)
+        case _            =>
+          Error.fail(
+            "indent_array_in_object has to be a boolean, got " + args(1).value.prettyName,
+            pos
+          )(ev)
       }
       val quoteKeys = args(2) match {
         case Val.False(_) => false
         case Val.True(_)  => true
-        case _            => Error.fail("quote_keys has to be a boolean, got " + v.getClass)
+        case _            =>
+          Error.fail("quote_keys has to be a boolean, got " + args(2).value.prettyName, pos)(ev)
       }
       Materializer
         .apply0(
@@ -433,22 +438,31 @@ object ManifestModule extends AbstractFunctionModule {
       "indent_array_in_object" -> Val.False(dummyPos),
       "c_document_end" -> Val.True(dummyPos),
       "quote_keys" -> Val.True(dummyPos)
-    ) { (args, _, ev) =>
+    ) { (args, pos, ev) =>
       val v = args(0)
       val indentArrayInObject = args(1) match {
         case Val.False(_) => false
         case Val.True(_)  => true
-        case _ => Error.fail("indent_array_in_object has to be a boolean, got" + v.getClass)
+        case _            =>
+          Error.fail(
+            "indent_array_in_object has to be a boolean, got " + args(1).value.prettyName,
+            pos
+          )(ev)
       }
       val cDocumentEnd = args(2) match {
         case Val.False(_) => false
         case Val.True(_)  => true
-        case _            => Error.fail("c_document_end has to be a boolean, got " + v.getClass)
+        case _            =>
+          Error.fail(
+            "c_document_end has to be a boolean, got " + args(2).value.prettyName,
+            pos
+          )(ev)
       }
       val quoteKeys = args(3) match {
         case Val.False(_) => false
         case Val.True(_)  => true
-        case _            => Error.fail("quote_keys has to be a boolean, got " + v.getClass)
+        case _            =>
+          Error.fail("quote_keys has to be a boolean, got " + args(3).value.prettyName, pos)(ev)
       }
       v match {
         case arr: Val.Arr =>

--- a/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
+++ b/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
@@ -1097,6 +1097,24 @@ object EvaluatorTests extends TestSuite {
       eval("""std.toString(0.0)""") ==> ujson.Str("0")
     }
 
+    test("manifestYamlParameterErrors") {
+      evalErr(
+        """std.manifestYamlDoc({}, indent_array_in_object="yes")"""
+      ).contains("indent_array_in_object has to be a boolean, got string")
+      evalErr(
+        """std.manifestYamlDoc({}, quote_keys=42)"""
+      ).contains("quote_keys has to be a boolean, got number")
+      evalErr(
+        """std.manifestYamlStream([{}], indent_array_in_object="x")"""
+      ).contains("indent_array_in_object has to be a boolean, got string")
+      evalErr(
+        """std.manifestYamlStream([{}], false, c_document_end=[])"""
+      ).contains("c_document_end has to be a boolean, got array")
+      evalErr(
+        """std.manifestYamlStream([{}], false, false, quote_keys=null)"""
+      ).contains("quote_keys has to be a boolean, got null")
+    }
+
     test("largeIntegerDoubleMaterialization") {
       // std.manifestJson(1e308) should output full decimal, not "1.0E308"
       // go-jsonnet and jrsonnet output 10^308 (1 followed by 308 zeros)


### PR DESCRIPTION
Motivation:
5 error messages in `ManifestModule.scala` referenced `v` (args(0), the value being manifest) instead of the actual parameter with the wrong type. They also used `v.getClass` (Java class names like `sjsonnet.Val$Str`) instead of friendly Jsonnet type names, and two messages had a missing space after "got".

Modification:
- Fixed 5 error messages to reference the correct argument (`args(1)`, `args(2)`, etc.) instead of `v`
- Replaced `v.getClass` with `args(N).value.prettyName` for user-friendly type names
- Added missing space after "got" in two messages
- Captured `pos` in `manifestYamlStream` (was `_`) for proper error positions
- Added `manifestYamlParameterErrors` test with 5 cases covering all parameter error paths

Result:
Error messages now correctly identify the parameter with the wrong type and report its Jsonnet type name (e.g., "indent_array_in_object has to be a boolean, got number" instead of "gotclass sjsonnet.Val$Num").