### PR TITLE
fix: add cycle detection to TOML renderer (manifestTomlEx)

### DIFF
--- a/sjsonnet/src/sjsonnet/stdlib/ManifestModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/ManifestModule.scala
@@ -178,93 +178,109 @@ object ManifestModule extends AbstractFunctionModule {
         v: Val.Obj,
         cumulatedIndent: String,
         indent: String,
-        path: mutable.ArrayBuffer[String])(implicit ev: EvalScope): Boolean = {
-      val keys = v.sortedVisibleKeyNames
-      if (keys.length == 0) {
-        return false
-      }
-
-      // Resolve each field once and cache the result: the value is needed twice
-      // (to classify scalars vs sections, then to render). Iterating `keys` directly
-      // also skips the binary search that mapped `visibleKeyNames` back into `keys`.
-      val resolved = new Array[Val](keys.length)
-      val sectionFlags = new Array[Boolean](keys.length)
-      var keyIdx = 0
-      while (keyIdx < keys.length) {
-        val r = v.value(keys(keyIdx), v.pos)(ev)
-        resolved(keyIdx) = r
-        sectionFlags(keyIdx) = isSection(r)
-        keyIdx += 1
-      }
-
-      val renderer = new TomlRenderer(out, cumulatedIndent, indent)
-      var hasSimpleKV = false
-      keyIdx = 0
-      while (keyIdx < keys.length) {
-        if (!sectionFlags(keyIdx)) {
-          hasSimpleKV = true
-          out.write(cumulatedIndent)
-          TomlRenderer.writeEscapedKey(out, keys(keyIdx))
-          out.write(" = ")
-          Materializer.apply0(resolved(keyIdx), renderer)(ev)
+        path: mutable.ArrayBuffer[String],
+        depth: Int,
+        visited: java.util.IdentityHashMap[Val.Obj, java.lang.Boolean])(implicit
+        ev: EvalScope): Boolean = {
+      val maxDepth = ev.settings.maxMaterializeDepth
+      if (depth >= maxDepth)
+        Error.fail("Stackoverflow while materializing, possibly due to recursive value", v.pos)
+      if (visited.put(v, java.lang.Boolean.TRUE) ne null)
+        Error.fail("Stackoverflow while materializing, possibly due to recursive value", v.pos)
+      try {
+        val keys = v.sortedVisibleKeyNames
+        if (keys.length == 0) {
+          return false
         }
-        keyIdx += 1
-      }
-      // childIndent depends only on cumulatedIndent + indent, so compute it once
-      // instead of per section iteration.
-      val childIndent = cumulatedIndent + indent
-      var lastEndedWithNewline = hasSimpleKV
-      keyIdx = 0
-      while (keyIdx < keys.length) {
-        if (sectionFlags(keyIdx)) {
-          val k = keys(keyIdx)
-          val v0 = resolved(keyIdx)
-          path += k
-          v0 match {
-            case arr: Val.Arr =>
-              var i = 0
-              while (i < arr.length) {
-                if (i == 0) {
-                  if (lastEndedWithNewline) out.write('\n')
-                  else out.write("\n\n")
-                } else {
+
+        // Resolve each field once and cache the result: the value is needed twice
+        // (to classify scalars vs sections, then to render). Iterating `keys` directly
+        // also skips the binary search that mapped `visibleKeyNames` back into `keys`.
+        val resolved = new Array[Val](keys.length)
+        val sectionFlags = new Array[Boolean](keys.length)
+        var keyIdx = 0
+        while (keyIdx < keys.length) {
+          val r = v.value(keys(keyIdx), v.pos)(ev)
+          resolved(keyIdx) = r
+          sectionFlags(keyIdx) = isSection(r)
+          keyIdx += 1
+        }
+
+        val renderer = new TomlRenderer(out, cumulatedIndent, indent)
+        var hasSimpleKV = false
+        keyIdx = 0
+        while (keyIdx < keys.length) {
+          if (!sectionFlags(keyIdx)) {
+            hasSimpleKV = true
+            out.write(cumulatedIndent)
+            TomlRenderer.writeEscapedKey(out, keys(keyIdx))
+            out.write(" = ")
+            Materializer.apply0(resolved(keyIdx), renderer)(ev)
+          }
+          keyIdx += 1
+        }
+        // childIndent depends only on cumulatedIndent + indent, so compute it once
+        // instead of per section iteration.
+        val childIndent = cumulatedIndent + indent
+        var lastEndedWithNewline = hasSimpleKV
+        keyIdx = 0
+        while (keyIdx < keys.length) {
+          if (sectionFlags(keyIdx)) {
+            val k = keys(keyIdx)
+            val v0 = resolved(keyIdx)
+            path += k
+            v0 match {
+              case arr: Val.Arr =>
+                var i = 0
+                while (i < arr.length) {
+                  if (i == 0) {
+                    if (lastEndedWithNewline) out.write('\n')
+                    else out.write("\n\n")
+                  } else {
+                    out.write('\n')
+                  }
+                  out.write(cumulatedIndent)
+                  renderTableArrayHeader(out, path)
                   out.write('\n')
+                  renderTableInternal(
+                    out,
+                    arr.value(i).asObj,
+                    childIndent,
+                    indent,
+                    path,
+                    depth + 1,
+                    visited
+                  )
+                  i += 1
                 }
+                lastEndedWithNewline = true
+              case obj: Val.Obj =>
+                if (lastEndedWithNewline) out.write('\n')
+                else out.write("\n\n")
                 out.write(cumulatedIndent)
-                renderTableArrayHeader(out, path)
-                out.write('\n')
-                renderTableInternal(
+                renderTableHeader(out, path)
+                val childHasContent = obj.sortedVisibleKeyNames.nonEmpty
+                if (childHasContent) out.write('\n')
+                lastEndedWithNewline = renderTableInternal(
                   out,
-                  arr.value(i).asObj,
+                  obj,
                   childIndent,
                   indent,
-                  path
+                  path,
+                  depth + 1,
+                  visited
                 )
-                i += 1
-              }
-              lastEndedWithNewline = true
-            case obj: Val.Obj =>
-              if (lastEndedWithNewline) out.write('\n')
-              else out.write("\n\n")
-              out.write(cumulatedIndent)
-              renderTableHeader(out, path)
-              val childHasContent = obj.sortedVisibleKeyNames.nonEmpty
-              if (childHasContent) out.write('\n')
-              lastEndedWithNewline = renderTableInternal(
-                out,
-                obj,
-                childIndent,
-                indent,
-                path
-              )
-            case _ =>
-              ()
+              case _ =>
+                ()
+            }
+            path.remove(path.length - 1)
           }
-          path.remove(path.length - 1)
+          keyIdx += 1
         }
-        keyIdx += 1
+        keys.nonEmpty
+      } finally {
+        visited.remove(v)
       }
-      keys.nonEmpty
     }
 
     private def renderTableHeader(out: StringBuilderWriter, path: mutable.ArrayBuffer[String]) = {
@@ -288,7 +304,7 @@ object ManifestModule extends AbstractFunctionModule {
       out
     }
 
-    def evalRhs(v: Eval, indent: Eval, ev: EvalScope, pos: Position): Val = {
+    def evalRhs(v: Eval, indent: Eval, ev: EvalScope, pos: Position): Val = try {
       // Pre-size at 1 KiB to skip the first ~6 doublings (16→1024) for typical TOML
       // outputs without overcommitting memory on small ones.
       val out = new StringBuilderWriter(1024)
@@ -297,9 +313,16 @@ object ManifestModule extends AbstractFunctionModule {
         v.value.asObj,
         "",
         indent.value.asString,
-        new mutable.ArrayBuffer[String](8)
+        new mutable.ArrayBuffer[String](8),
+        depth = 0,
+        visited = new java.util.IdentityHashMap[Val.Obj, java.lang.Boolean]()
       )(ev)
       Val.Str(pos, out.toString.stripTrailing())
+    } catch {
+      case _: StackOverflowError =>
+        Error.fail("Stackoverflow while materializing, possibly due to recursive value", pos)(ev)
+      case _: OutOfMemoryError =>
+        Error.fail("Out of memory while materializing, possibly due to recursive value", pos)(ev)
     }
   }
 

--- a/sjsonnet/test/resources/go_test_suite/builtinManifestJsonEx_cyclic.jsonnet
+++ b/sjsonnet/test/resources/go_test_suite/builtinManifestJsonEx_cyclic.jsonnet
@@ -1,0 +1,1 @@
+std.manifestJsonEx({a: $}, "  ", "\n", ": ")

--- a/sjsonnet/test/resources/go_test_suite/builtinManifestJsonEx_cyclic.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/builtinManifestJsonEx_cyclic.jsonnet.golden
@@ -1,0 +1,3 @@
+sjsonnet.Error: Stackoverflow while materializing, possibly due to recursive value
+    at [std.manifestJsonEx].(builtinManifestJsonEx_cyclic.jsonnet:1:20)
+    at [<root>].(builtinManifestJsonEx_cyclic.jsonnet:1:19)

--- a/sjsonnet/test/resources/go_test_suite/builtin_manifestTomlEx_cyclic.jsonnet
+++ b/sjsonnet/test/resources/go_test_suite/builtin_manifestTomlEx_cyclic.jsonnet
@@ -1,0 +1,1 @@
+std.manifestTomlEx({a: $}, "  ")

--- a/sjsonnet/test/resources/go_test_suite/builtin_manifestTomlEx_cyclic.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/builtin_manifestTomlEx_cyclic.jsonnet.golden
@@ -1,0 +1,3 @@
+sjsonnet.Error: Stackoverflow while materializing, possibly due to recursive value
+    at [std.manifestTomlEx].(builtin_manifestTomlEx_cyclic.jsonnet:1:20)
+    at [<root>].(builtin_manifestTomlEx_cyclic.jsonnet:1:19)

--- a/sjsonnet/test/resources/go_test_suite/builtin_manifestYamlDoc_cyclic.jsonnet
+++ b/sjsonnet/test/resources/go_test_suite/builtin_manifestYamlDoc_cyclic.jsonnet
@@ -1,0 +1,1 @@
+std.manifestYamlDoc({a: $})

--- a/sjsonnet/test/resources/go_test_suite/builtin_manifestYamlDoc_cyclic.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/builtin_manifestYamlDoc_cyclic.jsonnet.golden
@@ -1,0 +1,3 @@
+sjsonnet.Error: Stackoverflow while materializing, possibly due to recursive value
+    at [std.manifestYamlDoc].(builtin_manifestYamlDoc_cyclic.jsonnet:1:21)
+    at [<root>].(builtin_manifestYamlDoc_cyclic.jsonnet:1:20)


### PR DESCRIPTION
## Motivation

`std.manifestTomlEx` has its own recursive traversal in `renderTableInternal` that bypassed the `Materializer`'s `IdentityHashMap`-based cycle detection. Cyclic objects like `{a: $}` caused OutOfMemoryError instead of the clean "Stackoverflow while materializing" error that JSON and YAML renderers produce.

## Modification

- Add `depth: Int` and `visited: IdentityHashMap[Val.Obj, Boolean]` parameters to `renderTableInternal`, matching the pattern in `Materializer.MaterializeContext`
- Check depth against `maxMaterializeDepth` and detect revisited objects at method entry; remove from visited set in `finally` block (backtracking)
- Wrap `evalRhs` in try-catch for `StackOverflowError`/`OutOfMemoryError`
- Add 3 cyclic reference tests: `manifestJsonEx`, `manifestTomlEx`, `manifestYamlDoc` — all using `{a: $}` pattern

## Result

Cyclic objects now produce "Stackoverflow while materializing" error instead of OOM, consistent with JSON and YAML renderers.

| Implementation | Result | Detection mechanism |
|---|---|---|
| go-jsonnet v0.22.0 | Clean error | Depth limit in TOML renderer |
| jrsonnet v0.5.0-pre99 | Clean error | Stack overflow detection |
| C++ jsonnet | **HANGS** | No cycle detection — same bug as sjsonnet pre-fix |
| sjsonnet (before) | OOM crash | No cycle detection in TOML renderer |
| sjsonnet (after) | Clean error | IdentityHashMap + depth limit |

## Test plan
- [x] `std.manifestTomlEx({a: $}, "  ")` produces clean error instead of OOM
- [x] `std.manifestJsonEx({a: $}, ...)` continues to work (already had detection)
- [x] `std.manifestYamlDoc({a: $})` continues to work (already had detection)
- [x] All existing TOML tests pass (array, null, standard cases)
- [x] Error message matches JSON/YAML renderer format