### PR TITLE
perf: propagate ASCII-safety from format string LHS to scanFormat

### DIFF
--- a/sjsonnet/src/sjsonnet/Format.scala
+++ b/sjsonnet/src/sjsonnet/Format.scala
@@ -309,7 +309,7 @@ object Format {
    * large format strings (e.g. 605KB large_string_template with 256 interpolations), this avoids
    * the overhead of running parser combinators over hundreds of KB of literal text.
    */
-  private def scanFormat(s: String): RuntimeFormat = {
+  private def scanFormat(s: String, sourceAsciiSafe: Boolean = false): RuntimeFormat = {
     val len = s.length
     val specsBuilder = new scala.collection.mutable.ArrayBuilder.ofLong
     var labelsBuilder: java.util.ArrayList[String] = null
@@ -329,7 +329,7 @@ object Format {
     val leadingStart = 0
     val leadingEnd = if (pos < 0) len else pos
     staticChars += leadingEnd - leadingStart
-    if (allLiteralsAscii && !isAsciiJsonSafeRange(s, leadingStart, leadingEnd))
+    if (!sourceAsciiSafe && allLiteralsAscii && !isAsciiJsonSafeRange(s, leadingStart, leadingEnd))
       allLiteralsAscii = false
 
     while (pos >= 0 && pos < len) {
@@ -470,7 +470,7 @@ object Format {
       litStartsBuilder += litStart
       litEndsBuilder += litEnd
       staticChars += litEnd - litStart
-      if (allLiteralsAscii && !isAsciiJsonSafeRange(s, litStart, litEnd))
+      if (!sourceAsciiSafe && allLiteralsAscii && !isAsciiJsonSafeRange(s, litStart, litEnd))
         allLiteralsAscii = false
 
       pos = nextPct
@@ -1136,11 +1136,12 @@ object Format {
    * instance, bypassing [[FormatCache]] since each literal format string is unique and already
    * cached within the AST.
    */
-  class PartialApplyFmt(fmt: String) extends Val.Builtin1("format", "values") {
+  class PartialApplyFmt(fmt: String, sourceAsciiSafe: Boolean = false)
+      extends Val.Builtin1("format", "values") {
     // Pre-parse the format string at construction time (during static optimization).
     // Uses the hand-written scanner instead of fastparse for faster parsing of large format strings.
     // Each PartialApplyFmt instance caches its own parsed format, so no external cache needed.
-    private val parsed = scanFormat(fmt)
+    private val parsed = scanFormat(fmt, sourceAsciiSafe)
     def evalRhs(values0: Eval, ev: EvalScope, pos: Position): Val =
       format(parsed, values0.value, pos)(ev)
   }

--- a/sjsonnet/src/sjsonnet/StaticOptimizer.scala
+++ b/sjsonnet/src/sjsonnet/StaticOptimizer.scala
@@ -59,16 +59,22 @@ class StaticOptimizer(
         InSuper(pos, lhs, selfIdx)
       case b2 @ BinaryOp(pos, lhs: Val.Str, BinaryOp.OP_%, rhs) =>
         try {
+          val asciiSafe = lhs.isInstanceOf[Val.AsciiSafeStr]
           rhs match {
             case r: Val =>
-              val partial = new Format.PartialApplyFmt(lhs.str)
+              val partial = new Format.PartialApplyFmt(lhs.str, asciiSafe)
               try partial.evalRhs(r, ev, pos).asInstanceOf[Expr]
               catch {
                 case _: Exception =>
                   ApplyBuiltin1(pos, partial, rhs, tailstrict = false)
               }
             case _ =>
-              ApplyBuiltin1(pos, new Format.PartialApplyFmt(lhs.str), rhs, tailstrict = false)
+              ApplyBuiltin1(
+                pos,
+                new Format.PartialApplyFmt(lhs.str, asciiSafe),
+                rhs,
+                tailstrict = false
+              )
           }
         } catch { case _: Exception => b2 }
 


### PR DESCRIPTION
## Motivation

`scanFormat` checks every literal segment of a format string with `isAsciiJsonSafeRange` to decide whether the final format result can stay ASCII-safe. When the `%` LHS is already a `Val.AsciiSafeStr`, those literal segments are known to be JSON-safe ASCII, so the repeated range checks are redundant.

## Modification

- Add `sourceAsciiSafe: Boolean = false` to `Format.scanFormat`.
- Skip literal `isAsciiJsonSafeRange` checks only when the format source is already ASCII-safe.
- Thread the flag through `Format.PartialApplyFmt`.
- Detect `Val.AsciiSafeStr` LHS in `StaticOptimizer` and pass the flag for `%` formatting.

## Result

Behavior is unchanged. The optimization removes redundant literal checks in statically optimized ASCII-safe format strings.

Local validation:

- `./mill 'sjsonnet.jvm[3.3.7]'.test` -> `143/143, SUCCESS`

Benchmark evidence from the original PR run:

| Benchmark | master (ms/op) | PR #983 (ms/op) | Delta |
| --- | ---: | ---: | ---: |
| `repeat_format` | `0.147 ± 0.024` | `0.133 ± 0.001` | `-9.5%` |
| `assertions` | `0.188 ± 0.010` | `0.188 ± 0.002` | `0%` |
| `split_resolve` | `0.150 ± 0.009` | `0.146 ± 0.001` | `-2.7%` |
| `hash` | `1.568 ± 0.061` | `1.544 ± 0.120` | `-1.5%` |

## Risk

Low. The fast path is gated by `Val.AsciiSafeStr`; non-ASCII-safe format strings keep the previous literal range checks.