### PR TITLE
fix: strip Java WARNING lines from golden files and regenerate error goldens

### DIFF
--- a/sjsonnet/test/resources/refresh_golden_outputs.sh
+++ b/sjsonnet/test/resources/refresh_golden_outputs.sh
@@ -28,6 +28,8 @@ if [ $# -gt 0 ]; then
     fi
 
     java $JAVA_OPTS -jar "$SJSONNET" $PARAMS $EXT_PARAMS $TLA_PARAMS "$f" > "$f.golden" 2>&1 || true
+    # Strip Java runtime WARNING lines (e.g. sun.misc.Unsafe deprecation)
+    sed -i '' '/^WARNING:/d' "$f.golden"
   done
   popd || exit 1
   echo "Done refreshing specified golden outputs."
@@ -52,6 +54,8 @@ for f in *.jsonnet; do
   fi
 
   java $JAVA_OPTS -jar "$SJSONNET" $PARAMS $EXT_PARAMS $TLA_PARAMS "$f" > "$f.golden" 2>&1 || true
+  # Strip Java runtime WARNING lines (e.g. sun.misc.Unsafe deprecation)
+  sed -i '' '/^WARNING:/d' "$f.golden"
 done
 popd || exit 1
 
@@ -64,6 +68,8 @@ for f in *.jsonnet; do
 
   echo "  Processing file: $f"
   java $JAVA_OPTS -jar "$SJSONNET" $PARAMS "$f" > "$f.golden" 2>&1 || true
+  # Strip Java runtime WARNING lines (e.g. sun.misc.Unsafe deprecation)
+  sed -i '' '/^WARNING:/d' "$f.golden"
 done
 popd || exit 1
 
@@ -76,6 +82,8 @@ for f in *.jsonnet; do
 
   echo "  Processing file: $f"
   java $JAVA_OPTS -jar "$SJSONNET" $PARAMS "$f" > "$f.golden" 2>&1 || true
+  # Strip Java runtime WARNING lines (e.g. sun.misc.Unsafe deprecation)
+  sed -i '' '/^WARNING:/d' "$f.golden"
 done
 popd || exit 1
 

--- a/sync_test_suites.sh
+++ b/sync_test_suites.sh
@@ -242,6 +242,13 @@ sync_test_files() {
     if [ ! -e "$dest_file" ]; then
       cp -r "$src_file" "$dest_file"
       new_golden=$((new_golden + 1))
+      # If the new golden is an error output, regenerate with sjsonnet's error format
+      if ! is_success_golden "$src_file"; then
+        local jsonnet_file="$target_dir/${stem}.jsonnet"
+        if [ -f "$jsonnet_file" ]; then
+          echo "$jsonnet_file" >> "$GOLDEN_REFRESH_FILES"
+        fi
+      fi
     elif ! diff -q "$src_file" "$dest_file" > /dev/null 2>&1; then
       local src_ok=0 dest_ok=0
       is_success_golden "$src_file" && src_ok=1
@@ -301,6 +308,13 @@ sync_test_files() {
       if [ ! -e "$dest_file" ]; then
         cp -r "$src_entry" "$dest_file"
         new_golden=$((new_golden + 1))
+        # If the new golden is an error output, regenerate with sjsonnet's error format
+        if ! is_success_golden "$src_entry"; then
+          local local_jsonnet="$target_dir/${stem}.jsonnet"
+          if [ -f "$local_jsonnet" ]; then
+            echo "$local_jsonnet" >> "$GOLDEN_REFRESH_FILES"
+          fi
+        fi
       elif ! diff -q "$src_entry" "$dest_file" > /dev/null 2>&1; then
         local src_ok=0 dest_ok=0
         is_success_golden "$src_entry" && src_ok=1


### PR DESCRIPTION
## Motivation

JDK 21+ emits `sun.misc.Unsafe::objectFieldOffset` deprecation warnings to stderr. `refresh_golden_outputs.sh` captures stderr via `2>&1`, contaminating golden files with `WARNING:` lines that cause test failures on different JDK versions. Additionally, `sync_test_suites.sh` copies upstream error goldens as-is, but go-jsonnet's error format (`RUNTIME ERROR:`) differs from sjsonnet's (`sjsonnet.Error:`), causing mismatches for newly synced tests.

## Modification

- Add `sed -i '' '/^WARNING:/d'` after each golden generation in `refresh_golden_outputs.sh` (all 3 loops: specific-files, test_suite, go_test_suite/new_test_suite)
- Add error golden auto-regeneration in `sync_test_suites.sh`: when a new upstream error test is copied, detect it via `is_success_golden` and queue it for regeneration with sjsonnet's own error format

## Result

Golden files are clean of JDK version-specific warnings. New upstream error tests automatically get sjsonnet-format goldens on sync, eliminating manual regeneration steps.

## Test plan
- [x] `refresh_golden_outputs.sh` produces clean goldens (no `WARNING:` lines)
- [x] `sync_test_suites.sh` auto-regenerates error goldens for new upstream tests
- [x] Existing success goldens unchanged (only error goldens regenerated)
- [x] All existing tests pass after refresh