### PR TITLE
fix: update stale format_c golden files after PR #1015 changed code behavior

### DIFF
--- a/sjsonnet/test/resources/new_test_suite/error.format_c_empty_string.jsonnet.golden
+++ b/sjsonnet/test/resources/new_test_suite/error.format_c_empty_string.jsonnet.golden
@@ -1,1 +1,2 @@
-""
+sjsonnet.Error: [std.format] %c expected 1-sized string got: 0
+    at [<root>].(error.format_c_empty_string.jsonnet:5:6)

--- a/sjsonnet/test/resources/new_test_suite/error.format_c_multichar.jsonnet.golden
+++ b/sjsonnet/test/resources/new_test_suite/error.format_c_multichar.jsonnet.golden
@@ -1,1 +1,2 @@
-"AB"
+sjsonnet.Error: [std.format] %c expected 1-sized string got: 2
+    at [<root>].(error.format_c_multichar.jsonnet:5:6)


### PR DESCRIPTION
## Summary

PR #1022 added format_c error test files intended as part of PR #1015 `%c` validation coverage. However, PR #1022 CI ran at 08:07 UTC, before PR #1015 was merged at 16:51 UTC. The golden files were generated from code without `%c` rejection, so they contained success output instead of error messages.

Two minutes after #1015 merged, #1022 was squash-merged. The stale golden files entered master without a CI re-run on the combined state.

## Timeline

```
08:07  PR #1022 CI runs, master has NO %c rejection code
       "%c" % ""   outputs ""     golden correct at this time
       "%c" % "AB" outputs "AB"   golden correct at this time
       CI all green

16:51  PR #1015 merged, %c rejection code enters master
16:53  PR #1022 merged, stale golden files enter master with no CI re-run

After  All PRs branch from master with both %c rejection and stale goldens
       "%c" % ""   errors, golden "" is now wrong
       "%c" % "AB" errors, golden "AB" is now wrong
```

## Fix

Update both golden files to contain the actual `sjsonnet.Error` output:

| File | Before stale | After correct |
|---|---|---|
| `error.format_c_multichar.jsonnet.golden` | `"AB"` | `sjsonnet.Error: [std.format] %c expected 1-sized string got: 2` |
| `error.format_c_empty_string.jsonnet.golden` | `""` | `sjsonnet.Error: [std.format] %c expected 1-sized string got: 0` |

## Implementation behavior comparison

Behavior verified with go-jsonnet and jrsonnet latest local binary, `jrsonnet 0.5.0-pre99`. Both implementations reject empty and multi-character strings for `%c`, and accept single Unicode code points.

| Expression | go-jsonnet 0.21.0 | jrsonnet 0.5.0-pre99 | Expected sjsonnet behavior |
|---|---|---|---|
| `std.format("%c", "")` | exit 1, `%c expected 1-sized string got: 0` | exit 1, `%c expected 1 char string, got 0` | exit 1, `%c expected 1-sized string got: 0` |
| `std.format("%c", "AB")` | exit 1, `%c expected 1-sized string got: 2` | exit 1, `%c expected 1 char string, got 2` | exit 1, `%c expected 1-sized string got: 2` |
| `std.format("%c", "A")` | exit 0, `"A"` | exit 0, `"A"` | exit 0, `"A"` |
| `std.format("%c", "世")` | exit 0, `"世"` | exit 0, `"世"` | exit 0, `"世"` |
| `std.format("%c", 127757)` | exit 0, `"🌍"` | exit 0, `"🌍"` | exit 0, `"🌍"` |

## Verification

```
./mill "sjsonnet.jvm.2_13_18.test" -- "*FileTests*"
Tests: 102, Passed: 102, Failed: 0

rtk ./mill "sjsonnet.jvm[3.3.7]".test.testOnly sjsonnet.FileTests
Tests: 3, Passed: 3, Failed: 0

rtk ./mill "sjsonnet.jvm[3.3.7]".test
SUCCESS
```

## Test plan

- [x] FileTests.new_test_suite passes with corrected golden files
- [x] Full JVM Scala 3.3.7 test suite passes locally
- [x] go-jsonnet and jrsonnet behavior compared for `%c` empty, multi-character, single ASCII, single Unicode, and numeric codepoint cases
- [x] CI green on all 4 build targets: js, jvm, native, wasm
