### PR TITLE
fix: std.stripChars/lstripChars/rstripChars accept array parameter

### DIFF
--- a/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
@@ -426,12 +426,29 @@ object StringModule extends AbstractFunctionModule {
    *
    * Removes characters chars from the beginning and from the end of str.
    */
+  private def charsToString(charsVal: Val): String = charsVal match {
+    case s: Val.Str => s.str
+    case a: Val.Arr =>
+      val sb = new java.lang.StringBuilder
+      var i = 0
+      while (i < a.length) {
+        a.value(i) match {
+          case s: Val.Str if s.str.codePointCount(0, s.str.length) == 1 =>
+            sb.append(s.str)
+          case _ =>
+        }
+        i += 1
+      }
+      sb.toString
+    case other => Error.fail(s"expected string or array, got ${other.prettyName}")
+  }
+
   private object StripChars extends Val.Builtin2("stripChars", "str", "chars") {
     def evalRhs(str: Eval, chars: Eval, ev: EvalScope, pos: Position): Val = {
       val v = str.value
       val out = StripUtils.strip(
         v.asString,
-        chars.value.asString,
+        charsToString(chars.value),
         left = true,
         right = true
       )
@@ -454,7 +471,7 @@ object StringModule extends AbstractFunctionModule {
       val v = str.value
       val out = StripUtils.strip(
         v.asString,
-        chars.value.asString,
+        charsToString(chars.value),
         left = true,
         right = false
       )
@@ -477,7 +494,7 @@ object StringModule extends AbstractFunctionModule {
       val v = str.value
       val out = StripUtils.strip(
         v.asString,
-        chars.value.asString,
+        charsToString(chars.value),
         left = false,
         right = true
       )


### PR DESCRIPTION
## Motivation

`std.stripChars`, `std.lstripChars`, and `std.rstripChars` rejected arrays as the `chars` parameter, while go-jsonnet, jsonnet-cpp, and jrsonnet all accept arrays. When `chars` is an array, only single-character string elements are used for stripping; non-string elements and multi-character strings are silently ignored.

## Modification

Modified `std.stripChars`, `std.lstripChars`, and `std.rstripChars` in `Std.scala` to accept an array as the `chars` parameter. When `chars` is an array, filter to single-character string elements only and join them into the strip character set.

## Result

The three strip functions now match go-jsonnet behavior for array inputs.

| Test case | go-jsonnet v0.22.0 | sjsonnet (before) | sjsonnet (after) |
|-----------|-------------------|-------------------|-----------------|
| `std.lstripChars("forward", [1, "f", [], "o", "d", "for"])` | `"rward"` | error | `"rward"` |
| `std.rstripChars("cool just cool", ["o", "l", 12.2323443])` | `"cool just c"` | error | `"cool just c"` |
| `std.stripChars("UwU Lel Stosh", ["h", "U", "s", {}, [], null, "w", [1,2,3]])` | `" Lel Sto"` | error | `" Lel Sto"` |
| `std.stripChars("abchelloabc", ["abc"])` | `"abchelloabc"` | error | `"abchelloabc"` |
| `std.stripChars("abchelloabc", ["a", "bc"])` | `"bchelloabc"` | error | `"bchelloabc"` |
| `std.stripChars("1hello1", [1])` | `"1hello1"` | error | `"1hello1"` |

## Test plan
- [x] All existing tests pass (48 unit + 15 file test groups)
- [x] jrsonnet golden test `builtin_strings_string.jsonnet` passes (15 test cases)
- [x] Verified against go-jsonnet v0.22.0, jsonnet-cpp v0.22.0, and jrsonnet v0.5.0-pre99