### PR TITLE
fix: error stack traces preserve all intermediate function frames

### DIFF
--- a/sjsonnet/src/sjsonnet/Error.scala
+++ b/sjsonnet/src/sjsonnet/Error.scala
@@ -180,10 +180,6 @@ object Error {
       }
   }
 
-  private def isBuiltinName(name: String): Boolean =
-    name.startsWith("std.") || name == "default" ||
-    name == "object comprehension" || name == "array comprehension"
-
   private def stripDuplicateMessagePrefix(msg: String, name: String): String = {
     if (name == null || !msg.startsWith(name) || msg.length <= name.length) msg
     else {

--- a/sjsonnet/src/sjsonnet/Error.scala
+++ b/sjsonnet/src/sjsonnet/Error.scala
@@ -130,7 +130,8 @@ object Error {
       while (di < rawFrames.length) {
         val name = displayNames(di)
         val frameId = rawFrames(di).exprErrorString
-        val lastFrameId = if (frames.isEmpty) null else frames.get(frames.size - 1)._1.exprErrorString
+        val lastFrameId =
+          if (frames.isEmpty) null else frames.get(frames.size - 1)._1.exprErrorString
         if (frameId == null || frameId != lastFrameId) {
           frames.add((rawFrames(di), name))
         }

--- a/sjsonnet/src/sjsonnet/Error.scala
+++ b/sjsonnet/src/sjsonnet/Error.scala
@@ -112,33 +112,29 @@ object Error {
       val namedFrames = allFrames.filter(_.exprErrorString != null)
       val rawFrames = if (namedFrames.nonEmpty) namedFrames else allFrames
 
-      // Compute enclosing function scope for each frame by scanning from
-      // outermost to innermost. Each frame's callee name tells us what function
-      // was entered; builtin calls (std.*) are transparent and don't change scope.
-      val scopeNames = new Array[String](rawFrames.length)
-      var currentScope: String = rootName
-      var si = rawFrames.length - 1
-      while (si >= 0) {
-        scopeNames(si) = currentScope
-        val frameName = rawFrames(si).exprErrorString
-        if (frameName != null && !isBuiltinName(frameName)) {
-          currentScope = frameName
-        }
-        si -= 1
-      }
-      if (rawFrames.nonEmpty) {
-        scopeNames(0) = Option(rawFrames(0).exprErrorString).getOrElse(rootName)
+      // Label each frame with its own identity (function name or root).
+      // This replaces the old scope-chain approach which incorrectly labeled
+      // parent frames with their child function's name.
+      val displayNames = new Array[String](rawFrames.length)
+      var di = 0
+      while (di < rawFrames.length) {
+        displayNames(di) = Option(rawFrames(di).exprErrorString).getOrElse(rootName)
+        di += 1
       }
 
-      // Deduplicate consecutive same-scope frames, keeping the innermost (first)
+      // Deduplicate consecutive frames with the same function name.
+      // Only deduplicates named frames — unnamed frames (null exprErrorString)
+      // are always preserved.
       val frames = new java.util.ArrayList[(Frame, String)](rawFrames.length)
-      si = 0
-      while (si < rawFrames.length) {
-        val name = scopeNames(si)
-        if (frames.isEmpty || frames.get(frames.size - 1)._2 != name) {
-          frames.add((rawFrames(si), name))
+      di = 0
+      while (di < rawFrames.length) {
+        val name = displayNames(di)
+        val frameId = rawFrames(di).exprErrorString
+        val lastFrameId = if (frames.isEmpty) null else frames.get(frames.size - 1)._1.exprErrorString
+        if (frameId == null || frameId != lastFrameId) {
+          frames.add((rawFrames(di), name))
         }
-        si += 1
+        di += 1
       }
 
       var msg = err.getMessage

--- a/sjsonnet/test/resources/go_test_suite/recursive_thunk.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/recursive_thunk.jsonnet.golden
@@ -1,7 +1,9 @@
 sjsonnet.Error: xxx
     at [bar].(recursive_thunk.jsonnet:1:35)
-    at [foo].(recursive_thunk.jsonnet:2:19)
-    at [bar].(recursive_thunk.jsonnet:2:23)
-    at [foo].(recursive_thunk.jsonnet:2:19)
-    at [<root>].(recursive_thunk.jsonnet:3:4)
+    at [foo].(recursive_thunk.jsonnet:2:23)
+    at [bar].(recursive_thunk.jsonnet:2:19)
+    at [foo].(recursive_thunk.jsonnet:2:23)
+    at [bar].(recursive_thunk.jsonnet:2:19)
+    at [foo].(recursive_thunk.jsonnet:3:4)
+    at [<root>].(recursive_thunk.jsonnet:1:7)
 

--- a/sjsonnet/test/resources/go_test_suite/std.flatmap5.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/std.flatmap5.jsonnet.golden
@@ -1,4 +1,5 @@
 sjsonnet.Error: a
     at [std.flatMap].(std.flatmap5.jsonnet:1:21)
-    at [<root>].(std.flatmap5.jsonnet:2:9)
+    at [std.type].(std.flatmap5.jsonnet:2:9)
+    at [<root>].(std.flatmap5.jsonnet:1:7)
 

--- a/sjsonnet/test/resources/go_test_suite/tailstrict2.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/tailstrict2.jsonnet.golden
@@ -1,4 +1,5 @@
 sjsonnet.Error: xxx
     at [e].(tailstrict2.jsonnet:1:13)
-    at [<root>].(tailstrict2.jsonnet:2:19)
+    at [anonymous].(tailstrict2.jsonnet:2:19)
+    at [<root>].(tailstrict2.jsonnet:1:7)
 

--- a/sjsonnet/test/resources/new_test_suite/error.max_stack_cross_file.jsonnet.golden
+++ b/sjsonnet/test/resources/new_test_suite/error.max_stack_cross_file.jsonnet.golden
@@ -1,5 +1,6 @@
 sjsonnet.Error: [search] Max stack frames exceeded.
-    at [method].(error.max_stack_cross_file_helper.libsonnet:5:37)
-    at [m].(error.max_stack_cross_file.jsonnet:5:23)
-    at [<root>].(error.max_stack_cross_file.jsonnet:9:2)
+    at [std.objectHas].(error.max_stack_cross_file_helper.libsonnet:5:25)
+    at [method].(error.max_stack_cross_file.jsonnet:5:23)
+    at [m].(error.max_stack_cross_file.jsonnet:9:2)
+    at [<root>].(error.max_stack_cross_file.jsonnet:1:7)
 

--- a/sjsonnet/test/resources/test_suite/error.01.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.01.jsonnet.golden
@@ -1,5 +1,6 @@
 sjsonnet.Error: foo
     at [bananas].(error.01.jsonnet:17:29)
-    at [apples].(error.01.jsonnet:19:35)
-    at [<root>].(error.01.jsonnet:20:7)
+    at [oranges].(error.01.jsonnet:19:35)
+    at [apples].(error.01.jsonnet:20:7)
+    at [<root>].(error.01.jsonnet:17:7)
 

--- a/sjsonnet/test/resources/test_suite/error.recursive_function_nonterm.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.recursive_function_nonterm.jsonnet.golden
@@ -1,3 +1,3 @@
 sjsonnet.Error: [f] Max stack frames exceeded.
-    at [<root>].(error.recursive_function_nonterm.jsonnet:20:2)
+    at [<root>].(error.recursive_function_nonterm.jsonnet:17:7)
 

--- a/sjsonnet/test/resources/test_suite/error.tailstrict_stack.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.tailstrict_stack.jsonnet.golden
@@ -1,5 +1,5 @@
 sjsonnet.Error: n is 0
     at [sum_from_one_to_n].(error.tailstrict_stack.jsonnet:10:9)
-    at [foo].(error.tailstrict_stack.jsonnet:14:37)
-    at [<root>].(error.tailstrict_stack.jsonnet:19:18)
+    at [foo].(error.tailstrict_stack.jsonnet:19:18)
+    at [<root>].(error.tailstrict_stack.jsonnet:1:7)
 


### PR DESCRIPTION
fix: error stack traces preserve all intermediate function frames

## Motivation

Error stack traces dropped intermediate function frames. For a call chain `f→g→h`, only `f→h→root` was shown — `g` was silently removed. Root cause: the scope-chain labeling algorithm in `formatError` incorrectly assigned a child function's name as the parent's scope label, causing deduplication to remove the intermediate frame.

## Modification

- `Error.scala`: Replaced scope-chain labeling with direct frame identity labeling — each frame displays its own `exprErrorString` (function name). Deduplication only collapses consecutive frames with the same non-null function name.
- Removed unused `isBuiltinName` method (fixes `-Werror` compilation).
- Updated 7 golden files to reflect correct full stack traces.

## Result

| Implementation | Stack trace for `f→g→h` chain |
|---|---|
| cpp-jsonnet | `f → g → h → root` |
| go-jsonnet | `f → g → h → root` |
| jrsonnet | `f → g → h → root` |
| sjsonnet (before) | `f → h → root` ❌ (g missing!) |
| sjsonnet (after) | `f → g → h → root` ✅ |