### PR TITLE
fix(ci): prevent indefinite hang in native dependency resolution

### DIFF
--- a/.github/scripts/fix-build-config.sh
+++ b/.github/scripts/fix-build-config.sh
@@ -98,3 +98,11 @@ credentials ++= {
   else Nil
 }
 EOF
+
+# JVM network timeouts: prevent Coursier's HttpURLConnection from hanging
+# indefinitely on slow/unresponsive Maven mirrors. Default Java timeouts are
+# infinite — these convert hangs into timeout errors that Coursier can retry.
+cat >> .mill-jvm-opts << 'EOF'
+-Dsun.net.client.defaultConnectTimeout=15000
+-Dsun.net.client.defaultReadTimeout=30000
+EOF

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -57,5 +57,15 @@ jobs:
           sbt: 'true'
       - name: Check Formatting
         run: ./mill -j1 _.${{ matrix.lang }}[_].__.checkFormat
+      - name: Pre-resolve dependencies
+        run: |
+          for i in 1 2 3; do
+            if timeout 180 ./mill -j1 _.${{ matrix.lang }}[_].__.resolvedMvnDeps; then
+              exit 0
+            fi
+            echo "Pre-resolution attempt $i failed, retrying..."
+          done
+          echo "Pre-resolution failed after 3 attempts"
+          exit 1
       - name: Run mill tests for ${{ matrix.lang }}
         run: ./mill -j1 _.${{ matrix.lang }}[_].__.test


### PR DESCRIPTION
## Summary
- **Root cause**: Java's `HttpURLConnection` default timeouts are infinite (`0`). When Maven mirrors (GCS or JFrog) respond slowly, Coursier's HTTP requests hang forever during `resolvedMvnDeps.super.javalib.JavaModule` — Scala Native's javalib has hundreds of Maven artifacts.
- **Fix**: Add JVM network timeouts (15s connect, 30s read) to `.mill-jvm-opts` + pre-resolution step with 180s timeout and 3 retries before running tests.
- **Evidence**: PR #994 retry completed `resolvedMvnDeps` in 2s (cache warm) vs 361s+ hang (cache cold + slow mirror). PR #1002 hung for 421s+ at the same task.

## Test plan
- [ ] Verify `build-other` matrix jobs (js/wasm/native) pass on this PR
- [ ] Confirm pre-resolution step completes in ~2s when cache is warm
- [ ] Verify timeout triggers instead of infinite hang when mirror is slow