### PR TITLE
fix: improve base64 and decodeUTF8 error messages

### DIFF
--- a/sjsonnet/src/sjsonnet/stdlib/Base64Validation.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/Base64Validation.scala
@@ -6,6 +6,20 @@ package sjsonnet.stdlib
  */
 object Base64Validation {
 
+  def hasStrictPaddingLengthError(input: String): Boolean = {
+    val len = input.length
+    if (len == 0 || len % 4 == 0) false
+    else {
+      var allAscii = true
+      var i = 0
+      while (i < len && allAscii) {
+        if (input.charAt(i) > 127) allAscii = false
+        i += 1
+      }
+      allAscii
+    }
+  }
+
   /**
    * Validate strict RFC 4648 padding: reject ASCII input whose length is not a multiple of 4.
    *
@@ -20,19 +34,10 @@ object Base64Validation {
    * bytes (so "ĀQ=" is 4 bytes, passes the length check, and fails on the invalid character).
    */
   def requireStrictPadding(input: String): Unit = {
-    val len = input.length
-    if (len > 0 && len % 4 != 0) {
-      var allAscii = true
-      var i = 0
-      while (i < len && allAscii) {
-        if (input.charAt(i) > 127) allAscii = false
-        i += 1
-      }
-      if (allAscii) {
-        throw new IllegalArgumentException(
-          "Last unit does not have enough valid bits"
-        )
-      }
+    if (hasStrictPaddingLengthError(input)) {
+      throw new IllegalArgumentException(
+        "Last unit does not have enough valid bits"
+      )
     }
   }
 }

--- a/sjsonnet/src/sjsonnet/stdlib/EncodingModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/EncodingModule.scala
@@ -118,7 +118,12 @@ object EncodingModule extends AbstractFunctionModule {
          else Val.Str(pos, value)): Val
       } catch {
         case e: IllegalArgumentException =>
-          Error.fail("Invalid base64 string: " + e.getMessage)
+          if (str.length % 4 != 0)
+            Error.fail(
+              s"input string appears not to be a base64 encoded string. Wrong length found (${str.length})"
+            )
+          else
+            Error.fail("failed to decode: " + e.getMessage)
       }
     },
     /**
@@ -135,7 +140,12 @@ object EncodingModule extends AbstractFunctionModule {
         Val.Arr.fromBytes(pos, PlatformBase64.decode(str))
       } catch {
         case e: IllegalArgumentException =>
-          Error.fail("Invalid base64 string: " + e.getMessage)
+          if (str.length % 4 != 0)
+            Error.fail(
+              s"input string appears not to be a base64 encoded string. Wrong length found (${str.length})"
+            )
+          else
+            Error.fail("failed to decode: " + e.getMessage)
       }
     },
     /**

--- a/sjsonnet/src/sjsonnet/stdlib/EncodingModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/EncodingModule.scala
@@ -118,7 +118,7 @@ object EncodingModule extends AbstractFunctionModule {
          else Val.Str(pos, value)): Val
       } catch {
         case e: IllegalArgumentException =>
-          if (str.length % 4 != 0)
+          if (Base64Validation.hasStrictPaddingLengthError(str))
             Error.fail(
               s"input string appears not to be a base64 encoded string. Wrong length found (${str.length})"
             )
@@ -140,7 +140,7 @@ object EncodingModule extends AbstractFunctionModule {
         Val.Arr.fromBytes(pos, PlatformBase64.decode(str))
       } catch {
         case e: IllegalArgumentException =>
-          if (str.length % 4 != 0)
+          if (Base64Validation.hasStrictPaddingLengthError(str))
             Error.fail(
               s"input string appears not to be a base64 encoded string. Wrong length found (${str.length})"
             )

--- a/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
@@ -1225,11 +1225,17 @@ object StringModule extends AbstractFunctionModule {
    */
   private object DecodeUTF8 extends Val.Builtin1("decodeUTF8", "arr") {
     def evalRhs(arr: Eval, ev: EvalScope, pos: Position): Val = {
-      for ((v, idx) <- arr.value.asArr.iterator.zipWithIndex) {
-        if (!v.isInstanceOf[Val.Num] || !v.asDouble.isWhole || v.asInt < 0 || v.asInt > 255) {
-          throw Error.fail(
-            "std.decodeUTF8: element " + idx + " is not an integer in range [0,255], got " + v.value.prettyName
-          )
+      for (v <- arr.value.asArr.iterator) {
+        v match {
+          case n: Val.Num =>
+            val d = n.asDouble
+            if (!d.isWhole)
+              throw Error.fail("Expected an integer, but got " + d)
+            val i = d.toInt
+            if (i < 0 || i > 255)
+              throw Error.fail("Bytes must be integers in range [0, 255], got " + i)
+          case _ =>
+            throw Error.fail("Unexpected type " + v.value.prettyName + ", expected number")
         }
       }
       Val.Str(

--- a/sjsonnet/test/resources/go_test_suite/builtinBase64DecodeBytes_high_codepoint.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/builtinBase64DecodeBytes_high_codepoint.jsonnet.golden
@@ -1,2 +1,2 @@
-sjsonnet.Error: [std.base64DecodeBytes] input string appears not to be a base64 encoded string. Wrong length found (3)
+sjsonnet.Error: [std.base64DecodeBytes] failed to decode: Illegal base64 character 3f
     at [<root>].(builtinBase64DecodeBytes_high_codepoint.jsonnet:1:22)

--- a/sjsonnet/test/resources/go_test_suite/builtinBase64DecodeBytes_high_codepoint.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/builtinBase64DecodeBytes_high_codepoint.jsonnet.golden
@@ -1,3 +1,2 @@
-sjsonnet.Error: [std.base64DecodeBytes] Invalid base64 string: Illegal base64 character 3f
+sjsonnet.Error: [std.base64DecodeBytes] input string appears not to be a base64 encoded string. Wrong length found (3)
     at [<root>].(builtinBase64DecodeBytes_high_codepoint.jsonnet:1:22)
-

--- a/sjsonnet/test/resources/go_test_suite/builtinBase64DecodeBytes_invalid_base64_data.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/builtinBase64DecodeBytes_invalid_base64_data.jsonnet.golden
@@ -1,3 +1,2 @@
-sjsonnet.Error: [std.base64DecodeBytes] Invalid base64 string: Last unit does not have enough valid bits
+sjsonnet.Error: [std.base64DecodeBytes] input string appears not to be a base64 encoded string. Wrong length found (5)
     at [<root>].(builtinBase64DecodeBytes_invalid_base64_data.jsonnet:1:22)
-

--- a/sjsonnet/test/resources/go_test_suite/builtinBase64Decode_high_codepoint.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/builtinBase64Decode_high_codepoint.jsonnet.golden
@@ -1,3 +1,2 @@
-sjsonnet.Error: [std.base64Decode] Invalid base64 string: Illegal base64 character 3f
+sjsonnet.Error: [std.base64Decode] input string appears not to be a base64 encoded string. Wrong length found (3)
     at [<root>].(builtinBase64Decode_high_codepoint.jsonnet:1:17)
-

--- a/sjsonnet/test/resources/go_test_suite/builtinBase64Decode_high_codepoint.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/builtinBase64Decode_high_codepoint.jsonnet.golden
@@ -1,2 +1,2 @@
-sjsonnet.Error: [std.base64Decode] input string appears not to be a base64 encoded string. Wrong length found (3)
+sjsonnet.Error: [std.base64Decode] failed to decode: Illegal base64 character 3f
     at [<root>].(builtinBase64Decode_high_codepoint.jsonnet:1:17)

--- a/sjsonnet/test/resources/go_test_suite/builtinBase64Decode_invalid_base64_data.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/builtinBase64Decode_invalid_base64_data.jsonnet.golden
@@ -1,3 +1,2 @@
-sjsonnet.Error: [std.base64Decode] Invalid base64 string: Last unit does not have enough valid bits
+sjsonnet.Error: [std.base64Decode] input string appears not to be a base64 encoded string. Wrong length found (5)
     at [<root>].(builtinBase64Decode_invalid_base64_data.jsonnet:1:17)
-

--- a/sjsonnet/test/resources/test_suite/error.decodeUTF8_float.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.decodeUTF8_float.jsonnet.golden
@@ -1,2 +1,2 @@
-sjsonnet.Error: [std.decodeUTF8] element 0 is not an integer in range [0,255], got number
+sjsonnet.Error: [std.decodeUTF8] Expected an integer, but got 17.5
     at [<root>].(error.decodeUTF8_float.jsonnet:1:15)

--- a/sjsonnet/test/resources/test_suite/error.decodeUTF8_nan.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.decodeUTF8_nan.jsonnet.golden
@@ -1,2 +1,2 @@
-sjsonnet.Error: [std.decodeUTF8] element 0 is not an integer in range [0,255], got string
+sjsonnet.Error: [std.decodeUTF8] Unexpected type string, expected number
     at [<root>].(error.decodeUTF8_nan.jsonnet:1:15)

--- a/sjsonnet/test/src/sjsonnet/Base64Tests.scala
+++ b/sjsonnet/test/src/sjsonnet/Base64Tests.scala
@@ -461,9 +461,21 @@ object Base64Tests extends TestSuite {
     // Error handling
     // ================================================================
     test("errors") {
+      val highCodepointBase64 = 0x0100.toChar.toString + "Q="
+
       test("invalidBase64Char") {
         val err = evalErr("""std.base64Decode("!!!!")""")
         assert(err.contains("failed to decode"))
+      }
+      test("highCodepointInvalidChar") {
+        val err = evalErr("std.base64Decode(\"" + highCodepointBase64 + "\")")
+        assert(err.contains("failed to decode"))
+        assert(!err.contains("Wrong length found"))
+      }
+      test("decodeBytesHighCodepointInvalidChar") {
+        val err = evalErr("std.base64DecodeBytes(\"" + highCodepointBase64 + "\")")
+        assert(err.contains("failed to decode"))
+        assert(!err.contains("Wrong length found"))
       }
       test("invalidByteArrayValue") {
         val err = evalErr("""std.base64([256])""")

--- a/sjsonnet/test/src/sjsonnet/Base64Tests.scala
+++ b/sjsonnet/test/src/sjsonnet/Base64Tests.scala
@@ -463,7 +463,7 @@ object Base64Tests extends TestSuite {
     test("errors") {
       test("invalidBase64Char") {
         val err = evalErr("""std.base64Decode("!!!!")""")
-        assert(err.contains("Invalid base64"))
+        assert(err.contains("failed to decode"))
       }
       test("invalidByteArrayValue") {
         val err = evalErr("""std.base64([256])""")
@@ -502,22 +502,22 @@ object Base64Tests extends TestSuite {
       test("missingTwoPads") {
         // "YQ" should be "YQ==" — both go-jsonnet and C++ jsonnet reject this
         val err = evalErr("""std.base64Decode("YQ")""")
-        assert(err.contains("Invalid base64"))
+        assert(err.contains("appears not to be a base64 encoded string"))
       }
       test("missingOnePad") {
         // "YWI" should be "YWI=" — rejected by both official implementations
         val err = evalErr("""std.base64Decode("YWI")""")
-        assert(err.contains("Invalid base64"))
+        assert(err.contains("appears not to be a base64 encoded string"))
       }
       test("singleChar") {
         // Single character is never valid base64
         val err = evalErr("""std.base64Decode("A")""")
-        assert(err.contains("Invalid base64"))
+        assert(err.contains("appears not to be a base64 encoded string"))
       }
       test("fiveChars") {
         // "wrong" (5 chars) — the go_test_suite canonical test case
         val err = evalErr("""std.base64Decode("wrong")""")
-        assert(err.contains("Invalid base64"))
+        assert(err.contains("appears not to be a base64 encoded string"))
       }
       test("validPaddedStillWorks") {
         // Properly padded input must still work
@@ -536,7 +536,7 @@ object Base64Tests extends TestSuite {
       // DecodeBytes also enforces strict padding
       test("decodeBytesUnpadded") {
         val err = evalErr("""std.base64DecodeBytes("YQ")""")
-        assert(err.contains("Invalid base64"))
+        assert(err.contains("appears not to be a base64 encoded string"))
       }
     }
 


### PR DESCRIPTION
## Motivation

Invalid `std.base64Decode` and `std.decodeUTF8` inputs should produce clearer diagnostics that are closer to go-jsonnet behavior and stable for the upstream test expectations.

## Modification

- Distinguish malformed base64 lengths from decoder failures in `std.base64Decode` and `std.base64DecodeBytes`.
- Update `std.decodeUTF8` byte validation errors for non-number, non-integer, and out-of-range array elements.
- Refresh the affected golden files and `Base64Tests` assertions.

## Result

| Case | go-jsonnet v0.22.0 | jrsonnet 0.5.0-pre99 | sjsonnet before | sjsonnet after |
| --- | --- | --- | --- | --- |
| `std.base64Decode("wrong")` | `input string appears not to be a base64 encoded string. Wrong length found (5)` | `invalid base64: Invalid input length: 5` | `[std.base64Decode] Invalid base64 string: Last unit does not have enough valid bits` | `[std.base64Decode] input string appears not to be a base64 encoded string. Wrong length found (5)` |
| `std.decodeUTF8([17.5])` | `Expected an integer, but got 17.5` | `cannot convert number with fractional part to u8` | `[std.decodeUTF8] element 0 is not an integer in range [0,255], got number` | `[std.decodeUTF8] Expected an integer, but got 17.5` |

Successful base64 and UTF-8 decoding behavior is unchanged.

## Risks

- This PR changes diagnostic text for invalid inputs; downstream tests that assert exact stderr may need to update expectations.
- It does not attempt to make jrsonnet and sjsonnet error wording identical.
