### PR TITLE
fix: add word boundary check for in binary operator

### DIFF
--- a/sjsonnet/src/sjsonnet/Parser.scala
+++ b/sjsonnet/src/sjsonnet/Parser.scala
@@ -1065,7 +1065,6 @@ class Parser(
       ">>",
       "<=",
       ">=",
-      "in",
       "==",
       "!=",
       "&&",
@@ -1080,7 +1079,7 @@ class Parser(
       "&",
       "^",
       "|"
-    )
+    ) | ("in" ~~ break)
   ).!
 
   def document[$: P]: P[(Expr, FileScope)] = P(expr ~ Pass(fileScope) ~ End)

--- a/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
+++ b/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
@@ -1107,5 +1107,15 @@ object EvaluatorTests extends TestSuite {
       eval("""std.manifestJson(1e100)""") ==> ujson.Str(expected1e100)
     }
 
+    test("inOperatorWordBoundary") {
+      // `in` still works as a binary operator
+      eval(""" "a" in {a: 1} """) ==> ujson.True
+      eval(""" "b" in {a: 1} """) ==> ujson.False
+      // identifiers starting with "in" must not be parsed as the `in` operator
+      eval("""local index = 42; index""") ==> ujson.Num(42)
+      eval("""local information = [1, 2, 3]; information""") ==> ujson.Arr(1, 2, 3)
+      eval("""local input = {a: 1}; input""") ==> ujson.Obj("a" -> ujson.Num(1))
+    }
+
   }
 }


### PR DESCRIPTION
Motivation:
The `binaryop` parser rule matched the `in` keyword via `StringIn` without a word boundary check, potentially misparsing identifiers starting with "in" (e.g., `index`, `information`) as the `in` operator. All other keywords in the parser (`for`, `then`, `else`, `local`) use `~~ break` for word boundaries.

Modification:
- Extracted `"in"` from `StringIn` in the `binaryop` rule
- Added `| ("in" ~~ break)` with word boundary check, matching the pattern used elsewhere in the parser
- Added directional tests for `in` operator functionality and identifier parsing

Result:
The `in` operator now correctly requires word boundaries, preventing identifiers like `information` from being misparsed. `"a" in {a: 1}` still works correctly.