### PR TITLE
fix: std.base64 rejects string codepoints outside byte range

### DIFF
--- a/sjsonnet/src/sjsonnet/stdlib/EncodingModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/EncodingModule.scala
@@ -32,6 +32,19 @@ object EncodingModule extends AbstractFunctionModule {
     true
   }
 
+  private def validateBase64StringCodepoints(str: String): Unit = {
+    var i = 0
+    while (i < str.length) {
+      val cp = str.codePointAt(i)
+      if (cp > 255) {
+        Error.fail(
+          f"base64 encountered invalid codepoint value in the string (must be 0 <= X <= 255), got $cp"
+        )
+      }
+      i += Character.charCount(cp)
+    }
+  }
+
   /**
    * [[https://jsonnet.org/ref/stdlib.html#std-md5 std.md5(s)]].
    *
@@ -67,6 +80,13 @@ object EncodingModule extends AbstractFunctionModule {
           // intermediate heap Array[Byte]); on the JVM/JS side we still allocate the byte array
           // but skip the encoder's pre-count branch. See docs/perf-gap-vs-jrsonnet.md.
           val asciiSafe = s.isInstanceOf[Val.AsciiSafeStr]
+          if (!asciiSafe) {
+            // Non-ASCII-safe string: reject any codepoint outside [0, 255]. The Jsonnet spec
+            // requires base64 input to be a byte string, and go-jsonnet applies the same check
+            // (otherwise PlatformBase64 silently UTF-8-encodes values that are outside the
+            // specified input domain).
+            validateBase64StringCodepoints(s.str)
+          }
           Val.Str.asciiSafe(pos, PlatformBase64.encodeStringToString(s.str, asciiSafe))
         case ba: Val.ByteArr =>
           Val.Str.asciiSafe(pos, PlatformBase64.encodeToString(ba.rawBytes))

--- a/sjsonnet/test/resources/new_test_suite/base64_comprehensive.jsonnet
+++ b/sjsonnet/test/resources/new_test_suite/base64_comprehensive.jsonnet
@@ -134,13 +134,6 @@ std.assertEqual(e1, e2) &&
 std.assertEqual(e2, e3) &&
 
 // ================================================================
-// Unicode string roundtrip (UTF-8)
-// ================================================================
-std.assertEqual(std.base64Decode(std.base64("café résumé naïve")), "café résumé naïve") &&
-std.assertEqual(std.base64Decode(std.base64("你好世界")), "你好世界") &&
-std.assertEqual(std.base64Decode(std.base64("日本語テスト")), "日本語テスト") &&
-
-// ================================================================
 // String roundtrip for sizes 0..64 (covers SIMD boundaries)
 // ================================================================
 local mkStr(len) = std.join("", std.makeArray(len, function(i) std.char(65 + (i % 26))));

--- a/sjsonnet/test/resources/new_test_suite/error.base64_string_codepoint_out_of_range.jsonnet
+++ b/sjsonnet/test/resources/new_test_suite/error.base64_string_codepoint_out_of_range.jsonnet
@@ -1,0 +1,10 @@
+// std.base64 must reject string inputs whose codepoints fall outside [0, 255].
+// The Jsonnet spec requires base64 input to be a byte string; go-jsonnet applies
+// the same check and errors with "base64 encountered invalid codepoint value in
+// the array (must be 0 <= X <= 255), got <value>". sjsonnet previously passed
+// such strings through PlatformBase64 which silently UTF-8-encoded them,
+// producing values that did not round-trip through std.base64Decode on the
+// other implementations.
+
+// Codepoint 256 (just past the 1-byte range) — should error.
+std.base64(std.char(256))

--- a/sjsonnet/test/resources/new_test_suite/error.base64_string_codepoint_out_of_range.jsonnet.golden
+++ b/sjsonnet/test/resources/new_test_suite/error.base64_string_codepoint_out_of_range.jsonnet.golden
@@ -1,2 +1,3 @@
 sjsonnet.Error: [std.base64] base64 encountered invalid codepoint value in the string (must be 0 <= X <= 255), got 256
-    at [<root>].(builtinBase64_string_high_codepoint.jsonnet:1:11)
+    at [<root>].(error.base64_string_codepoint_out_of_range.jsonnet:10:11)
+

--- a/sjsonnet/test/resources/new_test_suite/error.base64_string_mid_codepoint_out_of_range.jsonnet
+++ b/sjsonnet/test/resources/new_test_suite/error.base64_string_mid_codepoint_out_of_range.jsonnet
@@ -1,0 +1,5 @@
+// std.base64 must reject string inputs with codepoints outside [0, 255]. This
+// case uses a BMP CJK character (世 = U+4E16 = codepoint 19990) embedded in an
+// otherwise-ASCII string to exercise the "mid-string" failure path. The error
+// message must include the offending codepoint value.
+std.base64("hello" + std.char(19990))

--- a/sjsonnet/test/resources/new_test_suite/error.base64_string_mid_codepoint_out_of_range.jsonnet.golden
+++ b/sjsonnet/test/resources/new_test_suite/error.base64_string_mid_codepoint_out_of_range.jsonnet.golden
@@ -1,0 +1,3 @@
+sjsonnet.Error: [std.base64] base64 encountered invalid codepoint value in the string (must be 0 <= X <= 255), got 19990
+    at [<root>].(error.base64_string_mid_codepoint_out_of_range.jsonnet:5:11)
+

--- a/sjsonnet/test/src-js/sjsonnet/FileTests.scala
+++ b/sjsonnet/test/src-js/sjsonnet/FileTests.scala
@@ -16,8 +16,6 @@ object FileTests extends BaseFileTests {
   )
 
   val goTestDataSkippedTests: Set[String] = Set(
-    // We support base64 of unicode strings
-    "builtinBase64_string_high_codepoint.jsonnet",
     "builtinSha1.jsonnet",
     "builtinSha256.jsonnet",
     "builtinSha3.jsonnet",

--- a/sjsonnet/test/src-jvm-native/sjsonnet/FileTests.scala
+++ b/sjsonnet/test/src-jvm-native/sjsonnet/FileTests.scala
@@ -16,10 +16,7 @@ object FileTests extends BaseFileTests {
       )
     else Set.empty[String]
 
-  val goTestDataSkippedTests: Set[String] = Set(
-    // We support base64 of unicode strings
-    "builtinBase64_string_high_codepoint.jsonnet"
-  )
+  val goTestDataSkippedTests: Set[String] = Set.empty[String]
 
   val tests: Tests = Tests {
     test("test_suite") - {

--- a/sjsonnet/test/src/sjsonnet/Base64Tests.scala
+++ b/sjsonnet/test/src/sjsonnet/Base64Tests.scala
@@ -402,24 +402,27 @@ object Base64Tests extends TestSuite {
     }
 
     // ================================================================
-    // Unicode string base64 (UTF-8 encoding)
+    // Unicode string base64 — codepoints outside [0, 255] must be rejected
+    // (Jsonnet spec: base64 input is a byte string; go-jsonnet errors with
+    // "base64 encountered invalid codepoint value in the array (must be
+    // 0 <= X <= 255), got <value>" for such inputs).
     // ================================================================
     test("unicode") {
-      test("chineseRoundtrip") {
-        val r = eval(
-          """local s = "你好世界";
-            |std.base64Decode(std.base64(s)) == s
-            |""".stripMargin
+      test("chineseRejected") {
+        // CJK characters have codepoints > 255; std.base64 must error.
+        val err = evalErr(
+          """std.base64("你好世界")""".stripMargin
         )
-        assert(r == ujson.True)
+        assert(err.contains("base64 encountered invalid codepoint value"))
+        assert(err.contains("got 20320"))
       }
-      test("emojiRoundtrip") {
-        val r = eval(
-          """local s = "Hello 🌍!";
-            |std.base64Decode(std.base64(s)) == s
-            |""".stripMargin
+      test("emojiRejected") {
+        // Emoji have codepoints > 255; std.base64 must error.
+        val err = evalErr(
+          """std.base64("Hello 🌍!")""".stripMargin
         )
-        assert(r == ujson.True)
+        assert(err.contains("base64 encountered invalid codepoint value"))
+        assert(err.contains("got 127757"))
       }
       test("mixedRoundtrip") {
         val r = eval(
@@ -569,17 +572,15 @@ object Base64Tests extends TestSuite {
         )
         assert(r == ujson.True)
       }
-      test("largeUnicodeStillCorrect") {
-        // 1500+ char unicode string — must NOT take the ASCII fast path
+      test("largeUnicodeRejected") {
+        // 1500+ char Japanese string — must NOT take the ASCII fast path
         // (AsciiSafeStr is only tagged for pure-ASCII literals), and the
-        // result must equal what we get going via the byte array.
+        // non-ASCII codepoints must be rejected per the Jsonnet spec.
         val src = "日本語テスト" * 250
-        val r = eval(
-          s"""local s = "$src";
-             |std.base64(s) == std.base64(std.encodeUTF8(s))
-             |""".stripMargin
+        val err = evalErr(
+          s"""std.base64("$src")""".stripMargin
         )
-        assert(r == ujson.True)
+        assert(err.contains("base64 encountered invalid codepoint value"))
       }
     }
   }


### PR DESCRIPTION
## Motivation

`std.base64(input)` accepts string or array inputs, but the Jsonnet stdlib defines the input domain as codepoints/numbers in `[0, 255]`.

sjsonnet already validated array elements, but string input had a gap: non-ASCII strings went straight to `PlatformBase64`, so codepoints above `255` were UTF-8 encoded instead of rejected. The observable bug is `std.base64(std.char(256))`: before this PR sjsonnet returned `"xIA="`, while go-jsonnet rejects the input with `got 256`.

This PR is intentionally scoped to that validation gap. It does not change the existing in-range string encoding behavior for `[128, 255]`; local checks show `std.base64(std.char(233))` remains `"w6k="`, matching go-jsonnet 0.22.0 and jrsonnet 0.5.0-pre99.

## Modification

- Add `validateBase64StringCodepoints` in `EncodingModule.scala` and call it for non-`Val.AsciiSafeStr` string inputs before encoding.
- Reject the first string codepoint above `255` with: `base64 encountered invalid codepoint value in the string (must be 0 <= X <= 255), got <value>`.
- Keep the `Val.AsciiSafeStr` fast path unchanged; those values are known to be printable ASCII-safe and therefore in range.
- Preserve existing behavior for valid non-ASCII codepoints in `[128, 255]`.
- Update `Base64Tests.scala` for CJK, emoji, large non-ASCII rejection, and in-range non-ASCII roundtrip.
- Re-enable `go_test_suite/builtinBase64_string_high_codepoint.jsonnet` in JVM/Native and JS file tests, and update its golden output.
- Add `new_test_suite` fixtures for `std.char(256)` and a mid-string out-of-range codepoint.

## Result

`std.base64` now rejects string inputs outside the byte-string domain, aligning the out-of-range behavior with the Jsonnet stdlib contract and the go-jsonnet high-codepoint fixture, while preserving valid ASCII and in-range non-ASCII behavior.

Behavior comparison:

| Input | sjsonnet before | sjsonnet after | go-jsonnet 0.22.0 | jrsonnet 0.5.0-pre99 |
|---|---|---|---|---|
| `std.base64("hello")` | `"aGVsbG8="` | `"aGVsbG8="` | `"aGVsbG8="` | `"aGVsbG8="` |
| `std.base64(std.char(0))` | `"AA=="` | `"AA=="` | `"AA=="` | `"AA=="` |
| `std.base64(std.char(233))` | `"w6k="` | `"w6k="` | `"w6k="` | `"w6k="` |
| `std.base64(std.char(255))` | `"w78="` | `"w78="` | `"w78="` | `"w78="` |
| `std.base64(std.char(256))` | `"xIA="` | error: `got 256` | error: `got 256` | `"xIA="` |
| `std.base64(std.char(19990))` | UTF-8 encoded | error: `got 19990` | error: `got 19990` | UTF-8 encoded |

The intended behavior change is limited to string codepoints above `255`. Valid ASCII and in-range non-ASCII cases remain unchanged.

Verification:

- `./mill sjsonnet.jvm.3_3_7.reformat` passed.
- `./mill sjsonnet.jvm.3_3_7.test` passed: 143/143.
- `./mill sjsonnet.js.3_3_7.test` passed: 475/475.
- `./mill sjsonnet.native.3_3_7.test` passed: 488/488.
- `std.base64(std.char(233))` remains `"w6k="`.
- `std.base64(std.char(256))` fails with `got 256`.
- PR branch is a single commit: `44cbec46 fix: std.base64 rejects string codepoints outside byte range`.

## References

- Jsonnet stdlib documentation for `std.base64`: https://jsonnet.org/ref/stdlib.html#std-base64
- go-jsonnet high-codepoint fixture: https://github.com/google/go-jsonnet/blob/master/testdata/builtinBase64_string_high_codepoint.jsonnet
- go-jsonnet high-codepoint golden: https://github.com/google/go-jsonnet/blob/master/testdata/builtinBase64_string_high_codepoint.golden
- Local cross-implementation check:
  - go-jsonnet 0.22.0: `std.char(233)` => `"w6k="`, `std.char(256)` => error.
  - jrsonnet 0.5.0-pre99: `std.char(233)` => `"w6k="`, `std.char(256)` => `"xIA="`.
