### PR TITLE
fix: reject duplicate function parameters with correct error in all contexts

### DIFF
--- a/sjsonnet/src/sjsonnet/Parser.scala
+++ b/sjsonnet/src/sjsonnet/Parser.scala
@@ -951,7 +951,7 @@ class Parser(
 
   def field[$: P](currentDepth: Int): P[Expr.Member.Field] = {
     P(
-      (Pos ~~ fieldname(currentDepth + 1) ~/ "+".!.? ~ ("(" ~ params(
+      (Pos ~~ fieldname(currentDepth + 1) ~/ "+".!.? ~ ("(" ~/ params(
         currentDepth + 1
       ) ~ ")").? ~ fieldKeySep ~/ expr(currentDepth + 1)).map { case (pos, name, plus, p, h2, e) =>
         Expr.Member.Field(pos, name, plus.nonEmpty, p.orNull, h2, e)
@@ -1045,18 +1045,27 @@ class Parser(
   def params[$: P]: P[Expr.Params] = params(0)
 
   def params[$: P](currentDepth: Int): P[Expr.Params] = {
-    P((id ~ ("=" ~ expr(currentDepth + 1)).?).rep(sep = ",") ~ ",".?).flatMapX { x =>
+    val ctx = implicitly[P[?]]
+    P(
+      (Pos ~~ id ~ ("=" ~ expr(currentDepth + 1)).?).rep(sep = ",") ~ ",".?
+    ).flatMapX { x =>
       val seen = collection.mutable.Set.empty[String]
-      var overlap: String = null
-      for ((k, _) <- x) {
-        if (seen(k)) overlap = k
-        else seen.add(k)
+      var overlap: (Position, String) = null
+      for ((pos, k, _) <- x) {
+        if (overlap == null) {
+          if (seen(k)) overlap = (pos, k)
+          else seen.add(k)
+        }
       }
       if (overlap == null) {
-        val names = x.map(_._1).toArray[String]
-        val exprs = x.map(_._2.orNull).toArray[Expr]
+        val names = x.map(_._2).toArray[String]
+        val exprs = x.map(_._3.orNull).toArray[Expr]
         Pass(Expr.Params(names, exprs))
-      } else Fail.opaque("no duplicate parameter: " + overlap)
+      } else {
+        ctx.cut = true
+        ctx.index = overlap._1.offset
+        Fail.opaque("no duplicate parameter: " + overlap._2)
+      }
     }
   }
 

--- a/sjsonnet/test/resources/test_suite/error.function_duplicate_param.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.function_duplicate_param.jsonnet.golden
@@ -1,3 +1,3 @@
-sjsonnet.ParseError: Expected no duplicate parameter: x:17:14, found ") x\n"
-    at [<root>].(error.function_duplicate_param.jsonnet:17:14)
+sjsonnet.ParseError: Expected no duplicate parameter: x:17:13, found "x) x\n"
+    at [<root>].(error.function_duplicate_param.jsonnet:17:13)
 

--- a/sjsonnet/test/src/sjsonnet/ParserTests.scala
+++ b/sjsonnet/test/src/sjsonnet/ParserTests.scala
@@ -57,6 +57,16 @@ object ParserTests extends TestSuite {
     test("duplicateFields") {
       parseErr("{ a: 1, a: 2 }") ==> """Expected no duplicate field: a:1:14, found "}""""
     }
+    test("duplicateParams") {
+      parseErr("(function(x, x, x) x)(null, 3, 2)") ==>
+        """Expected no duplicate parameter: x:1:14, found "x, x) x)(n""""
+      parseErr("local f(x, x) = x; f(1, 2)") ==>
+        "Expected no duplicate parameter: x:1:12, found \"x) = x; f(\""
+      parseErr("{ f(x, x): x }.f(1, 2)") ==>
+        "Expected no duplicate parameter: x:1:8, found \"x): x }.f(\""
+      parseErr("{ local f(x, x) = x, a: f(1, 2) }") ==>
+        "Expected no duplicate parameter: x:1:14, found \"x) = x, a:\""
+    }
     test("localInObj") {
       parse("""{
               |local x = 1,


### PR DESCRIPTION
## Motivation

go-jsonnet issue #873 reports that `(function(x, x, x) x)(null, 3, 2)`
silently returns `2` instead of rejecting duplicate parameter names.
sjsonnet already rejected duplicates in function expressions, but the
error message was misleading in local bindings and object methods
(e.g. "Expected \")\"" or "Expected \":\"").

## Modification

The `params` parser correctly detects duplicates via `flatMapX` +
`Fail`. However, in `bind` (`local f(x,x)=...`) and `field`
(`{f(x,x):...}`), the optional group `.?` around `params` swallowed
the "no duplicate parameter" error and backtracked, producing
misleading errors.

Two changes fix this:

1. In `field()`: added `~/` (cut) after `"("` to commit to the params
   path once `"("` is matched: `"(" ~/ params(...) ~ ")"`.
2. In `params()`: set `ctx.cut = true` programmatically when a
   duplicate is detected, preventing outer `.?` operators from
   swallowing the error. Also captures `Pos` for each parameter to
   position the error at the duplicate parameter name (not at the
   closing paren).

## Result

All duplicate parameter contexts now produce the correct error
`"Expected no duplicate parameter: x"` with accurate position info:

- `(function(x, x, x) x)` -> ParseError (already worked)
- `local f(x, x) = x` -> ParseError (was `"Expected )"`)
- `{ f(x, x): x }` -> ParseError (was `"Expected :"`)
- `{ local f(x, x) = x }` -> ParseError (was `"Expected )"`)
- Nested bindings also fixed as a bonus.

Tests pass on Scala 3.3.7, 2.13.18, 2.12.21.

## References

- https://github.com/google/go-jsonnet/issues/873


## Cross-implementation comparison: Duplicate function parameters

| Implementation | Detection Phase | All Contexts Covered | Error Message Example |
|---|---|---|---|
| **sjsonnet (this fix)** | Parse time | ✅ All 4 contexts | `Expected no duplicate parameter: x` |
| **cpp-jsonnet** | Static analysis (post-parse) | ✅ All 4 (via desugaring) | `Duplicate function parameter: x` |
| **go-jsonnet** (master) | ❌ None | ❌ Bug — silently accepts | N/A — last argument wins silently |
| **go-jsonnet** ([PR #876](https://github.com/google/go-jsonnet/pull/876), unmerged) | Parse time | ✅ All 4 | `Duplicate function parameter: a` / `Duplicate method parameter: x` |
| **jrsonnet** | Static analysis (post-parse) | ✅ All 4 (via desugaring) | `local is already defined in the current frame: x` |

### Behavior by test case

| Test Case | sjsonnet (fix) | cpp-jsonnet | go-jsonnet | jrsonnet |
|---|---|---|---|---|
| `(function(x, x, x) x)(null, 3, 2)` | ✅ ParseError | ✅ StaticError | ❌ Returns `2` | ✅ StaticError |
| `local f(x, x) = x; f(1, 2)` | ✅ ParseError | ✅ StaticError | ❌ Accepted | ✅ StaticError |
| `{ f(x, x): x }.f(1, 2)` | ✅ ParseError | ✅ StaticError | ❌ Accepted | ✅ StaticError |
| `{ local f(x, x) = x, a: f(1, 2) }` | ✅ ParseError | ✅ StaticError | ❌ Accepted | ✅ StaticError |

### Key differences

- **Detection timing**: sjsonnet and go-jsonnet (PR #876) detect at parse time; cpp-jsonnet and jrsonnet detect during a separate static analysis pass after parsing.
- **Error message specificity**: go-jsonnet PR #876 distinguishes "function parameter" vs "method parameter"; cpp-jsonnet uses "function parameter" uniformly (methods desugar to functions before the check).
- **Position accuracy**: sjsonnet points to the duplicate parameter name; cpp-jsonnet points to the entire function AST node.
- **go-jsonnet master** has a known bug ([issue #873](https://github.com/google/go-jsonnet/issues/873)) where duplicate parameters are silently accepted with "last argument wins" semantics.