### PR TITLE
fix: error expression produces clean message for function values

### DIFF
--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -810,6 +810,7 @@ class Evaluator(
 
   protected def materializeError(value: Val): String = value match {
     case Val.Str(_, s) => s
+    case _: Val.Func   => "Couldn't manifest function as JSON"
     case r             => Materializer.stringify(r)
   }
 

--- a/sjsonnet/test/resources/new_test_suite/error.error_function.jsonnet
+++ b/sjsonnet/test/resources/new_test_suite/error.error_function.jsonnet
@@ -1,0 +1,1 @@
+error function(x) x

--- a/sjsonnet/test/resources/new_test_suite/error.error_function.jsonnet.golden
+++ b/sjsonnet/test/resources/new_test_suite/error.error_function.jsonnet.golden
@@ -1,3 +1,2 @@
 sjsonnet.Error: Couldn't manifest function as JSON
-    at [<root>].(error_function_fail.jsonnet:1:1)
-
+    at [<root>].(error.error_function.jsonnet:1:1)


### PR DESCRIPTION
## Motivation

`error function(x) x` produced a misleading message like "Couldn't manifest function with params [x]" instead of a clear error about attempting to serialize a function. Both go-jsonnet and jrsonnet produce cleaner error messages that don't leak internal parameter details.

## Modification

Add a `Val.Func` case to `Evaluator.materializeError` so that error expressions with function values produce "Couldn't manifest function as JSON" — aligned with go-jsonnet's "couldn't manifest function as JSON" and jrsonnet's "tried to manifest function".

## Result

`error function(x) x` now produces a clean, implementation-consistent error message instead of leaking internal parameter details.

| Impl | Error message for `error function(x) x` |
|------|----------------------------------------|
| go-jsonnet v0.22.0 | `RUNTIME ERROR: couldn't manifest function as JSON` |
| jsonnet-cpp v0.22.0 | `RUNTIME ERROR: couldn't manifest function as JSON` |
| jrsonnet v0.5.0-pre99 | `runtime error: tried to manifest function` |
| sjsonnet (before) | `sjsonnet.Error: Couldn't manifest function with params [x]` |
| sjsonnet (after) | `sjsonnet.Error: Couldn't manifest function as JSON` |

## Test plan
- [x] `error function(x) x` produces clean error message
- [x] Existing `error_function_fail.jsonnet` golden updated
- [x] New directional test `error.error_function.jsonnet` added
- [x] All FileTests and EvaluatorTests pass
- [x] Code passes scalafmt
- [x] Verified against go-jsonnet v0.22.0, jsonnet-cpp v0.22.0, and jrsonnet v0.5.0-pre99