### PR TITLE
fix: report missing input files without stack traces

### DIFF
--- a/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMainBase.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMainBase.scala
@@ -398,36 +398,67 @@ object SjsonnetMainBase {
       profileOpt: Option[String] = None,
       stdoutStream: OutputStream = null): Either[String, String] = {
 
-    val (jsonnetCode, path) =
+    val loadedInput =
       if (config.exec.value)
-        (file, OsPath(wd / Util.wrapInLessThanGreaterThan("exec"), Some("exec")))
+        Right((file, OsPath(wd / Util.wrapInLessThanGreaterThan("exec"), Some("exec"))))
       // TODO: Get rid of the /dev/stdin special-casing (everywhere!) once we use scala-native
       // with https://github.com/scala-native/scala-native/issues/4384 fixed.
       else if (file == "-" || file == "/dev/stdin")
-        (
-          io.Source.stdin.mkString,
-          OsPath(wd / Util.wrapInLessThanGreaterThan("<stdin>"), Some("<stdin>"))
+        Right(
+          (
+            io.Source.stdin.mkString,
+            OsPath(wd / Util.wrapInLessThanGreaterThan("<stdin>"), Some("<stdin>"))
+          )
         )
       else {
-        val p = os.Path(file, wd)
-        (os.read(p), OsPath(p, Some(file)))
+        try {
+          val p = os.Path(file, wd)
+          Right((os.read(p), OsPath(p, Some(file))))
+        } catch {
+          case _: NoSuchFileException =>
+            Left(s"Opening input file: $file: no such file or directory")
+          case e: java.io.IOException      => Left(s"Opening input file: $file: ${e.getMessage}")
+          case e: IllegalArgumentException => Left(s"Opening input file: $file: ${e.getMessage}")
+        }
       }
 
-    val extBinding = parseBindings(
-      config.extStr,
-      config.extStrFile,
-      config.extCode,
-      config.extCodeFile,
-      wd
-    )
+    val (jsonnetCode, path) = loadedInput match {
+      case Right(v)  => v
+      case Left(err) => return Left(err)
+    }
 
-    val tlaBinding = parseBindings(
-      config.tlaStr,
-      config.tlaStrFile,
-      config.tlaCode,
-      config.tlaCodeFile,
-      wd
-    )
+    val bindingResult: Either[String, (Map[String, String], Map[String, String])] =
+      try {
+        Right(
+          (
+            parseBindings(
+              config.extStr,
+              config.extStrFile,
+              config.extCode,
+              config.extCodeFile,
+              wd
+            ),
+            parseBindings(
+              config.tlaStr,
+              config.tlaStrFile,
+              config.tlaCode,
+              config.tlaCodeFile,
+              wd
+            )
+          )
+        )
+      } catch {
+        case e: NoSuchFileException =>
+          Left(s"Opening binding file: ${e.getFile}: no such file or directory")
+        case e: java.io.IOException =>
+          Left(s"Opening binding file: ${e.getMessage}")
+        case e: IllegalArgumentException =>
+          Left(s"Opening binding file: ${e.getMessage}")
+      }
+    val (extBinding, tlaBinding) = bindingResult match {
+      case Right(v)  => v
+      case Left(err) => return Left(err)
+    }
 
     val (profileFormat, profileFile) = profileOpt match {
       case Some(s) if s.startsWith("flamegraph:") =>

--- a/sjsonnet/test/resources/db/cli_missing_input_file.golden
+++ b/sjsonnet/test/resources/db/cli_missing_input_file.golden
@@ -1,0 +1,1 @@
+Opening input file: sjsonnet/test/resources/db/cli_missing_input_file_does_not_exist.jsonnet: no such file or directory

--- a/sjsonnet/test/src-jvm/sjsonnet/MainTests.scala
+++ b/sjsonnet/test/src-jvm/sjsonnet/MainTests.scala
@@ -54,6 +54,30 @@ object MainTests extends TestSuite {
       assert(err1.nonEmpty, err3.nonEmpty)
     }
 
+    test("missingInputFileReportsCleanError") {
+      val sourceRel =
+        os.RelPath("sjsonnet") / "test" / "resources" / "db" /
+          "cli_missing_input_file_does_not_exist.jsonnet"
+      val golden = os.read(testSuiteRoot / "db" / "cli_missing_input_file.golden")
+      val sourceArg: os.Shellable = sourceRel
+      val (res, out, err) = runMain(sourceArg)
+      def normalize(s: String): String =
+        s.replace("\r\n", "\n").replaceAll("\n+\\z", "")
+      assert(res == 1)
+      assert(out.isEmpty)
+      assert(normalize(err) == normalize(golden))
+      assert(!err.contains("NoSuchFileException"))
+    }
+
+    test("malformedBindingFileReportsCleanError") {
+      val (res, out, err) = runMain("--exec", "--ext-str-file", "x=\u0000", "1")
+      assert(res == 1)
+      assert(out.isEmpty)
+      assert(err.contains("Opening binding file:"))
+      assert(!err.contains("InvalidPathException"))
+      assert(!err.contains("IllegalArgumentException"))
+    }
+
     val streamedOut =
       """--- 1
         |--- 2


### PR DESCRIPTION
## Motivation

Missing CLI input files and binding files could leak raw Java exceptions or stack traces instead of clean user-facing errors. Malformed paths could also escape the normal error path.

| Scenario | sjsonnet master | this PR |
| --- | --- | --- |
| Missing input file | Java `NoSuchFileException` stack trace | `Opening input file: missing.jsonnet: no such file or directory` |
| Missing binding file | Java file/path exception | `Opening binding file: missing.jsonnet: no such file or directory` |
| Malformed binding path | Java `InvalidPathException` / `IllegalArgumentException` detail | `Opening binding file: <message>` |

## Modification

- Wrap entry file path construction and read in `mainConfigured`.
- Wrap `parseBindings` calls for ext-vars and TLAs.
- Catch `NoSuchFileException`, `IOException`, and malformed-path `IllegalArgumentException` in the relevant error paths.
- Add JVM CLI regression tests for missing input files and malformed binding file paths.

## Result

- CLI input and binding file failures return exit code 1 with concise diagnostics.
- Tests assert stderr content and verify Java exception class names are not leaked.
- Existing stdin and `--exec` paths are unchanged.

## Verification

- `./mill --no-daemon 'sjsonnet.jvm[3.3.8].test' sjsonnet.MainTests`
- `./mill --no-daemon 'sjsonnet.jvm[3.3.8].checkFormat'`
