### PR TITLE
fix: std.format specialize arg swap and %-0 flag interaction

### DIFF
--- a/sjsonnet/src/sjsonnet/Format.scala
+++ b/sjsonnet/src/sjsonnet/Format.scala
@@ -262,10 +262,11 @@ object Format {
       else if (lhs2.isEmpty) mhs + rhs
       else lhs2 + mhs + rhs
     } else {
+      val zeroPad = formatted.zeroPadded && !formatted.leftAdjusted && numeric
       val padding =
-        if (formatted.zeroPadded && numeric) Platform.repeatString("0", missingWidth)
+        if (zeroPad) Platform.repeatString("0", missingWidth)
         else Platform.repeatString(" ", missingWidth)
-      if (formatted.zeroPadded && numeric) lhs2 + mhs + padding + rhs
+      if (zeroPad) lhs2 + mhs + padding + rhs
       else if (formatted.leftAdjusted) lhs2 + mhs + rhs + padding
       else padding + lhs2 + mhs + rhs
     }

--- a/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/StringModule.scala
@@ -1253,8 +1253,8 @@ object StringModule extends AbstractFunctionModule {
       Format.format(str.value.asString, vals.value, pos)(ev)
     override def specialize(args: Array[Expr], tailstrict: Boolean): (Val.Builtin, Array[Expr]) =
       args match {
-        case Array(str, fmt: Val.Str) =>
-          try { (new Format.PartialApplyFmt(fmt.str), Array(str)) }
+        case Array(fmtStr: Val.Str, vals) =>
+          try { (new Format.PartialApplyFmt(fmtStr.str), Array(vals)) }
           catch { case _: Exception => null }
         case _ => null
       }

--- a/sjsonnet/test/resources/new_test_suite/error.format_type_mismatch.jsonnet
+++ b/sjsonnet/test/resources/new_test_suite/error.format_type_mismatch.jsonnet
@@ -1,0 +1,1 @@
+std.format("%d", "abc")

--- a/sjsonnet/test/resources/new_test_suite/error.format_type_mismatch.jsonnet.golden
+++ b/sjsonnet/test/resources/new_test_suite/error.format_type_mismatch.jsonnet.golden
@@ -1,0 +1,1 @@
+sjsonnet.Error: [std.format] expected number at position 0, got string

--- a/sjsonnet/test/resources/new_test_suite/format_left_adjust_overrides_zero_pad.jsonnet
+++ b/sjsonnet/test/resources/new_test_suite/format_left_adjust_overrides_zero_pad.jsonnet
@@ -1,0 +1,14 @@
+{
+  // When both - (left-justify) and 0 (zero-pad) flags are present,
+  // left-justify takes precedence per POSIX/Python convention.
+  leftJustifyZeroPadInt: std.format("%-05d", 42),
+  leftJustifyZeroPadNeg: std.format("%-05d", -42),
+  leftJustifyZeroPadPlus: std.format("%-+05d", 42),
+  leftJustifyZeroPadFloat: std.format("%-08.2f", 3.14),
+  leftJustifyZeroPadWide: std.format("%-010d", 42),
+  leftJustifyZeroPadPercentOperator: "%-05d" % 42,
+  // Pure zero-pad still works
+  zeroPadInt: std.format("%05d", 42),
+  // Pure left-justify still works
+  leftJustifyInt: std.format("%-5d", 42),
+}

--- a/sjsonnet/test/resources/new_test_suite/format_left_adjust_overrides_zero_pad.jsonnet.golden
+++ b/sjsonnet/test/resources/new_test_suite/format_left_adjust_overrides_zero_pad.jsonnet.golden
@@ -1,0 +1,10 @@
+{
+   "leftJustifyInt": "42   ",
+   "leftJustifyZeroPadFloat": "3.14    ",
+   "leftJustifyZeroPadInt": "42   ",
+   "leftJustifyZeroPadNeg": "-42  ",
+   "leftJustifyZeroPadPercentOperator": "42   ",
+   "leftJustifyZeroPadPlus": "+42  ",
+   "leftJustifyZeroPadWide": "42        ",
+   "zeroPadInt": "00042"
+}


### PR DESCRIPTION
## Motivation

Two `std.format` bugs found via adversarial testing against go-jsonnet, jrsonnet, and Python's `%` operator:

1. **`std.format("%d", "abc")`** reported misleading `"too many values to format: 1, expected 0"` instead of a type error. Root cause: the `specialize()` method in `Format_` swapped the format string and values arguments when the values happened to be a string literal.

2. **`%-05d`** applied zero-padding instead of left-justification. Per POSIX/Python convention, when both `-` (left-justify) and `0` (zero-pad) flags are present, `-` takes precedence.

| Expression | sjsonnet (master) | go-jsonnet | jrsonnet | Python | this PR |
|---|---|---|---|---|---|
| `std.format("%d", "abc")` | `too many values...` | `Format required number...` | `type error...` | `TypeError` | `expected number...` ✅ |
| `std.format("%-05d", 42)` | `"00042"` | `"42   "` | `"42   "` | `"42   "` | `"42   "` ✅ |
| `std.format("%-05d", -42)` | `"-0042"` | `"-42  "` | `"-42  "` | `"-42  "` | `"-42  "` ✅ |

## Modification

1. **`StringModule.scala`**: Fix `specialize()` pattern to correctly use the first argument (format string) as the `PartialApplyFmt` template. Changed `Array(str, fmt: Val.Str)` to `Array(fmtStr: Val.Str, vals)`.

2. **`Format.scala`**: Add `&& !formatted.leftAdjusted` to zero-padding conditions in `widen()`, so left-justify takes precedence over zero-pad.

## Result

- `std.format("%d", "abc")` correctly reports type error.
- `%-05d` produces `"42   "` (left-justified), matching go-jsonnet, jrsonnet, and Python.
- `%05d` (zero-pad only) still produces `"00042"` correctly.
- All tests pass on JVM 2.12, 2.13, 3.3.