### PR TITLE
fix(client): wait for output pump before exit to prevent truncated stdout

### DIFF
--- a/sjsonnet/client/src/sjsonnet/client/SjsonnetClientMain.java
+++ b/sjsonnet/client/src/sjsonnet/client/SjsonnetClientMain.java
@@ -131,6 +131,13 @@ public class SjsonnetClientMain {
 
         locks.serverLock.await();
 
+        // The server closes its end of the socket before releasing serverLock,
+        // so the output pumper will see EOF. Wait for it to finish so that all
+        // output is fully written to stdout/stderr before we exit. Without this
+        // join, System.exit() kills the daemon thread mid-pump, which can result
+        // in empty or truncated output (flaky test: secondInvocationReusesServer).
+        outThread.join(5_000);
+
         try {
             String content = Files.readString(Path.of(lockBase, "exitCode"), StandardCharsets.UTF_8);
             return Integer.parseInt(content.trim());


### PR DESCRIPTION
## Motivation

`E2ETests.secondInvocationReusesServer` was flaky because the output
pumper thread (`outThread`) is a daemon thread. After
`serverLock.await()` returns, the main thread immediately reads the
exit code and calls `System.exit()`, killing the daemon thread before
it finishes draining the socket buffer to stdout. This results in
empty or truncated output.

## Modification

Add `outThread.join(5_000)` after `serverLock.await()` in
`SjsonnetClientMain.java`. The server closes its end of the socket
before releasing `serverLock`, so by the time `await()` returns the
socket has EOF waiting. The join gives the output pumper thread time
to read all remaining data and terminate naturally before the client
process exits.

## Result

E2E tests pass consistently across 5+ consecutive runs (previously
flaky). No deadlock or hang risk — `ProxyStreamPumper` reads until
EOF from the closed socket, then exits cleanly. The 5-second timeout
is generous relative to typical socket drain latency (<100ms).

## Behavior comparison

| Scenario | sjsonnet (before) | sjsonnet (after) |
|---|---|---|
| Second invocation stdout | Truncated or empty (flaky) | Complete output (stable) |
| Daemon thread lifecycle | Killed by `System.exit()` before drain | `join(5s)` ensures drain completes |
| E2E test stability | Flaky (~50% failure rate) | Stable (5+ consecutive passes) |

## References

- Prior stabilization: PR #998 (trailing newline band-aid)