### PR TITLE
fix: --string flag errors on null output instead of silently succeeding

### DIFF
--- a/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMainBase.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMainBase.scala
@@ -262,6 +262,8 @@ object SjsonnetMainBase {
           wr.write(s.toString)
           wr
         }
+        override def visitNull(index: Int): Writer =
+          throw new upickle.core.Abort(s"$expectedMsg got null")
       }
     else new Renderer(wr, indent = config.indent)
 

--- a/sjsonnet/test/src-jvm/sjsonnet/MainTests.scala
+++ b/sjsonnet/test/src-jvm/sjsonnet/MainTests.scala
@@ -166,6 +166,32 @@ object MainTests extends TestSuite {
       assert((res, out, err) == ((0, "hello\n", "")))
     }
 
+    test("execStringRejectsNull") {
+      // Regression: --string must error on null, matching C++/go/jrsonnet behavior
+      val (res, out, err) = runMain("null", "--exec", "--string")
+      assert(res == 1)
+      assert(out.isEmpty)
+      assert(err.contains("expected string result got null"))
+    }
+
+    test("execStringRejectsNonStringTypes") {
+      // Numbers
+      val (res1, out1, err1) = runMain("42", "--exec", "--string")
+      assert(res1 == 1, out1.isEmpty, err1.contains("expected string result"))
+
+      // Booleans
+      val (res2, out2, err2) = runMain("true", "--exec", "--string")
+      assert(res2 == 1, out2.isEmpty, err2.contains("expected string result"))
+
+      // Arrays
+      val (res3, out3, err3) = runMain("[1, 2]", "--exec", "--string")
+      assert(res3 == 1, out3.isEmpty, err3.contains("expected string result"))
+
+      // Objects
+      val (res4, out4, err4) = runMain("{a: 1}", "--exec", "--string")
+      assert(res4 == 1, out4.isEmpty, err4.contains("expected string result"))
+    }
+
     test("multiStringOutput") {
       val source = testSuiteRoot / "db" / "multi_string.jsonnet"
       val multiDest = os.temp.dir()


### PR DESCRIPTION
fix: --string flag rejects null output instead of silently succeeding

## Motivation

`sjsonnet -S -e 'null'` (the `--string` flag) exited with code 0 and produced empty output for null values. All other implementations (C++ jsonnet, go-jsonnet, jrsonnet) error with exit code 1. Other non-string types (number, boolean, array, object) correctly errored in sjsonnet — only null was broken.

## Modification

- `SjsonnetMainBase.scala`: Added `visitNull` override in the `SimpleVisitor` anonymous class used for `--string` mode, throwing `Abort("expected string result got null")`. The upickle default `visitNull` returned null without throwing — this was the root cause.
- Added `MainTests` regression tests verifying null and other non-string types all error.

## Result

| Input | cpp-jsonnet | go-jsonnet | jrsonnet | sjsonnet (before) | sjsonnet (after) |
|---|---|---|---|---|---|
| `-S -e 'null'` | ERROR (exit 1) | ERROR (exit 1) | ERROR (exit 1) | exit 0 ❌ | ERROR (exit 1) ✅ |
| `-S -e '42'` | ERROR | ERROR | ERROR | ERROR ✅ | ERROR ✅ |
| `-S -e '"hello"'` | `"hello"` | `"hello"` | `"hello"` | `"hello"` ✅ | `"hello"` ✅ |