### PR TITLE
fix: self-referential thunks produce clean error instead of StackOverflowError

### DIFF
--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -71,13 +71,18 @@ final class LazyExpr(
     private var scope: ValScope,
     private var ev: Evaluator)
     extends Lazy {
+  private var evaluating: Boolean = false
   def value: Val = {
     if (ev == null) exprOrVal.asInstanceOf[Val]
-    else {
+    else if (evaluating) {
+      Error.fail("Infinite recursion detected (self-referential thunk)")
+    } else {
+      evaluating = true
       val r = ev.visitExpr(exprOrVal.asInstanceOf[Expr])(scope)
       exprOrVal = r // cache result
       scope = null.asInstanceOf[sjsonnet.ValScope] // allow GC
       ev = null // sentinel: marks as computed
+      evaluating = false
       r
     }
   }

--- a/sjsonnet/test/resources/new_test_suite/error.self_referential_thunk.jsonnet
+++ b/sjsonnet/test/resources/new_test_suite/error.self_referential_thunk.jsonnet
@@ -1,0 +1,1 @@
+local x = x; x

--- a/sjsonnet/test/resources/new_test_suite/error.self_referential_thunk.jsonnet.golden
+++ b/sjsonnet/test/resources/new_test_suite/error.self_referential_thunk.jsonnet.golden
@@ -1,0 +1,2 @@
+sjsonnet.Error: Infinite recursion detected (self-referential thunk)
+    at [<root>].(error.self_referential_thunk.jsonnet:1:7)


### PR DESCRIPTION
fix: self-referential thunks produce clean error instead of StackOverflowError

## Motivation

`local x = x; x` (self-referential thunk) caused an uncontrolled `java.lang.StackOverflowError` with raw Java stack trace. C++ jsonnet, go-jsonnet, and jrsonnet all produce clean, controlled error messages.

## Modification

- `Val.scala`: Added `evaluating: Boolean` flag to `LazyExpr`. Set to `true` on first evaluation; if the same `LazyExpr` is re-entered during evaluation, cycle is detected and `"Infinite recursion detected (self-referential thunk)"` is thrown.
- Approach matches jrsonnet's `Pending` state sentinel.
- Added error test: `error.self_referential_thunk.jsonnet`

## Result

| Expression | cpp-jsonnet | go-jsonnet | jrsonnet | sjsonnet (before) | sjsonnet (after) |
|---|---|---|---|---|---|
| `local x = x; x` | "max stack frames" | "max stack frames" | "infinite recursion" | **StackOverflowError** 💥 | "Infinite recursion detected" ✅ |
| `local f() = f(); f()` | "max stack frames" | "max stack frames" | "stack overflow" | "Max stack frames" ✅ | "Max stack frames" ✅ |
| `local x = 1+2; x` | `3` | `3` | `3` | `3` ✅ | `3` ✅ |