### PR TITLE
perf(renderer): cache repeated long ASCII string value rendering

### DIFF
--- a/sjsonnet/src/sjsonnet/ByteRenderer.scala
+++ b/sjsonnet/src/sjsonnet/ByteRenderer.scala
@@ -33,6 +33,10 @@ class ByteRenderer(out: OutputStream = new java.io.ByteArrayOutputStream(), inde
   @inline private def isEmpty: Boolean = (emptyBits & (1L << depth)) == 0L
   @inline private def resetEmpty(): Unit = emptyBits &= ~(1L << depth)
 
+  private var stringValueCount = 0
+  private var stringValueCacheKeys: Array[String] = null
+  private var stringValueCacheBytes: Array[Array[Byte]] = null
+
   override def visitFloat64(d: Double, index: Int): OutputStream = {
     flushBuffer()
     renderDouble(d)
@@ -201,7 +205,7 @@ class ByteRenderer(out: OutputStream = new java.io.ByteArrayOutputStream(), inde
     (vt: @scala.annotation.switch) match {
       case 0 => // TAG_STR
         val s = v.asInstanceOf[Val.Str]
-        if (s.isInstanceOf[Val.AsciiSafeStr]) renderAsciiSafeString(s.str)
+        if (s.isInstanceOf[Val.AsciiSafeStr]) renderAsciiSafeValueString(s.str)
         else renderQuotedString(s.str)
       case 1 => // TAG_NUM
         renderDouble(v.asDouble)
@@ -313,6 +317,66 @@ class ByteRenderer(out: OutputStream = new java.io.ByteArrayOutputStream(), inde
     elemBuilder.append(':')
     elemBuilder.append(' ')
     materializeChild(childVal, matDepth, ctx)
+  }
+
+  private def renderAsciiSafeValueString(str: String): Unit = {
+    val len = str.length
+    if (
+      len < ByteRenderer.StringValueCacheMinLength || len > ByteRenderer.StringValueCacheMaxLength
+    ) {
+      renderAsciiSafeString(str)
+      return
+    }
+    stringValueCount += 1
+    if (stringValueCount <= ByteRenderer.StringValueCacheWarmupValues) {
+      renderAsciiSafeString(str)
+      return
+    }
+    var cacheKeys = stringValueCacheKeys
+    var cacheBytes = stringValueCacheBytes
+    if (cacheKeys == null) {
+      cacheKeys = new Array[String](ByteRenderer.StringValueCacheSize)
+      cacheBytes = new Array[Array[Byte]](ByteRenderer.StringValueCacheSize)
+      stringValueCacheKeys = cacheKeys
+      stringValueCacheBytes = cacheBytes
+    }
+    val slot = System.identityHashCode(str) & ByteRenderer.StringValueCacheMask
+    if (cacheKeys(slot) eq str) {
+      val bytes = cacheBytes(slot)
+      if (bytes != null) appendCachedValueBytes(bytes)
+      else {
+        val made = makeQuotedAsciiBytes(str)
+        cacheBytes(slot) = made
+        appendCachedValueBytes(made)
+      }
+    } else {
+      cacheKeys(slot) = str
+      cacheBytes(slot) = null
+      renderAsciiSafeString(str)
+    }
+  }
+
+  private def makeQuotedAsciiBytes(str: String): Array[Byte] = {
+    val len = str.length
+    val bytes = new Array[Byte](len + 2)
+    bytes(0) = '"'.toByte
+    Platform.copyAsciiStringToBytes(str, bytes, 1)
+    bytes(len + 1) = '"'.toByte
+    bytes
+  }
+
+  @inline private def appendCachedStringBytes(bytes: Array[Byte]): Unit = {
+    val len = bytes.length
+    elemBuilder.ensureLength(len)
+    System.arraycopy(bytes, 0, elemBuilder.arr, elemBuilder.length, len)
+    elemBuilder.length += len
+  }
+
+  @inline private def appendCachedValueBytes(bytes: Array[Byte]): Unit = {
+    if (bytes.length >= ByteRenderer.DirectCachedStringWriteMinLength) {
+      elemBuilder.writeOutToIfLongerThan(out, 0)
+      out.write(bytes)
+    } else appendCachedStringBytes(bytes)
   }
 
   /** Fused inline object rendering — bypasses visibleKeyNames and value() lookup. */
@@ -478,4 +542,13 @@ class ByteRenderer(out: OutputStream = new java.io.ByteArrayOutputStream(), inde
     elemBuilder.append(']')
     flushByteBuilder()
   }
+}
+
+object ByteRenderer {
+  private final val StringValueCacheWarmupValues = 4
+  private final val StringValueCacheMinLength = 256
+  private final val StringValueCacheMaxLength = 16384
+  private final val StringValueCacheSize = 32
+  private final val StringValueCacheMask = StringValueCacheSize - 1
+  private final val DirectCachedStringWriteMinLength = 1024
 }

--- a/sjsonnet/test/src/sjsonnet/RendererTests.scala
+++ b/sjsonnet/test/src/sjsonnet/RendererTests.scala
@@ -97,6 +97,32 @@ object RendererTests extends TestSuite {
       assert(out.size() < 15000)
     }
 
+    test("byteRendererRepeatedLongAsciiValues") {
+      val interpreter = new Interpreter(
+        Map(),
+        Map(),
+        DummyPath(),
+        Importer.empty,
+        parseCache = new DefaultParseCache
+      )
+      val value = interpreter.evaluate(
+        """local s = std.repeat("x", 2048);
+          |[s, s, s, s, s, s, s, s]""".stripMargin,
+        DummyPath("(memory)")
+      ) match {
+        case Right(v)  => v
+        case Left(err) => throw new Exception(Error.formatError(err))
+      }
+      val out = new ByteArrayOutputStream
+      interpreter.materialize(value, new ByteRenderer(out)) match {
+        case Left(err) => throw new Exception(Error.formatError(err))
+        case Right(_)  =>
+      }
+      val rendered = new String(out.toByteArray, java.nio.charset.StandardCharsets.UTF_8)
+      val elem = "\"" + ("x" * 2048) + "\""
+      rendered ==> "[" + Array.fill(8)(elem).mkString(", ") + "]"
+    }
+
     test("indentZero") {
       // indent=0 should produce newlines but no spaces
       ujson.transform(ujson.Arr(1, 2), new Renderer(indent = 0)).toString ==>


### PR DESCRIPTION
## Motivation

The byte renderer re-renders identical long ASCII string values on every occurrence. Programs that output the same long string many times (e.g. repeated base64-encoded values) pay the quote/copy cost repeatedly.

## Modification

- Add a renderer-local direct-mapped cache for repeated long ASCII **string values** (256–16384 chars, warmup after 4 renders).
- Use identity-based hash slots (`System.identityHashCode`) for O(1) cache lookup.
- Write cached large values (≥1024 bytes) directly to the output stream after flushing pending buffered bytes.
- Lazy allocation: cache arrays are null until first use.
- Add a renderer regression test for repeated long ASCII value output.

## Result

### Benchmarks (hyperfine 1.20.0, macOS arm64, native release binary, `-N --warmup 10-15 --runs 40-50`)

| Benchmark | Before (ms) | This PR (ms) | Delta |
|-----------|-----------:|------------:|------:|
| **base64** | 6.9 ± 0.5 | **6.0 ± 0.5** | **-13%** |
| **base64Decode** | 7.1 ± 0.6 | **6.2 ± 0.5** | **-13%** |
| realistic2 | 100.7 ± 5.1 | 103.3 ± 6.5 | 0% (noise) |
| gen_big_object | 10.5 ± 0.9 | 9.9 ± 3.1 | 0% (noise) |
| stdlib.jsonnet | 14.1 ± 1.0 | 14.7 ± 2.0 | 0% (noise) |
| repeated_keys | 7.5 ± 1.4 | 6.8 ± 2.1 | 0% (noise) |

No regressions on any benchmark.

## Risk

Low. Adds mutable renderer-local value cache with lazy allocation (zero overhead when unused). The cache uses identity checks, flushes pending buffered bytes before direct output, and the regression test covers repeated long ASCII value rendering.