### PR TITLE
perf: add post-link strip step for native binary

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -327,6 +327,14 @@ object sjsonnet extends VersionFileModule {
       )
     }
 
+    override def nativeLink = Task {
+      val linked = super.nativeLink()
+      val stripped = Task.ctx().dest / "out"
+      os.copy(linked.path, stripped)
+      os.proc("strip", stripped.toString).call()
+      PathRef(stripped)
+    }
+
     object test extends ScalaNativeTests with CrossTests {
       def releaseMode = ReleaseMode.Debug
       def nativeMultithreading = None


### PR DESCRIPTION
## Motivation

The Scala Native binary retains debug symbols in `__LINKEDIT` after linking, inflating the binary by ~2 MB without runtime benefit.

## Modification

Add a post-link `strip` step in `build.mill` that runs the system `strip` tool on the linked native binary.

## Result

Binary size reduced from 17.55 MB to 15.53 MB (-11.5%), with `__LINKEDIT` shrinking from 3.17 MB to 1.14 MB (-64%). No runtime performance impact — all benchmark results within measurement noise.

### Binary size

| Segment | Before | After | Delta |
|---------|-------:|------:|------:|
| **Total** | 17.55 MB | 15.53 MB | **-11.5%** |
| `__TEXT` | 12.98 MB | 13.00 MB | +0.1% |
| `__DATA_CONST` | 1.02 MB | 1.02 MB | 0% |
| `__DATA` | 390 KB | 390 KB | 0% |
| `__LINKEDIT` | 3.17 MB | 1.14 MB | **-64.0%** |

### Runtime benchmarks (hyperfine 1.20.0, macOS arm64, 15-30 runs, `--shell=none`)

| Benchmark | Before (ms) | After (ms) | Ratio |
|-----------|------------|-----------|-------|
| startup (`-e 1`) | 5.8 ± 0.6 | 5.4 ± 0.3 | 1.08× faster |
| stdlib.jsonnet | 13.7 ± 0.7 | 13.4 ± 0.5 | 1.02× faster |
| hash.jsonnet | 9.7 ± 0.6 | 10.0 ± 0.6 | 1.03× slower |
| bench.07.jsonnet | 5.8 ± 0.4 | 5.8 ± 0.3 | 1.00× |
| bench.09.jsonnet | 5.6 ± 0.6 | 6.2 ± 0.7 | 1.11× slower |
| realistic1.jsonnet | 11.7 ± 0.6 | 11.8 ± 0.7 | 1.01× slower |
| base64_stress.jsonnet | 6.3 ± 0.7 | 6.0 ± 0.5 | 1.06× faster |
| std fields eval | 5.1 ± 0.3 | 5.2 ± 0.5 | 1.01× slower |

All differences are within measurement noise (±3-10%). `strip` only removes symbol tables (`__LINKEDIT`), not executable code (`__TEXT`), so runtime performance is unaffected.

## Risk

Low. `strip` is a standard build step and does not affect runtime behavior. The only requirement is that the build environment provides the `strip` tool (available on all macOS and Linux systems).