### PR TITLE
fix: preserve negative zero in std.round

### DIFF
--- a/sjsonnet/src/sjsonnet/stdlib/MathModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/MathModule.scala
@@ -318,7 +318,8 @@ object MathModule extends AbstractFunctionModule {
       // adding 0.5 would invoke IEEE 754 round-to-even and produce the wrong
       // result for odd inputs (e.g. 2^53 - 1). Short-circuit to avoid it.
       if (x != x || math.abs(x) >= 4503599627370496.0) x
-      else if (x >= 0) math.floor(x + 0.5)
+      else if (x == 0) x
+      else if (x > 0) math.floor(x + 0.5)
       else math.ceil(x - 0.5)
     },
     /**

--- a/sjsonnet/test/resources/new_test_suite/round_negative_zero_sign.jsonnet
+++ b/sjsonnet/test/resources/new_test_suite/round_negative_zero_sign.jsonnet
@@ -1,0 +1,15 @@
+{
+  // round(-0) should preserve negative zero sign
+  roundNegZero: std.round(-0),
+  // round(0) should stay positive zero
+  roundPosZero: std.round(0),
+  // round(-0.4) should produce -0
+  roundNegSmall: std.round(-0.4),
+  // round(0.5) should produce 1
+  roundHalfUp: std.round(0.5),
+  // round(-0.5) should produce -1
+  roundNegHalf: std.round(-0.5),
+  // atan2 verifies sign of zero
+  signNegZero: std.atan2(std.round(-0), -1) < 0,
+  signPosZero: std.atan2(std.round(0), -1) > 0,
+}

--- a/sjsonnet/test/resources/new_test_suite/round_negative_zero_sign.jsonnet.golden
+++ b/sjsonnet/test/resources/new_test_suite/round_negative_zero_sign.jsonnet.golden
@@ -1,0 +1,9 @@
+{
+   "roundHalfUp": 1,
+   "roundNegHalf": -1,
+   "roundNegSmall": -0,
+   "roundNegZero": -0,
+   "roundPosZero": 0,
+   "signNegZero": true,
+   "signPosZero": true
+}


### PR DESCRIPTION
## Motivation

`std.round(-0)` returned positive zero in sjsonnet, while go-jsonnet and jrsonnet preserve the negative zero sign. This matters for programs that observe signed zero through functions such as `std.atan2`.

## Modification

- Preserve the original input when `std.round` receives either `+0` or `-0`.
- Keep the existing positive and negative rounding branches for non-zero numbers.
- Add a regression test that checks the sign of rounded zero values.

## Result

| Case | go-jsonnet v0.22.0 | jrsonnet 0.5.0-pre99 | sjsonnet before | sjsonnet after |
| --- | --- | --- | --- | --- |
| `std.round(-0)` | `-0` | `-0` | `0` | `-0` |
| `std.round(0)` | `0` | `0` | `0` | `0` |

`std.atan2(std.round(-0), -1)` now observes the negative-zero sign.

## Risks

- This intentionally changes materialized output for the exact `std.round(-0)` case.
- Other rounding behavior is intended to remain unchanged.
