### PR TITLE
docs: clarify threading model guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,12 @@ Shared and platform-specific sources are split across directories:
 - **Parse caching**: `ParseCache` / `DefaultParseCache` caches parsed ASTs to avoid re-parsing imports.
 - **Platform abstraction**: `Path` and `Importer` traits abstract filesystem access across JVM/JS/Native.
 
+### Threading Model
+
+- **No internal multithreading requirement**: A single `Interpreter` does not need to evaluate a program using multiple threads.
+- **Independent interpreters should not interfere**: Applications should be able to run multiple independent `Interpreter` instances concurrently on platforms that support concurrency, without one interpreter affecting another.
+- **Shared mutable state is exceptional**: State should belong to an interpreter or evaluation unless it has an explicit concurrency contract and tests.
+
 ## Dependencies
 
 Key runtime dependencies:


### PR DESCRIPTION
## Summary
- Add a Threading Model section to CLAUDE.md
- Clarify that a single Interpreter does not need internal multithreaded evaluation
- Require independent Interpreter instances to be safe for concurrent application use on platforms that support concurrency
- Treat shared mutable state as exceptional and require an explicit concurrency contract plus tests

## Verification
- git diff --check -- CLAUDE.md