### PR TITLE
fix: unify NaN error message casing to match go-jsonnet

### DIFF
--- a/sjsonnet/src/sjsonnet/stdlib/MathModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/MathModule.scala
@@ -220,7 +220,7 @@ object MathModule extends AbstractFunctionModule {
      */
     builtin("sqrt", "x") { (pos, ev, x: Double) =>
       val r = math.sqrt(x)
-      if (java.lang.Double.isNaN(r)) Error.fail("std.sqrt: not a number", pos)(ev)
+      if (java.lang.Double.isNaN(r)) Error.fail("std.sqrt: Not a number", pos)(ev)
       r
     },
     /**
@@ -293,7 +293,7 @@ object MathModule extends AbstractFunctionModule {
      */
     builtin("pow", "x", "n") { (pos, ev, x: Double, n: Double) =>
       val r = math.pow(x, n)
-      if (java.lang.Double.isNaN(r)) Error.fail("std.pow: not a number", pos)(ev)
+      if (java.lang.Double.isNaN(r)) Error.fail("std.pow: Not a number", pos)(ev)
       r
     },
     /**
@@ -432,7 +432,7 @@ object MathModule extends AbstractFunctionModule {
      */
     builtin("asin", "x") { (pos, ev, x: Double) =>
       val r = math.asin(x)
-      if (java.lang.Double.isNaN(r)) Error.fail("std.asin: not a number", pos)(ev)
+      if (java.lang.Double.isNaN(r)) Error.fail("std.asin: Not a number", pos)(ev)
       r
     },
     /**
@@ -444,7 +444,7 @@ object MathModule extends AbstractFunctionModule {
      */
     builtin("acos", "x") { (pos, ev, x: Double) =>
       val r = math.acos(x)
-      if (java.lang.Double.isNaN(r)) Error.fail("std.acos: not a number", pos)(ev)
+      if (java.lang.Double.isNaN(r)) Error.fail("std.acos: Not a number", pos)(ev)
       r
     },
     /**
@@ -506,7 +506,7 @@ object MathModule extends AbstractFunctionModule {
      */
     builtin("log", "x") { (pos, ev, x: Double) =>
       val r = math.log(x)
-      if (java.lang.Double.isNaN(r)) Error.fail("std.log: not a number", pos)(ev)
+      if (java.lang.Double.isNaN(r)) Error.fail("std.log: Not a number", pos)(ev)
       r
     },
     /**
@@ -518,7 +518,7 @@ object MathModule extends AbstractFunctionModule {
      */
     builtin("log2", "x") { (pos, ev, x: Double) =>
       val r = math.log(x) / math.log(2.0)
-      if (java.lang.Double.isNaN(r)) Error.fail("std.log2: not a number", pos)(ev)
+      if (java.lang.Double.isNaN(r)) Error.fail("std.log2: Not a number", pos)(ev)
       r
     },
     /**
@@ -530,7 +530,7 @@ object MathModule extends AbstractFunctionModule {
      */
     builtin("log10", "x") { (pos, ev, x: Double) =>
       val r = math.log10(x)
-      if (java.lang.Double.isNaN(r)) Error.fail("std.log10: not a number", pos)(ev)
+      if (java.lang.Double.isNaN(r)) Error.fail("std.log10: Not a number", pos)(ev)
       r
     },
     /**

--- a/sjsonnet/test/resources/go_test_suite/builtin_log7.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/builtin_log7.jsonnet.golden
@@ -1,2 +1,2 @@
-sjsonnet.Error: [std.log] not a number
+sjsonnet.Error: [std.log] Not a number
     at [<root>].(builtin_log7.jsonnet:1:8)

--- a/sjsonnet/test/resources/go_test_suite/builtin_log8.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/builtin_log8.jsonnet.golden
@@ -1,2 +1,2 @@
-sjsonnet.Error: [std.log] not a number
+sjsonnet.Error: [std.log] Not a number
     at [<root>].(builtin_log8.jsonnet:1:8)

--- a/sjsonnet/test/resources/go_test_suite/pow4.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/pow4.jsonnet.golden
@@ -1,2 +1,2 @@
-sjsonnet.Error: [std.pow] not a number
+sjsonnet.Error: [std.pow] Not a number
     at [<root>].(pow4.jsonnet:1:8)

--- a/sjsonnet/test/resources/new_test_suite/error.math_acos_nan.jsonnet.golden
+++ b/sjsonnet/test/resources/new_test_suite/error.math_acos_nan.jsonnet.golden
@@ -1,2 +1,2 @@
-sjsonnet.Error: [std.acos] not a number
+sjsonnet.Error: [std.acos] Not a number
     at [<root>].(error.math_acos_nan.jsonnet:2:9)

--- a/sjsonnet/test/resources/new_test_suite/error.math_asin_nan.jsonnet.golden
+++ b/sjsonnet/test/resources/new_test_suite/error.math_asin_nan.jsonnet.golden
@@ -1,2 +1,2 @@
-sjsonnet.Error: [std.asin] not a number
+sjsonnet.Error: [std.asin] Not a number
     at [<root>].(error.math_asin_nan.jsonnet:2:9)

--- a/sjsonnet/test/resources/new_test_suite/error.math_pow_nan.jsonnet.golden
+++ b/sjsonnet/test/resources/new_test_suite/error.math_pow_nan.jsonnet.golden
@@ -1,2 +1,2 @@
-sjsonnet.Error: [std.pow] not a number
+sjsonnet.Error: [std.pow] Not a number
     at [<root>].(error.math_pow_nan.jsonnet:2:8)

--- a/sjsonnet/test/src/sjsonnet/StdMathTests.scala
+++ b/sjsonnet/test/src/sjsonnet/StdMathTests.scala
@@ -39,23 +39,23 @@ object StdMathTests extends TestSuite {
       evalErr("std.exponent(std.pow(2, 1024))")
     }
     test("sqrt rejects negative input") {
-      // go-jsonnet: makeDoubleCheck returns "not a number" for NaN results
+      // go-jsonnet: makeDoubleCheck returns "Not a number" for NaN results
       val err = evalErr("std.sqrt(-1)")
-      assert(err.contains("not a number"))
+      assert(err.contains("Not a number"))
       val err2 = evalErr("std.sqrt(-0.001)")
-      assert(err2.contains("not a number"))
+      assert(err2.contains("Not a number"))
       // sqrt(0) and sqrt(positive) must still work
       eval("std.sqrt(0)") ==> ujson.Num(0.0)
       eval("std.sqrt(4)") ==> ujson.Num(2.0)
     }
     test("log and log2 reject negative and zero input") {
-      // go-jsonnet: makeDoubleCheck returns "not a number" for NaN, Val.Num catches Infinity as "overflow"
+      // go-jsonnet: makeDoubleCheck returns "Not a number" for NaN, Val.Num catches Infinity as "overflow"
       val errLog = evalErr("std.log(-1)")
-      assert(errLog.contains("not a number"))
+      assert(errLog.contains("Not a number"))
       val errLog2 = evalErr("std.log2(-1)")
-      assert(errLog2.contains("not a number"))
+      assert(errLog2.contains("Not a number"))
       val errLog10 = evalErr("std.log10(-1)")
-      assert(errLog10.contains("not a number"))
+      assert(errLog10.contains("Not a number"))
       val errLog0 = evalErr("std.log(0)")
       assert(errLog0.contains("Overflow"))
       val errLog2Zero = evalErr("std.log2(0)")


### PR DESCRIPTION
## Summary

- Capitalize all 7 NaN error messages in `MathModule.scala` from `"not a number"` to `"Not a number"` to match go-jsonnet's `makeDoubleCheck` convention
- Eliminates internal inconsistency: the Evaluator and `Val.Num` already used uppercase, but `std.sqrt`/`std.pow`/`std.asin`/`std.acos`/`std.log`/`std.log2`/`std.log10` used lowercase
- Update 6 golden files and `StdMathTests.scala` assertions

## Cross-implementation comparison

| Failure mode              | sjsonnet (before)  | sjsonnet (after)   | go-jsonnet 0.22.0  | jrsonnet 0.5.0     | C++ jsonnet 0.22.0 |
|---------------------------|--------------------|--------------------|--------------------|--------------------|--------------------|
| `std.pow(-1, 0.5)` NaN    | `"not a number"`   | `"Not a number"`   | `"Not a number"`   | `"non-finite"`     | `"not a number"`   |
| `std.sqrt(-1)` NaN        | `"not a number"`   | `"Not a number"`   | `"Not a number"`   | `"out of bounds"`  | `"not a number"`   |
| `std.asin(2)` NaN         | `"not a number"`   | `"Not a number"`   | `"Not a number"`   | `"non-finite"`     | `"not a number"`   |
| `std.acos(2)` NaN         | `"not a number"`   | `"Not a number"`   | `"Not a number"`   | `"non-finite"`     | `"not a number"`   |
| `std.log(-1)` NaN         | `"not a number"`   | `"Not a number"`   | `"Not a number"`   | `"non-finite"`     | `"not a number"`   |
| `std.log2(-1)` NaN        | `"not a number"`   | `"Not a number"`   | `"Not a number"`   | `"non-finite"`     | `"not a number"`   |
| `std.log10(-1)` NaN       | `"not a number"`   | `"Not a number"`   | `"Not a number"`   | `"non-finite"`     | `"not a number"`   |

## Test plan
- [x] `./mill sjsonnet.jvm[3.3.7].test` passes (33/33 tests)
- [x] `./mill sjsonnet.jvm[2.13.18].test` passes (8/8 tests)
- [x] 6 golden files regenerated