### PR TITLE
fix: --yaml-stream produces correct output matching C++ jsonnet/go-jsonnet

### DIFF
--- a/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMainBase.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMainBase.scala
@@ -347,8 +347,6 @@ object SjsonnetMainBase {
     }
   }
 
-  private def isScalar(v: ujson.Value) = !v.isInstanceOf[ujson.Arr] && !v.isInstanceOf[ujson.Obj]
-
   def parseBindings(
       strs: Seq[String],
       strFiles: Seq[String],
@@ -511,32 +509,56 @@ object SjsonnetMainBase {
 
         interp.interpret(jsonnetCode, path).flatMap {
           case arr: ujson.Arr =>
-            writeToFile(config, wd) { writer =>
-              arr.value.toSeq match {
-                case Nil         => // donothing
-                case Seq(single) =>
-                  val renderer = rendererForConfig(writer, config, () => currentPos)
-                  single.transform(renderer)
-                  writer.write(if (isScalar(single)) "\n..." else "")
-                case multiple =>
-                  for ((v, i) <- multiple.zipWithIndex) {
-                    if (i > 0) writer.write('\n')
-                    if (isScalar(v)) writer.write("--- ")
-                    else if (i != 0) writer.write("---\n")
-                    val renderer = rendererForConfig(
-                      writer,
-                      config.copy(yamlOut = mainargs.Flag(true)),
-                      () => currentPos
-                    )
-                    v.transform(renderer)
-                  }
+            def renderYamlStream(writer: Writer): Either[String, Unit] = {
+              val docs = arr.value.toSeq
+              if (docs.nonEmpty) {
+                for (v <- docs) {
+                  writer.write("---\n")
+                  val renderer = new Renderer(writer, indent = config.indent)
+                  v.transform(renderer)
+                  writer.write('\n')
+                }
+                writer.write("...\n")
               }
-              writer.write('\n')
-              Right("")
+              Right(())
             }
 
-          case _ =>
-            renderNormal(config, interp, jsonnetCode, path, wd, () => currentPos, stdoutStream)
+            config.outputFile match {
+              case None =>
+                // Write directly to stdout stream; return "" so main0 does not add
+                // an extra trailing newline (the stream already ends with \n).
+                val wr = new OutputStreamWriter(stdoutStream, StandardCharsets.UTF_8)
+                renderYamlStream(wr)
+                wr.flush()
+                Right("")
+              case Some(f) =>
+                handleWriteFile(
+                  os.write.over
+                    .outputStream(os.Path(f, wd), createFolders = config.createDirs.value)
+                ).flatMap { out =>
+                  try {
+                    val buf = new BufferedOutputStream(out)
+                    val wr = new OutputStreamWriter(buf, StandardCharsets.UTF_8)
+                    renderYamlStream(wr)
+                    wr.flush()
+                    Right("")
+                  } finally out.close()
+                }
+            }
+
+          case other =>
+            val typeName = other match {
+              case _: ujson.Obj  => "object"
+              case _: ujson.Str  => "string"
+              case _: ujson.Num  => "number"
+              case _: ujson.Bool => "boolean"
+              case ujson.Null    => "null"
+              case _             => "unknown"
+            }
+            Left(
+              s"stream mode: top-level object was a $typeName, should be an array " +
+              "whose elements hold the JSON for each document in the stream."
+            )
         }
       case _ =>
         renderNormal(config, interp, jsonnetCode, path, wd, () => currentPos, stdoutStream)

--- a/sjsonnet/test/src-jvm/sjsonnet/MainTests.scala
+++ b/sjsonnet/test/src-jvm/sjsonnet/MainTests.scala
@@ -55,11 +55,17 @@ object MainTests extends TestSuite {
     }
 
     val streamedOut =
-      """--- 1
-        |--- 2
-        |--- 3
-        |--- 4
-        |--- 5
+      """---
+        |1
+        |---
+        |2
+        |---
+        |3
+        |---
+        |4
+        |---
+        |5
+        |...
         |""".stripMargin
 
     val expectedWorldDestStr =
@@ -72,7 +78,7 @@ object MainTests extends TestSuite {
     test("yamlStream") {
       val source = testSuiteRoot / "db" / "stream.jsonnet"
       val (res, out, err) = runMain(source, "--yaml-stream")
-      assert((res, out, err) == ((0, streamedOut + "\n", "")))
+      assert((res, out, err) == ((0, streamedOut, "")))
     }
 
     test("exec") {
@@ -104,6 +110,18 @@ object MainTests extends TestSuite {
       assert((res, out, err) == ((0, "", "")))
       val destStr = os.read(dest)
       assert(destStr == streamedOut)
+    }
+
+    test("yamlStreamNonArray") {
+      val (res, out, err) = runMain("--yaml-stream", "--exec", """{"a": 1}""")
+      assert(res == 1)
+      assert(out.isEmpty)
+      assert(err.contains("stream mode: top-level object was a object"))
+    }
+
+    test("yamlStreamEmptyArray") {
+      val (res, out, err) = runMain("--yaml-stream", "--exec", "[]")
+      assert((res, out, err) == ((0, "", "")))
     }
 
     test("multi") {


### PR DESCRIPTION
## Summary

This PR fixes `--yaml-stream` (`-y`) output to match C++ jsonnet and go-jsonnet stream behavior.

Before this PR, sjsonnet rendered the top-level array using YAML-style output without the JSON document stream markers expected by C++ jsonnet/go-jsonnet.

## Behavior comparison

Local reference versions used:

- C++ jsonnet `v0.22.0`
- go-jsonnet `v0.22.0`
- jrsonnet `0.5.0-pre99`

| Case | C++ jsonnet | go-jsonnet | jrsonnet | sjsonnet before | sjsonnet after |
| --- | --- | --- | --- | --- | --- |
| `[1, 2]` with `-y` | `---\n1\n---\n2\n...\n` | same as C++ | same as C++ | missing stream markers / YAML-style rendering | same as C++/go |
| `[]` with `-y` | empty output | empty output | `\n...\n` | wrong stream rendering | empty output |
| `{a: 1}` with `-y` | error: top-level object should be array | same as C++ | error with different wording | silently rendered normally | error matching C++/go wording |

The intentional compatibility target is C++ jsonnet/go-jsonnet. jrsonnet differs for empty arrays and error wording.

## Changes

- `SjsonnetMainBase.scala`: render YAML streams as JSON documents separated by `---` and terminated by `...`, with empty arrays producing no output
- `SjsonnetMainBase.scala`: reject non-array top-level values in stream mode with the C++/go-jsonnet style error
- `MainTests.scala`: update expected output and add non-array / empty-array regression coverage

## Tests

```bash
rtk ./mill 'sjsonnet.jvm[3.3.7]'.test.testOnly sjsonnet.MainTests
rtk git diff --check upstream/master...HEAD
```

Both passed locally after rebasing onto `upstream/master`.
