### PR TITLE
Harden shared parse cache

### DIFF
--- a/sjsonnet/src-js/sjsonnet/Platform.scala
+++ b/sjsonnet/src-js/sjsonnet/Platform.scala
@@ -7,6 +7,37 @@ import java.util.regex.Pattern
 import scala.collection.mutable
 
 object Platform {
+  // Scala.js/Wasm cannot link scala.collection.concurrent.TrieMap; the JS runtime is
+  // single-threaded, so the parse cache only needs TrieMap-like method names here.
+  private[sjsonnet] type ParseCacheMap =
+    JsParseCacheMap
+  private[sjsonnet] type ParseCacheValue = Either[Error, (Expr, FileScope)]
+
+  def newParseCacheMap(): ParseCacheMap =
+    new JsParseCacheMap
+
+  private[sjsonnet] final class JsParseCacheMap {
+    private[this] val cache = mutable.HashMap.empty[(Path, String), ParseCacheValue]
+
+    def get(key: (Path, String)): Option[ParseCacheValue] =
+      cache.get(key)
+
+    def putIfAbsent(key: (Path, String), value: ParseCacheValue): Option[ParseCacheValue] = {
+      cache.get(key) match {
+        case existing @ Some(_) => existing
+        case None               =>
+          cache.put(key, value)
+          None
+      }
+    }
+
+    def valuesIterator: Iterator[ParseCacheValue] =
+      cache.valuesIterator
+
+    def keySet: scala.collection.Set[(Path, String)] =
+      cache.keySet
+  }
+
   private def repeatCapacity(s: String, count: Int): Int =
     if (count > 0 && s.length <= Int.MaxValue / count) s.length * count else 0
 

--- a/sjsonnet/src-jvm/sjsonnet/Platform.scala
+++ b/sjsonnet/src-jvm/sjsonnet/Platform.scala
@@ -14,12 +14,20 @@ import org.yaml.snakeyaml.{DumperOptions, LoaderOptions, Yaml}
 import org.yaml.snakeyaml.nodes.{MappingNode, Node, ScalarNode, SequenceNode, Tag}
 
 import scala.annotation.nowarn
+import scala.collection.concurrent.TrieMap
 import scala.collection.compat.*
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
 
 object Platform {
   private val hexFormat = HexFormat.of()
+
+  private[sjsonnet] type ParseCacheMap =
+    TrieMap[(Path, String), Either[Error, (Expr, FileScope)]]
+  private[sjsonnet] type ParseCacheValue = Either[Error, (Expr, FileScope)]
+
+  def newParseCacheMap(): ParseCacheMap =
+    TrieMap.empty[(Path, String), ParseCacheValue]
 
   def repeatString(s: String, count: Int): String =
     if (count <= 0) "" else s.repeat(count)

--- a/sjsonnet/src-native/sjsonnet/Platform.scala
+++ b/sjsonnet/src-native/sjsonnet/Platform.scala
@@ -7,10 +7,18 @@ import java.util.Base64
 import java.util.zip.GZIPOutputStream
 import scala.scalanative.regex.Pattern
 import scala.annotation.nowarn
+import scala.collection.concurrent.TrieMap
 import scala.collection.mutable
 import org.virtuslab.yaml.*
 
 object Platform {
+  private[sjsonnet] type ParseCacheMap =
+    TrieMap[(Path, String), Either[Error, (Expr, FileScope)]]
+  private[sjsonnet] type ParseCacheValue = Either[Error, (Expr, FileScope)]
+
+  def newParseCacheMap(): ParseCacheMap =
+    TrieMap.empty[(Path, String), ParseCacheValue]
+
   private val hexChars = "0123456789abcdef".toCharArray
 
   private def repeatCapacity(s: String, count: Int): Int =

--- a/sjsonnet/src/sjsonnet/ParseCache.scala
+++ b/sjsonnet/src/sjsonnet/ParseCache.scala
@@ -24,16 +24,20 @@ object ParseCache {
   }
 }
 
-// A default implementation based on a mutable HashMap. This implementation is not thread-safe.
+// A default implementation backed by the platform cache store.
 class DefaultParseCache extends ParseCache {
-  val cache =
-    new scala.collection.mutable.HashMap[(Path, String), Either[Error, (Expr, FileScope)]]()
+  private val cache = Platform.newParseCacheMap()
 
   // parseCache.getOrElseUpdate((path, txt), {...})
   override def getOrElseUpdate(
       key: (Path, String),
       defaultValue: => Either[Error, (Expr, FileScope)]): Either[Error, (Expr, FileScope)] = {
-    cache.getOrElseUpdate(key, defaultValue)
+    cache.get(key) match {
+      case Some(value) => value
+      case None        =>
+        val value = defaultValue
+        cache.putIfAbsent(key, value).getOrElse(value)
+    }
   }
 
   // parseCache.valuesIterator.map(_.getOrElse(???)).map(_._1).toSeq
@@ -43,6 +47,6 @@ class DefaultParseCache extends ParseCache {
 
   // parseCache.keySet.toIndexedSeq
   def keySet: scala.collection.Set[(Path, String)] = {
-    cache.keySet
+    cache.keySet.toSet
   }
 }

--- a/sjsonnet/test/src-jvm-native/sjsonnet/ParallelManifestRaceTests.scala
+++ b/sjsonnet/test/src-jvm-native/sjsonnet/ParallelManifestRaceTests.scala
@@ -264,6 +264,41 @@ object ParallelManifestRaceTests extends TestSuite {
 
     // ---- Fix 4: shared MemberList key-name caches (parse cache) ----
 
+    test("defaultParseCacheConcurrentColdSharedInterpreters") {
+      // End-to-end guard: independent interpreters share a cold DefaultParseCache and all parse the
+      // same root at once. This exercises CachedResolver.parse -> ParseCache.getOrElseUpdate under
+      // contention, not just direct cache calls.
+      val src =
+        """local base = { hidden:: 1, visible: 2 };
+          |{
+          |  fields: std.objectFields(base),
+          |  mapped: std.map(function(x) x * 3, [1, 2, 3]),
+          |  nested: { c: 3, a: 1, b: 2 },
+          |}
+          |""".stripMargin
+      val path = DummyPath("root", "cold-shared.jsonnet")
+      val expected =
+        new Interpreter(Map(), Map(), DummyPath("root"), Importer.empty, new DefaultParseCache)
+          .interpret(src, path)
+      assert(expected.isRight)
+
+      val sharedCache = new DefaultParseCache
+      val failure = stress { _ =>
+        var n = 0
+        while (n < 60) {
+          val got =
+            new Interpreter(Map(), Map(), DummyPath("root"), Importer.empty, sharedCache)
+              .interpret(src, path)
+          if (got != expected) {
+            throw new java.lang.AssertionError(s"unexpected interpret result: $got")
+          }
+          n += 1
+        }
+      }
+      failure.foreach(throw _)
+      assert(sharedCache.keySet.size == 1)
+    }
+
     test("sharedMemberListConcurrentVisibleKeys") {
       // A non-static object (fields reference a local, so it is NOT folded to a Val.staticObject) with
       // interleaved hidden/visible fields, evaluated by independent interpreters that SHARE one parse


### PR DESCRIPTION
## Summary

- replace `DefaultParseCache`'s non-thread-safe mutable `HashMap` with a platform cache store
- use `TrieMap` on JVM and Scala Native, while keeping a single-threaded `HashMap` shim for Scala.js/Wasm where `TrieMap` does not link
- keep the existing `ParseCache` interface and store parsed `Either[Error, (Expr, FileScope)]` values directly, without `LazyVal` or additional wrapper allocation
- add an end-to-end concurrent regression test for independent interpreters sharing a cold `DefaultParseCache`

## Notes

Concurrent cold misses for the same key may now duplicate parse work, but `putIfAbsent` ensures the cache publishes one winner and avoids mutable map corruption. The parse path is deterministic CPU work, so this keeps the fix focused on cache correctness without adding a lazy wrapper abstraction.

## Verification

- `git diff --check`
- `./mill "sjsonnet.jvm[3.3.8].checkFormat"`
- `./mill "sjsonnet.jvm[3.3.8].test.testOnly" sjsonnet.ParallelManifestRaceTests` — 8/8 passed
- `./mill "sjsonnet.js[2.13.18].test.fastLinkJSTest"`
- `./mill "sjsonnet.wasm[2.13.18].test.fastLinkJSTest"`
- `./mill "sjsonnet.js[3.3.8].test.fastLinkJSTest"`
- `./mill "sjsonnet.wasm[3.3.8].test.fastLinkJSTest"`
- `./mill "sjsonnet.native[3.3.8].compile"`
- `./mill "sjsonnet.native[2.13.18].compile"`
- `./mill "sjsonnet.jvm[2.13.18].compile"`
- Qoder stdout review: no must-fix findings
- GitHub Pull Request Validation: 5/5 checks passed