### PR TITLE
fix: don't treat scaladoc warnings as fatal so publishM2Local succeeds

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -87,6 +87,8 @@ trait SjsonnetCrossModule extends CrossScalaModule with ScalafmtModule {
             else Seq("-Xfatal-warnings", "-Ywarn-unused:-nowarn"))
     else Seq[String]("-Wconf:origin=scala.collection.compat.*:s", "-Xlint:all")
   )
+  def scalaDocOptions =
+    super.scalaDocOptions().filterNot(o => o == "-Werror" || o == "-Xfatal-warnings")
   trait CrossTests extends ScalaModule with TestModule.Utest {
     def mvnDeps = Seq(mvn"com.lihaoyi::utest::0.9.5")
     def testSandboxWorkingDir = false


### PR DESCRIPTION

Override `scalaDocOptions` to strip the fatal-warning flags for doc generation only. Compilation stays strict (`-Werror` still applies to `compile`). `./mill 'sjsonnet.jvm[_].publishM2Local'` now succeeds and emits `-javadoc.jar` for Scala 3.3.7, 2.13.18, and 2.12.21.
