### PR TITLE
fix: reject function equality comparisons with clear error

### DIFF
--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -2149,10 +2149,16 @@ class Evaluator(
             val ye = y.eval(i)
             // Skip forcing when Eval references match (shared backing elements)
             if (!(xe eq ye)) {
-              if (!equal(xe.value, ye.value)) return false
+              val xv = xe.value
+              val yv = ye.value
+              if (xv.isInstanceOf[Val.Func] && yv.isInstanceOf[Val.Func])
+                Error.fail("cannot test equality of functions")
+              if (!equal(xv, yv)) return false
             } else if (!xe.isInstanceOf[Val]) {
               // Invariant: Eval = Val | Lazy. Val is pure; Lazy may error on force.
-              xe.value // Force shared Lazy thunks for error semantics
+              val xv = xe.value // Force shared Lazy thunks for error semantics
+              if (xv.isInstanceOf[Val.Func])
+                Error.fail("cannot test equality of functions")
             }
             i += 1
           }
@@ -2174,12 +2180,17 @@ class Evaluator(
             if (!y.containsVisibleKey(k)) return false
             val v1 = x.value(k, emptyMaterializeFileScopePos)
             val v2 = y.value(k, emptyMaterializeFileScopePos)
+            if (v1.isInstanceOf[Val.Func] && v2.isInstanceOf[Val.Func])
+              Error.fail("cannot test equality of functions")
             if (!equal(v1, v2)) return false
             i += 1
           }
           true
         case _ => false
       }
+    case _: Val.Func =>
+      if (y.isInstanceOf[Val.Func]) Error.fail("cannot test equality of functions")
+      false
     case _ => false
   })
 }


### PR DESCRIPTION
## Motivation

Jsonnet semantics dictate that functions cannot be compared for equality. sjsonnet silently returned `false` for `f == g` (two functions), diverging from go-jsonnet, C++ jsonnet, and jrsonnet which all raise runtime errors. This silent divergence masked bugs where users accidentally compared functions instead of their return values.

## Modification

- **Evaluator.scala**: Add `Val.Func` checks in `equal()` for object field comparison (lazy-evaluated fields), array element comparison, and top-level scalar comparison
- Raise `Error.fail("cannot test equality of functions")` when both operands are `Val.Func` instances
- Handle asymmetric cases (func == non-func) by returning false after checking the non-func operand

## Result

`function(x) x == function(x) x` now raises `sjsonnet.Error: cannot test equality of functions`, matching go-jsonnet, C++ jsonnet, and jrsonnet behavior.

| Implementation | Result | Error message |
|---|---|---|
| go-jsonnet v0.22.0 | Error | `RUNTIME ERROR: Cannot test equality of functions` |
| C++ jsonnet | Error | `RUNTIME ERROR: cannot test equality of functions` |
| jrsonnet v0.5.0-pre99 | Error | `runtime error: cannot test equality of functions` |
| sjsonnet (before) | Silent `false` | (no error, returns false) |
| sjsonnet (after) | Error | `sjsonnet.Error: cannot test equality of functions` |

## Test plan
- [x] `function(x) x == function(x) x` raises error
- [x] `function(x) x != function(x) x` raises error
- [x] Function equality in arrays: `[f] == [g]` raises error
- [x] Function equality in objects: `{a: f} == {a: g}` raises error
- [x] Non-function comparisons unchanged: `1 == 2`, `"a" == "b"`, etc.
- [x] All existing tests pass