### PR TITLE
fix: std.parseJson reports truncated input cleanly

### DIFF
--- a/sjsonnet/src/sjsonnet/stdlib/ManifestModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/ManifestModule.scala
@@ -130,6 +130,8 @@ object ManifestModule extends AbstractFunctionModule {
       } catch {
         case e: ujson.ParseException =>
           throw Error.fail("Invalid JSON: " + e.getMessage, pos)(ev)
+        case _: ujson.IncompleteParseException =>
+          throw Error.fail("Invalid JSON: unexpected end of JSON input", pos)(ev)
       }
     }
   }

--- a/sjsonnet/test/resources/new_test_suite/error.parsejson_empty_input.jsonnet
+++ b/sjsonnet/test/resources/new_test_suite/error.parsejson_empty_input.jsonnet
@@ -1,0 +1,1 @@
+std.parseJson("")

--- a/sjsonnet/test/resources/new_test_suite/error.parsejson_empty_input.jsonnet.golden
+++ b/sjsonnet/test/resources/new_test_suite/error.parsejson_empty_input.jsonnet.golden
@@ -1,0 +1,1 @@
+sjsonnet.Error: [std.parseJson] Invalid JSON: unexpected end of JSON input

--- a/sjsonnet/test/resources/new_test_suite/error.parsejson_truncated_input.jsonnet
+++ b/sjsonnet/test/resources/new_test_suite/error.parsejson_truncated_input.jsonnet
@@ -1,0 +1,1 @@
+std.parseJson('{"a":')

--- a/sjsonnet/test/resources/new_test_suite/error.parsejson_truncated_input.jsonnet.golden
+++ b/sjsonnet/test/resources/new_test_suite/error.parsejson_truncated_input.jsonnet.golden
@@ -1,0 +1,1 @@
+sjsonnet.Error: [std.parseJson] Invalid JSON: unexpected end of JSON input


### PR DESCRIPTION
## Motivation

`std.parseJson` should report incomplete JSON input as a Jsonnet runtime error instead of leaking an internal ujson exception. Before this change, empty or truncated JSON strings produced `[std.parseJson] Internal Error`, which made the user-facing failure look like an interpreter bug.

## Modification

- Catch `ujson.IncompleteParseException` in `std.parseJson`.
- Report `Invalid JSON: unexpected end of JSON input` through the existing `Error.fail` path.
- Add regression goldens for empty input and truncated object input.

## Result

| Case | go-jsonnet v0.22.0 | jrsonnet 0.5.0-pre99 | sjsonnet before | sjsonnet after |
| --- | --- | --- | --- | --- |
| `std.parseJson("")` | `failed to parse JSON: unexpected end of JSON input` | `failed to parse json: EOF while parsing a value` | `[std.parseJson] Internal Error` | `[std.parseJson] Invalid JSON: unexpected end of JSON input` |
| `std.parseJson('{"a":')` | `failed to parse JSON: unexpected end of JSON input` | `failed to parse json: EOF while parsing a value at line 1 column 5` | `[std.parseJson] Internal Error` | `[std.parseJson] Invalid JSON: unexpected end of JSON input` |

The PR only changes `ManifestModule.scala` and the two regression tests with their goldens.

## Risks

- This intentionally changes the exact error text for incomplete JSON input.
- Other malformed JSON errors continue to use the existing parse-error path.
