### PR TITLE
fix: %d/%o/%x/%.0f use exact IEEE 754 value for large floats

### DIFF
--- a/sjsonnet/src/sjsonnet/DecimalFormat.scala
+++ b/sjsonnet/src/sjsonnet/DecimalFormat.scala
@@ -70,9 +70,8 @@ object DecimalFormat {
             else if (number >= 0) math.floor(number + 0.5)
             else math.ceil(number - 0.5)
           val prefix =
-            if (rounded.isInfinite || math.abs(rounded) > Long.MaxValue)
-              BigDecimal(rounded).toBigInt.toString
-            else rounded.toLong.toString
+            if (number != number) rounded.toLong.toString
+            else RenderUtils.truncatedDoubleToString(rounded)
           if (alternate) prefix + "." else prefix
         } else {
           val denominator = BigDecimal(10).pow(precision)

--- a/sjsonnet/src/sjsonnet/Format.scala
+++ b/sjsonnet/src/sjsonnet/Format.scala
@@ -963,23 +963,7 @@ object Format {
   }
 
   private def formatInteger(formatted: FormatSpec, s: Double): String = {
-    // Fast path: if the value fits in a Long (and isn't Long.MinValue where
-    // negation overflows), avoid BigInt allocation entirely
-    val sl = s.toLong
-    if (sl.toDouble == s && sl != Long.MinValue) {
-      val negative = sl < 0
-      val lhs = if (negative) "-" else ""
-      val rhs = java.lang.Long.toString(if (negative) -sl else sl)
-      val rhs2 = precisionPad(lhs, rhs, formatted.precisionValue)
-      widen(formatted, lhs, "", rhs2, numeric = true, signedConversion = !negative)
-    } else {
-      val i = BigDecimal(s).toBigInt
-      val negative = i.signum < 0
-      val lhs = if (negative) "-" else ""
-      val rhs = i.abs.toString(10)
-      val rhs2 = precisionPad(lhs, rhs, formatted.precisionValue)
-      widen(formatted, lhs, "", rhs2, numeric = true, signedConversion = !negative)
-    }
+    formatIntegralRadix(formatted, s, 10, _ => "")
   }
 
   private def formatFloat(formatted: FormatSpec, s: Double): String = {
@@ -1002,69 +986,39 @@ object Format {
   }
 
   private def formatOctal(formatted: FormatSpec, s: Double): String = {
-    // Fast path: if the value fits in a Long, avoid BigInt allocation
-    val sl = s.toLong
-    if (sl.toDouble == s && sl != Long.MinValue) {
-      val negative = sl < 0
-      val lhs = if (negative) "-" else ""
-      val rhs = java.lang.Long.toString(if (negative) -sl else sl, 8)
-      val rhs2 = precisionPad(lhs, rhs, formatted.precisionValue)
-      widen(
-        formatted,
-        lhs,
-        if (!formatted.alternate || rhs2.charAt(0) == '0') "" else "0",
-        rhs2,
-        numeric = true,
-        signedConversion = !negative
-      )
-    } else {
-      val i = BigDecimal(s).toBigInt
-      val negative = i.signum < 0
-      val lhs = if (negative) "-" else ""
-      val rhs = i.abs.toString(8)
-      val rhs2 = precisionPad(lhs, rhs, formatted.precisionValue)
-      widen(
-        formatted,
-        lhs,
-        if (!formatted.alternate || rhs2.charAt(0) == '0') "" else "0",
-        rhs2,
-        numeric = true,
-        signedConversion = !negative
-      )
-    }
+    formatIntegralRadix(
+      formatted,
+      s,
+      8,
+      rhs => if (!formatted.alternate || rhs.charAt(0) == '0') "" else "0"
+    )
   }
 
   private def formatHexadecimal(formatted: FormatSpec, s: Double): String = {
-    // Fast path: if the value fits in a Long, avoid BigInt allocation
-    val sl = s.toLong
-    if (sl.toDouble == s && sl != Long.MinValue) {
-      val negative = sl < 0
-      val lhs = if (negative) "-" else ""
-      val rhs = java.lang.Long.toString(if (negative) -sl else sl, 16)
-      val rhs2 = precisionPad(lhs, rhs, formatted.precisionValue)
-      widen(
-        formatted,
-        lhs,
-        if (!formatted.alternate) "" else "0x",
-        rhs2,
-        numeric = true,
-        signedConversion = !negative
-      )
-    } else {
-      val i = BigDecimal(s).toBigInt
-      val negative = i.signum < 0
-      val lhs = if (negative) "-" else ""
-      val rhs = i.abs.toString(16)
-      val rhs2 = precisionPad(lhs, rhs, formatted.precisionValue)
-      widen(
-        formatted,
-        lhs,
-        if (!formatted.alternate) "" else "0x",
-        rhs2,
-        numeric = true,
-        signedConversion = !negative
-      )
-    }
+    formatIntegralRadix(
+      formatted,
+      s,
+      16,
+      _ => if (!formatted.alternate) "" else "0x"
+    )
+  }
+
+  private def formatIntegralRadix(
+      formatted: FormatSpec,
+      s: Double,
+      radix: Int,
+      prefix: String => String): String = {
+    val (negative, rhs) = RenderUtils.truncatedDoubleDigits(s, radix)
+    val lhs = if (negative) "-" else ""
+    val rhs2 = precisionPad(lhs, rhs, formatted.precisionValue)
+    widen(
+      formatted,
+      lhs,
+      prefix(rhs2),
+      rhs2,
+      numeric = true,
+      signedConversion = !negative
+    )
   }
 
   private def precisionPad(lhs: String, rhs: String, precision: Int): String = {

--- a/sjsonnet/src/sjsonnet/Renderer.scala
+++ b/sjsonnet/src/sjsonnet/Renderer.scala
@@ -175,10 +175,10 @@ class PythonRenderer(out: Writer = new StringBuilderWriter(), indent: Int = -1)
       case d                              =>
         val i = d.toLong
         val abs = math.abs(d)
-        if (d == i.toDouble && abs < 1e16) {
-          if (i == 0L && java.lang.Double.doubleToRawLongBits(d) != 0L) {
-            visitFloat64StringParts("-0", -1, -1, index)
-          } else writeLongDirect(i)
+        if (java.lang.Double.compare(d, -0.0) == 0) {
+          visitFloat64StringParts("-0", -1, -1, index)
+        } else if (RenderUtils.isExactLongDouble(d, i) && abs < 1e16) {
+          writeLongDirect(i)
         } else {
           // Non-integer double, or integer-valued double >= 1e16 (Python 3
           // repr() switches to scientific notation at 1e+16). Apply Python
@@ -658,6 +658,49 @@ object RenderUtils {
     l.toDouble == d &&
     d >= Long.MinValue.toDouble &&
     d < LongUpperExclusive
+
+  private final val DoubleFractionMask = 0x000fffffffffffffL
+  private final val DoubleHiddenBit = 0x0010000000000000L
+  private final val DoubleExponentMask = 0x7ffL
+  private final val DoubleMantissaBits = 52
+  private final val DoubleExponentBias = 1023
+
+  private[sjsonnet] def truncateDoubleToBigInt(d: Double): BigInt = {
+    val bits = java.lang.Double.doubleToRawLongBits(d)
+    val rawExponent = ((bits >>> DoubleMantissaBits) & DoubleExponentMask).toInt
+    if (rawExponent == DoubleExponentMask.toInt) {
+      throw new NumberFormatException("Infinite or NaN")
+    }
+
+    val fraction = bits & DoubleFractionMask
+    val (significand, shift) =
+      if (rawExponent == 0) (BigInt(fraction), -1074)
+      else
+        (BigInt(fraction | DoubleHiddenBit), rawExponent - DoubleExponentBias - DoubleMantissaBits)
+
+    val magnitude =
+      if (shift >= 0) significand << shift
+      else significand >> -shift
+
+    if (bits < 0 && magnitude.signum != 0) -magnitude else magnitude
+  }
+
+  private[sjsonnet] def truncatedDoubleDigits(d: Double, radix: Int): (Boolean, String) = {
+    val l = d.toLong
+    if (isExactLongDouble(d, l) && l != Long.MinValue) {
+      val negative = l < 0
+      val magnitude = if (negative) -l else l
+      (negative, java.lang.Long.toString(magnitude, radix))
+    } else {
+      val i = truncateDoubleToBigInt(d)
+      (i.signum < 0, i.abs.toString(radix))
+    }
+  }
+
+  private[sjsonnet] def truncatedDoubleToString(d: Double): String = {
+    val (negative, digits) = truncatedDoubleDigits(d, 10)
+    if (negative) "-" + digits else digits
+  }
 
   /** Maximum number of digits in a Long value (Long.MinValue = -9223372036854775808, 20 chars). */
   private final val MaxLongChars = 20

--- a/sjsonnet/test/resources/new_test_suite/large_float_format_precision.jsonnet
+++ b/sjsonnet/test/resources/new_test_suite/large_float_format_precision.jsonnet
@@ -1,0 +1,38 @@
+// Regression test for large float formatting with %d/%o/%x/%f
+// Format by truncating the IEEE 754 value directly instead of relying on
+// platform BigDecimal(double) implementations.
+local test_d_1e30 = ("%d" % 1e30) == "1000000000000000019884624838656";
+local test_d_neg_1e30 = ("%d" % -1e30) == "-1000000000000000019884624838656";
+local test_d_1e20 = ("%d" % 1e20) == "100000000000000000000";
+local test_d_1_5e20 = ("%d" % 1.5e20) == "150000000000000000000";
+local test_x_1e20 = ("%x" % 1e20) == "56bc75e2d63100000";
+local test_o_1e20 = ("%o" % 1e20) == "12657072742654304000000";
+local test_d_2pow63 = ("%d" % 9223372036854775808) == "9223372036854775808";
+local test_x_2pow63 = ("%x" % 9223372036854775808) == "8000000000000000";
+local test_o_2pow63 = ("%o" % 9223372036854775808) == "1000000000000000000000";
+local test_f0_1e30 = ("%.0f" % 1e30) == "1000000000000000019884624838656";
+local test_f0_1e25 = ("%.0f" % 1e25) == "10000000000000000905969664";
+local test_f0_2pow63 = ("%.0f" % 9223372036854775808) == "9223372036854775808";
+local test_d_2pow53 = ("%d" % 9007199254740992) == "9007199254740992";
+local test_d_2pow53_plus1 = ("%d" % 9007199254740993) == "9007199254740992";
+local results = [
+  ["%d 1e30", test_d_1e30],
+  ["%d -1e30", test_d_neg_1e30],
+  ["%d 1e20", test_d_1e20],
+  ["%d 1.5e20", test_d_1_5e20],
+  ["%x 1e20", test_x_1e20],
+  ["%o 1e20", test_o_1e20],
+  ["%d 2^63", test_d_2pow63],
+  ["%x 2^63", test_x_2pow63],
+  ["%o 2^63", test_o_2pow63],
+  ["%.0f 1e30", test_f0_1e30],
+  ["%.0f 1e25", test_f0_1e25],
+  ["%.0f 2^63", test_f0_2pow63],
+  ["%d 2^53", test_d_2pow53],
+  ["%d 2^53+1", test_d_2pow53_plus1],
+];
+local failures = [r[0] for r in results if !r[1]];
+if std.length(failures) > 0 then
+  error "Failed: " + std.join(", ", failures)
+else
+  "All large float format tests passed"

--- a/sjsonnet/test/resources/new_test_suite/large_float_format_precision.jsonnet.golden
+++ b/sjsonnet/test/resources/new_test_suite/large_float_format_precision.jsonnet.golden
@@ -1,0 +1,1 @@
+"All large float format tests passed"

--- a/sjsonnet/test/resources/new_test_suite/manifest_python_repr.jsonnet
+++ b/sjsonnet/test/resources/new_test_suite/manifest_python_repr.jsonnet
@@ -22,6 +22,7 @@ std.assertEqual(std.manifestPython(0.00012), "0.00012") &&
 std.assertEqual(std.manifestPython(3.141592653589793), "3.141592653589793") &&
 std.assertEqual(std.manifestPython(1e15), "1000000000000000") &&
 std.assertEqual(std.manifestPython(10000000000000000.0), "1e+16") &&
+std.assertEqual(std.manifestPython(9223372036854775808), "9.223372036854776e+18") &&
 // Fractional doubles — scientific outside [-4, 16). Lowercase "e", signed
 // exponent, zero-padded to 2 digits, mantissa stripped of trailing zeros.
 std.assertEqual(std.manifestPython(0.000001), "1e-06") &&

--- a/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
+++ b/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
@@ -689,6 +689,9 @@ object EvaluatorTests extends TestSuite {
       eval("'%d' % -1e19") ==> ujson.Str(
         "-10000000000000000000"
       )
+      eval("'%d' % 9223372036854775808") ==> ujson.Str(
+        "9223372036854775808"
+      )
       eval("'%o' % 1e19") ==> ujson.Str(
         "1053071060221172000000"
       )


### PR DESCRIPTION
## Motivation

CI failed on Scala.js/WASM and Scala Native after the previous implementation used `new java.math.BigDecimal(double).toBigInteger` for large floating-point integer formatting. The JVM result matched the desired exact IEEE-754 binary64 truncation, but JS/WASM/Native produced a different value for cases such as `-1e19`.

The affected formatting paths are `%d`, `%o`, `%x`, `%X`, and `%.0f`. They need a portable truncation of the finite binary64 value, independent of platform `BigDecimal` behavior.

## Modification

- Added shared `RenderUtils` helpers that reconstruct the truncated integer directly from the double sign, exponent, and significand bits, then render the result in the requested radix.
- Routed `%d`, `%o`, `%x`, `%X`, and `%.0f` through those shared helpers.
- Reused the existing `RenderUtils.isExactLongDouble` boundary for the `manifestPython` integer fast path, while keeping large integer-valued doubles on Python-style scientific float rendering.
- Added regression coverage for `1e30`, `-1e30`, `1e20`, `2^53`, `2^63`, and `manifestPython(2^63)`.

## Result

- Fixes the Scala.js/WASM and Scala Native CI failures from this PR.
- Keeps the JVM expected output while making JS/WASM/Native match the same portable bit-level truncation.
- Squashed the branch to one commit: `4b6cfbd8 fix: make large double integer formatting portable`.

## Implementation comparison

sjsonnet before this PR used Scala `BigDecimal(double).toBigInt`, which follows the decimal string form of the double. The new implementation truncates the actual IEEE-754 binary64 value directly.

| Expression | sjsonnet before | sjsonnet after |
|---|---:|---:|
| `"%d" % 1e30` | `1000000000000000000000000000000` | `1000000000000000019884624838656` |
| `"%d" % -1e30` | `-1000000000000000000000000000000` | `-1000000000000000019884624838656` |
| `"%.0f" % 1e30` | `1000000000000000000000000000000` | `1000000000000000019884624838656` |
| `"%d" % 9223372036854775808` | `9223372036854776000` | `9223372036854775808` |
| `"%x" % 1e20` | `56bc75e2d63100000` | `56bc75e2d63100000` |

Cross-implementation behavior, using locally verified binaries: jrsonnet from `~/RustroverProjects/jrsonnet` at `0.5.0-pre99` / `ecbe9eb`, `go-jsonnet` v0.21.0, and Homebrew `jsonnet` reporting Go implementation v0.22.0.

| Expression | sjsonnet after | jrsonnet `0.5.0-pre99` | go-jsonnet `0.21.0` | jsonnet CLI / go-jsonnet `0.22.0` |
|---|---:|---:|---:|---:|
| `"%d" % 1e30` | `1000000000000000019884624838656` | `1000000000000000019884624838656` | `1000000000000000424684240284426` | `1000000000000000424684240284426` |
| `"%d" % -1e30` | `-1000000000000000019884624838656` | `-1000000000000000019884624838656` | `-1000000000000000424684240284426` | `-1000000000000000424684240284426` |
| `"%.0f" % 1e30` | `1000000000000000019884624838656` | `1000000000000000019884624838656` | `1000000000000000424684240284426` | `1000000000000000424684240284426` |
| `"%d" % 1e20` | `100000000000000000000` | `100000000000000000000` | `100000000000000000000` | `100000000000000000000` |
| `"%x" % 1e20` | `56bc75e2d63100000` | `56bc75e2d63100000` | `56bc75e2d63100000` | `56bc75e2d63100000` |
| `"%d" % 9223372036854775808` | `9223372036854775808` | `9223372036854775808` | `9223372036854776028` | `9223372036854776028` |

## Risk

- Low. JSON/TOML rendering still uses canonical decimal rendering and does not reuse the exact binary payload formatting path.
- `manifestPython` intentionally keeps scientific rendering for large integer-valued doubles such as `2^63`.
- Remaining low-risk gap: helper internals do not have direct unit tests for subnormal, NaN, or Infinity inputs; non-finite behavior remains guarded by existing formatting behavior and review.

## References

- PR: https://github.com/databricks/sjsonnet/pull/1012
- Scala.js issue: https://github.com/scala-js/scala-js/issues/5381
- Scala Native issue: https://github.com/scala-native/scala-native/issues/4967

## Verification

- [x] `./mill 'sjsonnet.jvm[3.3.7]'.test`
- [x] `./mill -j1 '_.js[_].__.test'`
- [x] `./mill -j1 '_.wasm[_].__.test'`
- [x] `./mill -j1 '_.native[_].__.test'`
- [x] `./mill __.reformat`
- [x] `./mill __.checkFormat`
- [x] Independent sub-agent review: no blocking findings
