### PR TITLE
fix: std.length counts only required parameters for functions

### DIFF
--- a/sjsonnet/src/sjsonnet/Expr.scala
+++ b/sjsonnet/src/sjsonnet/Expr.scala
@@ -146,6 +146,15 @@ object Expr {
 
   final case class Params(names: Array[String], defaultExprs: Array[Expr]) {
     val paramMap: Map[String, Int] = names.zipWithIndex.toMap
+    val requiredParamsCount: Int = {
+      var count = 0
+      var i = 0
+      while (i < defaultExprs.length) {
+        if (defaultExprs(i) == null) count += 1
+        i += 1
+      }
+      count
+    }
     override def toString: String = s"Params(${arrStr(names)}, ${arrStr(defaultExprs)})"
   }
 

--- a/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
@@ -88,7 +88,7 @@ object StringModule extends AbstractFunctionModule {
             else s.codePointCount(0, s.length)
           case a: Val.Arr  => a.length
           case o: Val.Obj  => o.visibleKeyNames.length
-          case o: Val.Func => o.params.names.length
+          case o: Val.Func => o.params.requiredParamsCount
           case x           => Error.fail("Cannot get length of " + x.prettyName)
         }).toDouble
       )

--- a/sjsonnet/test/resources/new_test_suite/std_length_function_defaults.jsonnet
+++ b/sjsonnet/test/resources/new_test_suite/std_length_function_defaults.jsonnet
@@ -1,0 +1,12 @@
+// Test that std.length on functions counts only required (non-default) parameters
+{
+  no_params: std.length(function() 42),
+  one_required: std.length(function(a) a),
+  two_required: std.length(function(a, b) a + b),
+  one_req_one_default: std.length(function(a, b=1) a + b),
+  one_req_two_defaults: std.length(function(a, b=1, c=2) a + b + c),
+  all_defaults: std.length(function(a=1, b=2) a + b),
+  builtin_sort: std.length(std.sort),
+  builtin_map: std.length(std.map),
+  builtin_format: std.length(std.format),
+}

--- a/sjsonnet/test/resources/new_test_suite/std_length_function_defaults.jsonnet.golden
+++ b/sjsonnet/test/resources/new_test_suite/std_length_function_defaults.jsonnet.golden
@@ -1,0 +1,11 @@
+{
+   "all_defaults": 0,
+   "builtin_format": 2,
+   "builtin_map": 2,
+   "builtin_sort": 1,
+   "no_params": 0,
+   "one_req_one_default": 1,
+   "one_req_two_defaults": 1,
+   "one_required": 1,
+   "two_required": 2
+}


### PR DESCRIPTION
## Summary

- `std.length` on a function was counting all parameters including those with default values
- Both go-jsonnet v0.22.0 and jrsonnet v0.5.0-pre99 count only required (non-default) parameters
- This represents the minimum number of arguments needed to call the function

## Behavior Comparison

| Test Case | go-jsonnet v0.22.0 | jrsonnet v0.5.0-pre99 | sjsonnet (before) | sjsonnet (after) |
|-----------|-------------------|----------------------|-------------------|------------------|
| `std.length(function() 42)` | 0 | 0 | 0 | 0 |
| `std.length(function(a) a)` | 1 | 1 | 1 | 1 |
| `std.length(function(a, b) a+b)` | 2 | 2 | 2 | 2 |
| `std.length(function(a, b=1) a+b)` | **1** | **1** | **2** ❌ | **1** ✅ |
| `std.length(function(a, b=1, c=2) a+b+c)` | **1** | **1** | **3** ❌ | **1** ✅ |
| `std.length(function(a=1, b=2) a+b)` | **0** | **0** | **2** ❌ | **0** ✅ |
| `std.length(std.sort)` | **1** | **1** | **2** ❌ | **1** ✅ |
| `std.length(std.map)` | 2 | 2 | 2 | 2 |
| `std.length(std.format)` | 2 | 2 | 2 | 2 |

## Changes

- Add `requiredParamsCount` field to `Expr.Params` that counts parameters without default values
- Change `StringModule.Length` to use `requiredParamsCount` instead of `names.length` for functions
- Add directional test `std_length_function_defaults.jsonnet`

## Test plan

- [x] All 232 existing tests pass (test_suite, go_test_suite, new_test_suite)
- [x] New test `std_length_function_defaults.jsonnet` added with golden output from go-jsonnet
- [x] Output matches go-jsonnet v0.22.0 and jrsonnet v0.5.0-pre99 exactly