### PR TITLE
Harden remaining shared interpreter state

### DIFF
--- a/sjsonnet/src-js/sjsonnet/Platform.scala
+++ b/sjsonnet/src-js/sjsonnet/Platform.scala
@@ -523,6 +523,9 @@ object Platform {
     throw new Exception("SHA3 not implemented in Scala.js")
   }
 
+  def hashBytes(bytes: Array[Byte]): String =
+    scala.util.hashing.MurmurHash3.bytesHash(bytes).toHexString
+
   private val regexCache = new util.concurrent.ConcurrentHashMap[String, Pattern]
   private val namedGroupPattern = Pattern.compile("\\(\\?<(.+?)>.*?\\)")
   private val namedGroupPatternReplace = Pattern.compile("(\\(\\?P<)(.+?>.*?\\))")

--- a/sjsonnet/src/sjsonnet/Importer.scala
+++ b/sjsonnet/src/sjsonnet/Importer.scala
@@ -186,15 +186,55 @@ final case class StaticResolvedFile(content: String) extends ResolvedFile {
   override def readRawBytes(): Array[Byte] = content.getBytes(StandardCharsets.UTF_8)
 }
 
-final case class StaticBinaryResolvedFile(content: Array[Byte]) extends ResolvedFile {
+final class StaticBinaryResolvedFile(content0: Array[Byte])
+    extends ResolvedFile
+    with Product
+    with Serializable {
+  private val bytes: Array[Byte] = content0.clone()
+
   def getParserInput(): ParserInput = throw new NotImplementedError("Not used for binary imports")
 
   def readString(): String = throw new NotImplementedError("Not used for binary imports")
 
-  // We just cheat, the content hash can be the content itself for static imports
-  def contentHash(): String = content.hashCode().toString
+  def content: Array[Byte] = bytes
 
-  override def readRawBytes(): Array[Byte] = content
+  private lazy val contentHashValue: String = Platform.hashBytes(bytes)
+
+  def contentHash(): String = contentHashValue
+
+  override def readRawBytes(): Array[Byte] = bytes
+
+  def copy(content: Array[Byte] = this.content): StaticBinaryResolvedFile =
+    new StaticBinaryResolvedFile(content)
+
+  def productArity: Int = 1
+
+  def productElement(n: Int): Any =
+    if (n == 0) content else throw new IndexOutOfBoundsException(n.toString)
+
+  def canEqual(that: Any): Boolean = that.isInstanceOf[StaticBinaryResolvedFile]
+
+  override def productPrefix: String = "StaticBinaryResolvedFile"
+
+  override def equals(that: Any): Boolean = that match {
+    case other: StaticBinaryResolvedFile =>
+      (this eq other) || (other.canEqual(this) && java.util.Arrays.equals(bytes, other.bytes))
+    case _ => false
+  }
+
+  override def hashCode(): Int = java.util.Arrays.hashCode(bytes)
+
+  override def toString: String = productIterator.mkString(productPrefix + "(", ",", ")")
+}
+
+object StaticBinaryResolvedFile
+    extends scala.runtime.AbstractFunction1[Array[Byte], StaticBinaryResolvedFile]
+    with Serializable {
+  def apply(content: Array[Byte]): StaticBinaryResolvedFile =
+    new StaticBinaryResolvedFile(content)
+
+  def unapply(file: StaticBinaryResolvedFile): Option[Array[Byte]] =
+    if (file == null) None else Some(file.content)
 }
 
 class CachedImporter(parent: Importer) extends Importer {

--- a/sjsonnet/src/sjsonnet/StaticOptimizer.scala
+++ b/sjsonnet/src/sjsonnet/StaticOptimizer.scala
@@ -138,11 +138,11 @@ class StaticOptimizer(
       case e @ UnaryOp(pos, op, v: Val) => tryFoldUnaryOp(pos, op, v, e)
 
       // Branch elimination: constant condition in if-else
-      case IfElse(pos, _: Val.True, thenExpr, _) =>
-        thenExpr.pos = pos; thenExpr
-      case IfElse(pos, _: Val.False, _, elseExpr) =>
-        if (elseExpr == null) Val.Null(pos)
-        else { elseExpr.pos = pos; elseExpr }
+      case IfElse(_, _: Val.True, thenExpr, _) =>
+        thenExpr
+      case IfElse(_, _: Val.False, _, elseExpr) =>
+        if (elseExpr == null) Val.staticNull
+        else elseExpr
 
       // Short-circuit elimination for And/Or with constant lhs.
       //
@@ -152,10 +152,12 @@ class StaticOptimizer(
       // into just `rhs` without the Bool guard, we silently remove that runtime type check,
       // causing programs like `true && "hello"` to return "hello" instead of erroring.
       // See: Evaluator.visitAnd / Evaluator.visitOr for the authoritative runtime semantics.
-      case And(pos, _: Val.True, rhs: Val.Bool) => rhs.pos = pos; rhs
-      case And(pos, _: Val.False, _)            => Val.False(pos)
-      case Or(pos, _: Val.True, _)              => Val.True(pos)
-      case Or(pos, _: Val.False, rhs: Val.Bool) => rhs.pos = pos; rhs
+      // The lhs-result cases return lhs itself to keep the selected boolean's position and avoid
+      // turning the already-created literal/folded lhs into garbage.
+      case And(_, _: Val.True, rhs: Val.Bool) => rhs
+      case And(_, lhs: Val.False, _)          => lhs
+      case Or(_, lhs: Val.True, _)            => lhs
+      case Or(_, _: Val.False, rhs: Val.Bool) => rhs
 
       // Identity-equivalent function recognition. Cheap pattern match here keeps the runtime
       // fast path (`Val.Func.isEffectivelyIdentity`) at single-field cost.

--- a/sjsonnet/src/sjsonnet/functions/FunctionModule.scala
+++ b/sjsonnet/src/sjsonnet/functions/FunctionModule.scala
@@ -34,7 +34,11 @@ trait FunctionModule extends FunctionBuilder {
    *   the module object
    */
   def moduleFromFunctions(functions: (String, Val.Func)*): Val.Obj = {
-    Val.Obj.mk(dummyPos, functions.map { case (k, v) => (k, memberOf(v)) }: _*)
+    Val.Obj.mkWithConstCache(
+      dummyPos,
+      functions.size,
+      functions.map { case (k, v) => (k, memberOf(v)) }
+    )
   }
 
   /**
@@ -46,7 +50,11 @@ trait FunctionModule extends FunctionBuilder {
    *   the module object
    */
   def moduleFromModules(subModules: FunctionModule*): Val.Obj = {
-    Val.Obj.mk(dummyPos, subModules.map { module => (module.name, memberOf(module.module)) }: _*)
+    Val.Obj.mkWithConstCache(
+      dummyPos,
+      subModules.size,
+      subModules.map { module => (module.name, memberOf(module.module)) }
+    )
   }
 
   /**

--- a/sjsonnet/test/resources/test_suite/error.recursive_import.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.recursive_import.jsonnet.golden
@@ -1,2 +1,2 @@
 sjsonnet.Error: Max stack frames exceeded.
-    at [<root>].(error.recursive_import.jsonnet:17:1)
+    at [<root>].(error.recursive_import.jsonnet:17:15)

--- a/sjsonnet/test/src-jvm-native/sjsonnet/ParallelManifestRaceTests.scala
+++ b/sjsonnet/test/src-jvm-native/sjsonnet/ParallelManifestRaceTests.scala
@@ -11,6 +11,8 @@ import java.util.concurrent.{
   TimeUnit
 }
 import java.util.concurrent.atomic.AtomicReference
+import scala.collection.mutable
+import sjsonnet.stdlib.ArrayModule
 import sjsonnet.stdlib.StdLibModule
 import utest._
 
@@ -114,6 +116,34 @@ object ParallelManifestRaceTests extends TestSuite {
 
   private def newInterpreter(): Interpreter =
     new Interpreter(Map(), Map(), DummyPath(), Importer.empty, parseCache = new DefaultParseCache)
+
+  private val noEvalScope: EvalScope = new EvalScope {
+    def extVars: String => Option[Expr] = _ => None
+    def importer: CachedImporter = new CachedImporter(Importer.empty)
+    def wd: Path = DummyPath()
+    def visitExpr(expr: Expr)(implicit scope: ValScope): Val =
+      throw new UnsupportedOperationException("not used")
+    def materialize(v: Val): ujson.Value =
+      throw new UnsupportedOperationException("not used")
+    def equal(x: Val, y: Val): Boolean = x == y
+    def compare(x: Val, y: Val): Int = 0
+    def settings: Settings = Settings.default
+    def debugStats: DebugStats = null
+    def trace(msg: String): Unit = ()
+    def warn(e: Error): Unit = ()
+  }
+
+  private def directOptimizer(): StaticOptimizer =
+    new StaticOptimizer(
+      noEvalScope,
+      _ => None,
+      new StdLibModule().module,
+      new mutable.HashMap[String, String],
+      new mutable.HashMap[
+        Val.StaticObjectFieldSet,
+        java.util.LinkedHashMap[String, java.lang.Boolean]
+      ]
+    )
 
   /**
    * Parse + StaticOptimize `src` on `interp` and return the optimized root Expr WITHOUT evaluating it.
@@ -284,6 +314,15 @@ object ParallelManifestRaceTests extends TestSuite {
       }
     }
 
+    test("functionModulesPrefillConstCacheAtConstruction") {
+      val module = ArrayModule.module
+      for ((name, expected) <- ArrayModule.functions.take(8)) {
+        val cached = module.cachedValueForTest(name)
+        assert(cached != null)
+        assert(cached eq expected)
+      }
+    }
+
     test("sharedStdModuleConcurrentFirstAccess") {
       // Independent interpreters share one std module (Interpreter's default std is a singleton). The
       // StaticOptimizer folds `std.fn` by calling std.value(fn), so concurrent first access to a cold
@@ -428,6 +467,69 @@ object ParallelManifestRaceTests extends TestSuite {
       val arr = expr.asInstanceOf[Val.Arr]
       assert(arr.directBackingArray != null) // materialized, not a concat view
       assert(arr.length == 6)
+    }
+
+    test("optimizerReusesSharedValsWithoutMutatingPositions") {
+      val std = new StdLibModule().module
+      assert(std.pos == null)
+      val stdInterp =
+        new Interpreter(Map(), Map(), DummyPath(), Importer.empty, new DefaultParseCache, std = std)
+      assert(parseOptimized(stdInterp, "if true then std else {}") eq std)
+      assert(std.pos == null)
+
+      val truePos = Val.staticTrue.pos
+      val falsePos = Val.staticFalse.pos
+      val cachedThree = Val.cachedNum(new Position(null, -1), 3)
+      val cachedThreePos = cachedThree.pos
+      val sharedAsciiStr = Val.Str.asciiSafe(new Position(null, -1), "abc")
+      val sharedAsciiStrPos = sharedAsciiStr.pos
+      val staticNullPos = Val.staticNull.pos
+
+      val foldedTrue = parseOptimized(newInterpreter(), "if true then std.all([]) else false")
+      assert(foldedTrue.isInstanceOf[Val.True])
+      assert(foldedTrue eq Val.staticTrue)
+      assert(Val.staticTrue.pos eq truePos)
+
+      val foldedFalse = parseOptimized(newInterpreter(), "if true then std.any([]) else true")
+      assert(foldedFalse.isInstanceOf[Val.False])
+      assert(foldedFalse eq Val.staticFalse)
+      assert(Val.staticFalse.pos eq falsePos)
+
+      val foldedNum = parseOptimized(newInterpreter(), """if true then std.length("abc") else 0""")
+      assert(foldedNum.isInstanceOf[Val.Num])
+      assert(foldedNum eq cachedThree)
+      assert(cachedThree.pos eq cachedThreePos)
+
+      val foldedStr = directOptimizer().optimize(
+        Expr.IfElse(new Position(null, 123), Val.True(new Position(null, 124)), sharedAsciiStr, null)
+      )
+      assert(foldedStr.isInstanceOf[Val.AsciiSafeStr])
+      assert(foldedStr.asInstanceOf[Val.Str].str == "abc")
+      assert(foldedStr eq sharedAsciiStr)
+      assert(sharedAsciiStr.pos eq sharedAsciiStrPos)
+
+      val foldedNull = directOptimizer().optimize(
+        Expr.IfElse(new Position(null, 125), Val.True(new Position(null, 126)), Val.staticNull, null)
+      )
+      assert(foldedNull.isInstanceOf[Val.Null])
+      assert(foldedNull eq Val.staticNull)
+      assert(Val.staticNull.pos eq staticNullPos)
+
+      val lhsFalse = Val.False(new Position(null, 127))
+      val lhsFalsePos = lhsFalse.pos
+      val foldedAnd = directOptimizer().optimize(
+        Expr.And(new Position(null, 128), lhsFalse, Val.Str(new Position(null, 129), "ignored"))
+      )
+      assert(foldedAnd eq lhsFalse)
+      assert(lhsFalse.pos eq lhsFalsePos)
+
+      val lhsTrue = Val.True(new Position(null, 130))
+      val lhsTruePos = lhsTrue.pos
+      val foldedOr = directOptimizer().optimize(
+        Expr.Or(new Position(null, 131), lhsTrue, Val.Str(new Position(null, 132), "ignored"))
+      )
+      assert(foldedOr eq lhsTrue)
+      assert(lhsTrue.pos eq lhsTruePos)
     }
 
     test("sharedFoldedObjectValuesConcurrentMember") {

--- a/sjsonnet/test/src/sjsonnet/ImporterTests.scala
+++ b/sjsonnet/test/src/sjsonnet/ImporterTests.scala
@@ -33,5 +33,33 @@ object ImporterTests extends TestSuite {
       importer.read(DummyPath("missing.libsonnet"), binaryData = false) ==> None
       readCalls ==> 1
     }
+
+    test("StaticBinaryResolvedFile protects cached bytes") {
+      val original = Array[Byte](1, 2, 3)
+      val file = StaticBinaryResolvedFile(original)
+      val expected = Array[Byte](1, 2, 3)
+      val expectedHash = Platform.hashBytes(expected)
+      val fromConstructor = new StaticBinaryResolvedFile(expected)
+      val fromFunction = (StaticBinaryResolvedFile: Array[Byte] => StaticBinaryResolvedFile)(expected)
+
+      // Constructor defensively copies, so mutating the input does not affect the file.
+      original(0) = 9
+      file.readRawBytes().toSeq ==> expected.toSeq
+      file.contentHash() ==> expectedHash
+      fromConstructor.readRawBytes().toSeq ==> expected.toSeq
+      fromFunction.readRawBytes().toSeq ==> expected.toSeq
+
+      // contentHash is cached (lazy val): same reference on repeated calls.
+      assert(file.contentHash() eq file.contentHash())
+
+      file.productArity ==> 1
+      file.productElement(0).asInstanceOf[Array[Byte]].toSeq ==> expected.toSeq
+
+      StaticBinaryResolvedFile.unapply(null) ==> None
+
+      val copied = file.copy()
+      copied.readRawBytes().toSeq ==> expected.toSeq
+      copied ==> file
+    }
   }
 }


### PR DESCRIPTION

## Motivation

Issue #1047 fixed the main shared-interpreter race paths, but a broader audit found remaining shared mutable state in binary resolved files, function module objects, and StaticOptimizer position rewriting. Independent `Interpreter` instances can share process-wide values such as `std`, so optimization must not mutate shared `Val.pos` state.

A follow-up review also found that preserving the folded outer expression position by cloning `Val` literals made the optimizer safe, but added avoidable allocations. For branch and boolean short-circuit folds, the better rule is to return the selected existing expression/value and keep its own position, rather than clone it or replace it with an unrelated singleton.

## Modification

- **StaticBinaryResolvedFile**: Convert from `case class` to manual `Product` with constructor-level defensive copy, content-based `equals`/`hashCode`, and `lazy val` `contentHash` computed once via `Platform.hashBytes`.
- **Platform.hashBytes (JS)**: Add MurmurHash3-based implementation to match native binary file hashing support.
- **StaticOptimizer**: Remove folded-position rewrites for branch and boolean short-circuit folding. The optimizer now reuses selected child expressions. For `false && rhs` and `true || rhs`, it returns the original lhs boolean, preserving its position and avoiding both cloning and discarding an already-created literal/folded lhs.
- **FunctionModule.mkWithConstCache**: Pre-fill const caches at construction, eliminating lazy cache population races on shared `std` and sub-module objects.
- **Tests**: Cover binary file API behavior, shared `Val` position immutability with literal reuse, short-circuit lhs boolean reuse, function module cache pre-fill, and the accepted recursive import error-position change.

## Result

Independent interpreters sharing the `std` singleton no longer corrupt each other through StaticOptimizer position mutation or lazy cache population. StaticOptimizer avoids the extra literal allocation that `withFoldedPos` introduced, and the lhs-result short-circuit cases now preserve the original lhs boolean position while avoiding avoidable garbage. `StaticBinaryResolvedFile` has content-based equality and cached hashing.

## Risks

- Folded-expression error stack locations can now point at the selected child expression rather than the folded outer expression. The recursive import golden changes from `17:1` to `17:15`, which points at the actual `import` expression and is acceptable for this optimization.
- The optimizer intentionally relies on shared literal immutability by never mutating reused `Val.pos`; regression tests assert reused singletons, cached literals, and short-circuit lhs booleans keep their original positions.

## Validation

- `./mill sjsonnet.jvm[3.3.8].test`: 143/143, SUCCESS
- `./mill sjsonnet.js[3.3.8].test.fastLinkJSTest`: 157/157, SUCCESS
- `./mill sjsonnet.wasm[3.3.8].test.fastLinkJSTest`: 157/157, SUCCESS
- `./mill sjsonnet.native[3.3.8].compile`: 68/68, SUCCESS
- `./mill sjsonnet.jvm[2.12.21].compile`: 61/61, SUCCESS
- `./mill sjsonnet.jvm[2.13.18].compile`: 61/61, SUCCESS
- `./mill __.checkFormat`: 36/36, SUCCESS
- `git diff --check upstream/master..HEAD`: SUCCESS

## References

- https://github.com/databricks/sjsonnet/issues/1047
