### PR TITLE
fix: std.round preserves identity for |x| >= 2^52

### DIFF
--- a/sjsonnet/src/sjsonnet/stdlib/MathModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/MathModule.scala
@@ -314,7 +314,12 @@ object MathModule extends AbstractFunctionModule {
      * The official docs list std.round(x) as a mathematical function.
      */
     builtin("round", "x") { (pos, ev, x: Double) =>
-      if (x >= 0) math.floor(x + 0.5) else math.ceil(x - 0.5)
+      // For |x| >= 2^52 the double is already an exact integer (ULP >= 1.0);
+      // adding 0.5 would invoke IEEE 754 round-to-even and produce the wrong
+      // result for odd inputs (e.g. 2^53 - 1). Short-circuit to avoid it.
+      if (x != x || math.abs(x) >= 4503599627370496.0) x
+      else if (x >= 0) math.floor(x + 0.5)
+      else math.ceil(x - 0.5)
     },
     /**
      * [[https://jsonnet.org/ref/stdlib.html#math std.ceil(x)]].

--- a/sjsonnet/test/resources/new_test_suite/math_round_isEven_isOdd_isInteger_isDecimal.jsonnet
+++ b/sjsonnet/test/resources/new_test_suite/math_round_isEven_isOdd_isInteger_isDecimal.jsonnet
@@ -12,6 +12,14 @@ assert std.round(-1.8) == -2 : 'round(-1.8)';
 assert std.round(0) == 0 : 'round(0)';
 assert std.round(1) == 1 : 'round(1)';
 assert std.round(-1) == -1 : 'round(-1)';
+// Large-integer regression: for |x| >= 2^52 the double is already an exact
+// integer (ULP >= 1.0), so std.round must be the identity. go-jsonnet and
+// jrsonnet agree on all four values below.
+assert std.round(9007199254740991) == 9007199254740991 : 'round(2^53 - 1)';
+assert std.round(9007199254740990) == 9007199254740990 : 'round(2^53 - 2)';
+assert std.round(4503599627370497) == 4503599627370497 : 'round(2^52 + 1)';
+assert std.round(-9007199254740991) == -9007199254740991 : 'round(-(2^53 - 1))';
+assert std.round(1e20) == 1e20 : 'round(1e20)';
 
 // === std.isEven: truncation of integral part (go-jsonnet + jrsonnet agree) ===
 // Integer inputs


### PR DESCRIPTION
## Motivation

`std.round` returned the wrong integer for large odd inputs in
`[2^52, 2^53)`. For example, `std.round(9007199254740991)` (2^53 - 1)
produced `9007199254740992`. The prior `floor(x + 0.5)` /
`ceil(x - 0.5)` implementation invokes IEEE 754 round-to-even when the
ULP is >= 1.0, so adding 0.5 rounds to the nearest *even* integer
rather than the correct half-away-from-zero value. go-jsonnet
(`math.Round`) and jrsonnet both return the identity for these inputs;
sjsonnet was the outlier.

## Modification

- Short-circuit in `MathModule.scala` `std.round` when `|x| >= 2^52`
  or `x` is NaN — at that magnitude every double is already an exact
  integer (ULP >= 1.0), so returning `x` unchanged is both correct and
  avoids the precision trap.
- Half-away-from-zero semantics are preserved for all smaller
  magnitudes; NaN / Infinity propagate naturally.
- Add five regression assertions (2^53-1, 2^53-2, 2^52+1, -(2^53-1),
  1e20) to the existing std.round/isEven/isOdd/isInteger/isDecimal
  fixture.

## Result

`std.round` now matches go-jsonnet and jrsonnet on every integer in
`[2^52, 2^53)`. The existing `std.round(0.5)==1` /
`std.round(-0.5)==-1` half-away-from-zero semantics are preserved.
All 23 file tests plus 86 evaluator tests pass.

## References

- IEEE 754-2019 §4.3.1: Rounding-direction attributes
  (roundTiesToEven)
- go-jsonnet `math.Round`: https://github.com/google/go-jsonnet/blob/master/builtin.go
- Jsonnet spec: https://jsonnet.org/ref/stdlib.html#math
  (`std.round` "ties away from zero")


## Cross-implementation comparison: `std.round` for large doubles

| Implementation | Algorithm | Handles `[2^52, 2^53)` correctly | Negative large values |
|---|---|---|---|
| **sjsonnet (this fix)** | Short-circuit `x` when `\|x\| >= 2^52`; else `floor(x+0.5)`/`ceil(x-0.5)` | ✅ | ✅ |
| **go-jsonnet** | `math.Round` (bitwise IEEE 754 manipulation) | ✅ | ✅ |
| **cpp-jsonnet** | `std.floor(x + 0.5)` (pure Jsonnet) | ❌ Odd integers rounded up | ❌ Also wrong for negatives |
| **jrsonnet** | Rust `f64::round()` (platform `libm`) | ✅ | ✅ |

### Test results

| Input | Expected | sjsonnet (fix) | go-jsonnet | cpp-jsonnet | jrsonnet |
|---|---|---|---|---|---|
| `std.round(9007199254740991)` (2^53-1) | 9007199254740991 | ✅ | ✅ | ❌ `9007199254740992` | ✅ |
| `std.round(9007199254740990)` (2^53-2) | 9007199254740990 | ✅ | ✅ | ✅ | ✅ |
| `std.round(4503599627370497)` (2^52+1) | 4503599627370497 | ✅ | ✅ | ❌ `4503599627370498` | ✅ |
| `std.round(-9007199254740991)` | -9007199254740991 | ✅ | ✅ | ❌ `-9007199254740990` | ✅ |
| `std.round(1e20)` | 1e20 | ✅ | ✅ | ✅ | ✅ |

### Root cause

The `floor(x + 0.5)` pattern triggers IEEE 754 round-to-nearest-even during the **addition step**. For odd integers in `[2^52, 2^53)`, the ULP is exactly 1.0, so `x + 0.5` lands exactly halfway between two representable doubles and the hardware rounds to the nearest even double. go-jsonnet avoids this via bitwise manipulation; jrsonnet delegates to Rust `libm`; both return `x` unchanged when `|x| >= 2^52`.

**Note:** cpp-jsonnet has the same bug as sjsonnet (pre-fix). Even values are correct in both because IEEE 754 round-to-even picks the even neighbor, which is the correct answer for even inputs.