### PR TITLE
fix: assert errors with type error for non-boolean conditions

### DIFF
--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -1152,7 +1152,13 @@ class Evaluator(
   }
 
   def visitAssert(e: AssertExpr)(implicit scope: ValScope): Val = {
-    if (!visitExpr(e.asserted.value).isInstanceOf[Val.True]) {
+    val cond = visitExpr(e.asserted.value)
+    cond match {
+      case _: Val.Bool => // ok
+      case _           =>
+        Error.fail("Expected boolean, got " + cond.value.prettyName, e.asserted.value.pos)
+    }
+    if (!cond.isInstanceOf[Val.True]) {
       e.asserted.msg match {
         case null => Error.fail("Assertion failed", e)
         case msg  =>
@@ -1726,7 +1732,13 @@ class Evaluator(
       var i = 0
       while (i < asserts.length) {
         val a = asserts(i)
-        if (!visitExpr(a.value)(newScope).isInstanceOf[Val.True]) {
+        val cond = visitExpr(a.value)(newScope)
+        cond match {
+          case _: Val.Bool => // ok
+          case _           =>
+            Error.fail("Expected boolean, got " + cond.value.prettyName, a.value.pos)
+        }
+        if (!cond.isInstanceOf[Val.True]) {
           a.msg match {
             case null => Error.fail("Assertion failed", a.value.pos)
             case msg  =>

--- a/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
+++ b/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
@@ -1107,5 +1107,15 @@ object EvaluatorTests extends TestSuite {
       eval("""std.manifestJson(1e100)""") ==> ujson.Str(expected1e100)
     }
 
+    test("assertBooleanTypeCheck") {
+      // non-boolean assert condition should error with type error
+      assert(evalErr("""assert "hello"; 42""").contains("Expected boolean, got string"))
+      assert(evalErr("""assert 0; 42""").contains("Expected boolean, got number"))
+      assert(evalErr("""assert null; 42""").contains("Expected boolean, got null"))
+      // boolean conditions should still work
+      eval("""assert true; 42""") ==> ujson.Num(42)
+      assert(evalErr("""assert false; 42""").contains("Assertion failed"))
+    }
+
   }
 }


### PR DESCRIPTION
Motivation:
`assert` statements produced misleading "Assertion failed" errors when the condition was a non-boolean value (e.g., string, number, null). go-jsonnet correctly reports a type error: "Expected boolean, got string". This applies to both standalone `assert` statements and object-level assertions.

Modification:
Added boolean type validation before checking assert truthiness in two locations in `Evaluator.scala`:
- `visitAssert` method (standalone assert)
- Object-level assert evaluation loop

When the condition is not a `Val.Bool`, the evaluator now raises "Expected boolean, got {type}" before evaluating truthiness.

Added tests for string, number, and null conditions, and verified boolean conditions still work correctly.

Result:
`assert "hello"; 42` now produces "Expected boolean, got string" instead of "Assertion failed", matching go-jsonnet behavior. `assert true; 42` still evaluates to 42 and `assert false; 42` still produces "Assertion failed".