### PR TITLE
refactor: replace private[this] with private

### DIFF
--- a/sjsonnet/src/sjsonnet/stdlib/SetModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/SetModule.scala
@@ -24,16 +24,16 @@ object SetModule extends AbstractFunctionModule {
   def name = "set"
 
   private val DefaultKeyF = Val.Null(dummyPos)
-  private[this] final val SortKindOther = 0
-  private[this] final val SortKindString = 1
-  private[this] final val SortKindNumber = 2
-  private[this] final val SortKindArray = 3
-  private[this] final val SortKindBoolean = 4
-  private[this] final val SortKindObject = 5
-  private[this] final val SortKindNull = 6
-  private[this] final val SortKindFunction = 7
+  private final val SortKindOther = 0
+  private final val SortKindString = 1
+  private final val SortKindNumber = 2
+  private final val SortKindArray = 3
+  private final val SortKindBoolean = 4
+  private final val SortKindObject = 5
+  private final val SortKindNull = 6
+  private final val SortKindFunction = 7
 
-  @inline private[this] def sortKind(v: Val): Int = v match {
+  @inline private def sortKind(v: Val): Int = v match {
     case _: Val.Str  => SortKindString
     case _: Val.Num  => SortKindNumber
     case _: Val.Arr  => SortKindArray
@@ -44,7 +44,7 @@ object SetModule extends AbstractFunctionModule {
     case _           => SortKindOther
   }
 
-  @inline private[this] def allSameSortKind(values: Array[Val], kind: Int): Boolean = {
+  @inline private def allSameSortKind(values: Array[Val], kind: Int): Boolean = {
     var i = 1
     while (i < values.length) {
       if (sortKind(values(i)) != kind) return false


### PR DESCRIPTION
## Motivation

`private[this]` restricts access to the current instance only, but in
singleton `object`s there is only one instance, making it semantically
identical to `private`. In the `final class StringBuilderWriter`, the
`builder` field has no cross-instance access. Using `private` uniformly
simplifies the access modifier vocabulary without changing behavior.

## Modification

- `Renderer.scala`: `private[this] val builder` -> `private val builder`
  (no cross-instance `.builder` access exists).
- `SetModule.scala`: 8 `private[this] final val` constants and 2
  `@inline private[this] def` methods -> `private` / `@inline private`.

## Result

Cleaner, more idiomatic Scala with no semantic change. Compiles
cleanly on Scala 2.12/2.13/3.3 and all tests pass.

## References

None — pure style refactor.
