### PR TITLE
perf: defer stdlib and Val singleton construction for faster startup

### DIFF
--- a/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMainBase.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMainBase.scala
@@ -85,7 +85,7 @@ object SjsonnetMainBase {
       wd: os.Path,
       allowedInputs: Option[Set[os.Path]],
       importer: Option[Importer],
-      std: Val.Obj): Int =
+      std: => Val.Obj): Int =
     main0(
       args,
       parseCache,
@@ -108,7 +108,7 @@ object SjsonnetMainBase {
       wd: os.Path,
       allowedInputs: Option[Set[os.Path]] = None,
       importer: Option[Importer] = None,
-      std: Val.Obj = sjsonnet.stdlib.StdLibModule.Default.module,
+      std: => Val.Obj = sjsonnet.stdlib.StdLibModule.Default.module,
       jsonnetPathEnv: Option[String] = None): Int =
     main0(
       args,
@@ -133,7 +133,7 @@ object SjsonnetMainBase {
       wd: os.Path,
       allowedInputs: Option[Set[os.Path]],
       importer: Option[Importer],
-      std: Val.Obj,
+      std: => Val.Obj,
       jsonnetPathEnv: Option[String],
       rawOutputStream: OutputStream): Int = {
 
@@ -390,7 +390,7 @@ object SjsonnetMainBase {
       wd: os.Path,
       importer: Importer,
       warnLogger: Evaluator.Logger,
-      std: Val.Obj,
+      std: => Val.Obj,
       evaluatorOverride: Option[Evaluator] = None,
       debugStats: DebugStats = null,
       profileOpt: Option[String] = None,
@@ -445,7 +445,7 @@ object SjsonnetMainBase {
       settings = settings,
       storePos = (position: Position) => if (config.yamlDebug.value) currentPos = position else (),
       logger = warnLogger,
-      std = std,
+      stdParam = std,
       variableResolver = _ => None,
       debugStats = debugStats,
       formatCache = FormatCache.SharedDefault

--- a/sjsonnet/src-native/sjsonnet/SjsonnetMain.scala
+++ b/sjsonnet/src-native/sjsonnet/SjsonnetMain.scala
@@ -5,6 +5,9 @@ import scala.scalanative.libc.stdio
 
 object SjsonnetMain {
   def main(args: Array[String]): Unit = {
+    val stdLib = new sjsonnet.stdlib.StdLibModule(nativeFunctions =
+      Map.from(NativeGzip.functions ++ NativeRegex.functions)
+    )
     val exitCode = SjsonnetMainBase.main0(
       args,
       new DefaultParseCache,
@@ -14,9 +17,7 @@ object SjsonnetMain {
       os.pwd,
       None,
       None,
-      new sjsonnet.stdlib.StdLibModule(nativeFunctions =
-        Map.from(NativeGzip.functions ++ NativeRegex.functions)
-      ).module,
+      stdLib.module,
       None,
       new NativeOutputStream(stdio.stdout)
     )

--- a/sjsonnet/src/sjsonnet/Interpreter.scala
+++ b/sjsonnet/src/sjsonnet/Interpreter.scala
@@ -43,11 +43,13 @@ class Interpreter(
     settings: Settings,
     storePos: Position => Unit,
     logger: Evaluator.Logger,
-    std: Val.Obj,
+    stdParam: => Val.Obj,
     variableResolver: String => Option[Expr],
     val debugStats: DebugStats,
     formatCache: FormatCache
 ) { self =>
+
+  lazy val std: Val.Obj = stdParam
 
   def this(
       extVars: Map[String, String],
@@ -58,7 +60,7 @@ class Interpreter(
       settings: Settings = Settings.default,
       storePos: Position => Unit = null,
       logger: (Boolean, String) => Unit = null,
-      std: Val.Obj = sjsonnet.stdlib.StdLibModule.Default.module,
+      std: => Val.Obj = sjsonnet.stdlib.StdLibModule.Default.module,
       variableResolver: String => Option[Expr] = _ => None) =
     this(
       key => extVars.get(key).map(ExternalVariable.code),

--- a/sjsonnet/src/sjsonnet/StaticOptimizer.scala
+++ b/sjsonnet/src/sjsonnet/StaticOptimizer.scala
@@ -24,13 +24,14 @@ import ScopedExprTransform.*
 class StaticOptimizer(
     ev: EvalScope,
     variableResolver: String => Option[Expr],
-    std: Val.Obj,
+    stdParam: => Val.Obj,
     internedStrings: mutable.HashMap[String, String],
     internedStaticFieldSets: mutable.HashMap[
       Val.StaticObjectFieldSet,
       java.util.LinkedHashMap[String, java.lang.Boolean]
     ])
     extends ScopedExprTransform {
+  lazy val std: Val.Obj = stdParam
   def optimize(e: Expr): Expr = transform(e)
 
   override def transform(_e: Expr): Expr = {

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -255,10 +255,10 @@ object Val {
    * Shared singletons for runtime boolean results — avoids per-comparison allocation. WARNING:
    * These singletons have mutable `var pos` (inherited from Expr). Their `pos` must NEVER be
    * mutated. The evaluation model is single-threaded, but mutating shared singleton state would
-   * corrupt all subsequent uses.
+   * corrupt all subsequent uses. (Lazy to defer startup cost)
    */
-  val staticTrue: Bool = True(new Position(null, -1))
-  val staticFalse: Bool = False(new Position(null, -1))
+  lazy val staticTrue: Bool = True(new Position(null, -1))
+  lazy val staticFalse: Bool = False(new Position(null, -1))
 
   /**
    * Returns a shared singleton boolean. Use for runtime comparison results where position is not
@@ -271,10 +271,10 @@ object Val {
   /**
    * Pre-allocated pool of Val.Num for small non-negative integers 0–255. Used by Evaluator
    * arithmetic fast paths to avoid per-operation allocation. Position is synthetic — acceptable for
-   * intermediate runtime results.
+   * intermediate runtime results. (Lazy to defer startup cost)
    */
   private val numCacheSize = 256
-  private val numCache: Array[Num] = {
+  private lazy val numCache: Array[Num] = {
     val pos = new Position(null, -1)
     val arr = new Array[Num](numCacheSize)
     var i = 0
@@ -317,9 +317,9 @@ object Val {
 
   /**
    * Singleton null for runtime results where position is not meaningful. Safe in single-threaded
-   * evaluation. See staticTrue/staticFalse for rationale.
+   * evaluation. See staticTrue/staticFalse for rationale. (Lazy to defer startup cost)
    */
-  val staticNull: Val.Null = Val.Null(new Position(null, -1))
+  lazy val staticNull: Val.Null = Val.Null(new Position(null, -1))
 
   /**
    * Rope string: O(1) concatenation via inline tree nodes.

--- a/sjsonnet/src/sjsonnet/stdlib/StdLibModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/StdLibModule.scala
@@ -21,14 +21,14 @@ final class StdLibModule(
       nativeFunctions.getOrElse(name.value.asString, Val.Null(pos))
   }
 
-  // All functions including native and additional functions
-  val functions: Map[String, Val.Func] = allModuleFunctions ++
+  // All functions including native and additional functions (lazy to defer startup cost)
+  lazy val functions: Map[String, Val.Func] = allModuleFunctions ++
     additionalStdFunctions +
     ("native" -> nativeFunction) +
     ("trace" -> traceFunction) +
     ("extVar" -> extVarFunction)
 
-  val module: Val.Obj = Val.Obj.mk(
+  lazy val module: Val.Obj = Val.Obj.mk(
     null,
     functions.size + additionalStdMembers.size,
     functions.view.map { case (k, v) =>
@@ -52,8 +52,8 @@ final class StdLibModule(
  *   - [[https://jsonnet.org/ref/stdlib.html#math std.pi]]
  */
 object StdLibModule {
-  // Combine all functions from all modules
-  private val allModuleFunctions: Map[String, Val.Func] = (
+  // Combine all functions from all modules (lazy to defer startup cost)
+  private[stdlib] lazy val allModuleFunctions: Map[String, Val.Func] = (
     ArrayModule.functions ++
       StringModule.functions ++
       ObjectModule.functions ++
@@ -133,7 +133,7 @@ object StdLibModule {
   )
 
   /**
-   * The default standard library module instance
+   * The default standard library module instance (lazy to defer startup cost)
    */
-  val Default = new StdLibModule()
+  lazy val Default = new StdLibModule()
 }

--- a/sjsonnet/test/src-jvm/sjsonnet/Example.java
+++ b/sjsonnet/test/src-jvm/sjsonnet/Example.java
@@ -1,5 +1,6 @@
 package sjsonnet;
 
+import scala.Function0;
 import scala.collection.immutable.Map$;
 
 public class Example {
@@ -13,8 +14,13 @@ public class Example {
             os.package$.MODULE$.pwd(),
             scala.None$.empty(),
             scala.None$.empty(),
-            new sjsonnet.stdlib.StdLibModule(Map$.MODULE$.empty(), Map$.MODULE$.empty()).module(),
-            scala.None$.empty()
+            new Function0<Val.Obj>() {
+                public Val.Obj apply() {
+                    return new sjsonnet.stdlib.StdLibModule(Map$.MODULE$.empty(), Map$.MODULE$.empty()).module();
+                }
+            },
+            scala.None$.empty(),
+            null
         );
     }
 }


### PR DESCRIPTION
## Motivation

`StdLibModule` and several `Val` static singletons are initialized eagerly during startup. Simple programs that do not touch `std` still pay to build std function maps, the std module object, and the number singleton cache.

## Modification

- Make `Val.staticTrue`, `Val.staticFalse`, `Val.staticNull`, and `numCache` lazy.
- Make `StdLibModule.functions`, `module`, `allModuleFunctions`, and `Default` lazy.
- Change `Interpreter` and `StaticOptimizer` std inputs to by-name values that are cached in lazy vals.
- Thread the by-name std argument through `SjsonnetMainBase` and native main.
- Update the Java example to pass a `Function0[Val.Obj]`.

## Result

Startup can avoid constructing stdlib state until code actually accesses `std`.

Behavioral comparison:

| Behavior | sjsonnet before | sjsonnet after | go-jsonnet v0.22.0 | C++ jsonnet v0.22.0 | jrsonnet v0.5.0-pre99 |
| --- | --- | --- | --- | --- | --- |
| `std.length([1,2,3])` | `3` | `3` | `3` | `3` | `3` |
| Stdlib construction | eager | lazy until first std access | eager | eager | eager |

Local validation after rebasing onto current `upstream/master`:

- `./mill 'sjsonnet.jvm[2.13.18]'.test` -> `143/143, SUCCESS`
- `./mill 'sjsonnet.js[2.13.18]'.test` -> `Tests: 474, Passed: 474, Failed: 0`
- `./mill 'sjsonnet.native[2.13.18]'.test` -> `Tests: 487, Passed: 487, Failed: 0`
- `./mill 'sjsonnet.jvm[2.13.18]'.checkFormat`
- `./mill 'sjsonnet.js[2.13.18]'.checkFormat`
- `./mill 'sjsonnet.native[2.13.18]'.checkFormat`
- `./mill 'sjsonnet.wasm[2.13.18]'.checkFormat`
- `git diff --check upstream/master..HEAD`

## Risk

Medium. This changes initialization timing and the public Java-facing call shape for by-name std arguments. Existing JVM, JS, and Native tests pass after the rebase, and the updated Java example compiles through the JVM test target.
