### PR TITLE
docs: add AGENTS.md entry point

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Agent Instructions
+
+This repository keeps agent-facing development guidance in [CLAUDE.md](CLAUDE.md).
+
+Before making changes, read and follow `CLAUDE.md`. If this file conflicts with
+`CLAUDE.md`, follow `CLAUDE.md` and update this file to keep the entry point in
+sync.


### PR DESCRIPTION
## Motivation

Codex and other AI agents look for `AGENTS.md` as the local instruction
entry point, but this repository keeps agent-facing guidance in
`CLAUDE.md`.

## Modification

Add a root `AGENTS.md` that points agents to `CLAUDE.md` and makes
`CLAUDE.md` authoritative if the two files ever conflict.

## Result

Agent workflows can discover the repository guidance without
duplicating the `CLAUDE.md` contents.

## References

None — agent instruction entry point.
