### PR TITLE
Align CLI behavior with go-jsonnet

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -382,6 +382,84 @@ object sjsonnet extends VersionFileModule {
     def forkArgs =
       Seq("-Xss" + stackSize, "--enable-native-access=ALL-UNNAMED")
 
+    override def prependShellScript = mill.util.Jvm.universalScript(
+      shellCommands =
+        s"""if [ -z "$$JAVA_HOME" ] ; then
+           |  JAVACMD="java"
+           |else
+           |  JAVACMD="$$JAVA_HOME/bin/java"
+           |fi
+           |SJSONNET_JAVA_OPTS=""
+           |if "$$JAVACMD" --sun-misc-unsafe-memory-access=allow -version >/dev/null 2>&1; then
+           |  SJSONNET_JAVA_OPTS="--sun-misc-unsafe-memory-access=allow"
+           |fi
+           |exec "$$JAVACMD" -Xss$stackSize --enable-native-access=ALL-UNNAMED $$SJSONNET_JAVA_OPTS $$JAVA_OPTS -cp "$$0" 'sjsonnet.SjsonnetMain' "$$@"""".stripMargin,
+      cmdCommands =
+        s"""set "JAVACMD=java.exe"
+           |if not "%JAVA_HOME%"=="" set "JAVACMD=%JAVA_HOME%\\bin\\java.exe"
+           |set "SJSONNET_JAVA_OPTS="
+           |"%JAVACMD%" --sun-misc-unsafe-memory-access=allow -version >nul 2>&1
+           |if "%errorlevel%" == "0" set "SJSONNET_JAVA_OPTS=--sun-misc-unsafe-memory-access=allow"
+           |"%JAVACMD%" -Xss$stackSize --enable-native-access=ALL-UNNAMED %SJSONNET_JAVA_OPTS% %JAVA_OPTS% -cp "%~dpnx0" "sjsonnet.SjsonnetMain" %*""".stripMargin
+    )
+
+    def assemblySmoke = Task {
+      val jar = assembly().path
+      val jarCommand =
+        if (scala.util.Properties.isWin) Seq[os.Shellable](jar)
+        else
+          Seq[os.Shellable](
+            "env",
+            "-u",
+            "JDK_JAVA_OPTIONS",
+            "-u",
+            "JAVA_TOOL_OPTIONS",
+            jar
+          )
+      def callJar(args: os.Shellable*) =
+        os.proc((jarCommand ++ args)*).call(
+          stdout = os.Pipe,
+          stderr = os.Pipe,
+          check = false
+        )
+
+      val version = callJar("--version")
+      assert(
+        version.exitCode == 0,
+        s"--version failed with exit ${version.exitCode}: ${version.err.text()}"
+      )
+      assert(version.err.text().isEmpty, s"--version stderr was not empty: ${version.err.text()}")
+
+      val help = callJar("--help")
+      val helpOut = help.out.text()
+      val helpErr = help.err.text()
+      assert(help.exitCode == 0, s"--help failed with exit ${help.exitCode}: $helpErr")
+      assert(helpErr.isEmpty, s"--help stderr was not empty: $helpErr")
+      assert(!helpOut.contains("Missing argument"), helpOut)
+      assert(!helpOut.contains("Unknown argument"), helpOut)
+
+      val stack = callJar(
+        "--exec",
+        "--max-stack",
+        "2",
+        "local f(n) = if n == 0 then 0 else f(n - 1); f(3)"
+      )
+      val stackErr = stack.err.text()
+      assert(stack.exitCode != 0, s"--max-stack unexpectedly exited ${stack.exitCode}")
+      assert(stackErr.contains("Max stack frames exceeded."), stackErr)
+
+      val defaultStack = callJar(
+        "--exec",
+        "local f(n) = if n == 0 then 0 else f(n - 1); f(1000)"
+      )
+      val defaultStackErr = defaultStack.err.text()
+      assert(
+        defaultStack.exitCode != 0,
+        s"default max-stack unexpectedly exited ${defaultStack.exitCode}"
+      )
+      assert(defaultStackErr.contains("Max stack frames exceeded."), defaultStackErr)
+    }
+
     def scalacOptions = super.scalacOptions() ++ Seq("-release", "17") ++
       (if (JvmWorkerUtil.isScala3(scalaVersion())) Seq("-Yfuture-lazy-vals") else Seq.empty)
     def javacOptions = super.javacOptions() ++ Seq("--release", "17")

--- a/readme.md
+++ b/readme.md
@@ -13,8 +13,8 @@ Expected Signature: Sjsonnet 0.7.0
 usage: sjsonnet [sjsonnet-options] script-file
   -A --tla-str <str>                  <var>[=<val>] Provide top-level arguments as string. 'If <val>
                                       is omitted, get from environment var <var>
-  -J --jpath <str>                    Specify an additional library search dir (left-most wins
-                                      unless reverse-jpaths-priority is set)
+  -J --jpath <str>                    Specify an additional library search dir (right-most wins,
+                                      matching go-jsonnet)
   -S --string                         Expect a string, manifest as plain text
   -V --ext-str <str>                  <var>[=<val>] Provide 'external' variable as string. 'If <val>
                                       is omitted, get from environment var <var>
@@ -44,9 +44,11 @@ usage: sjsonnet [sjsonnet-options] script-file
   --profile <str>                     Profile evaluation and write results to a file. Format:
                                       --profile <file> or --profile <format>:<file> where format is
                                       'text' (default) or 'flamegraph'
-  --reverse-jpaths-priority           If set, reverses the import order of specified jpaths (so that the
-                                      rightmost wins)
+  --reverse-jpaths-priority           Deprecated compatibility flag; --jpath already uses
+                                      right-most-wins priority
   -s --max-stack <int>                Number of allowed stack frames (default 500)
+  -t --max-trace <int>                Max length of stack trace before cropping (default 20, 0 means
+                                      unlimited)
   --strict                            Enforce some additional syntax limitations
   --throw-error-for-invalid-sets      Throw an error if a set operation is used on a non-set
   --tla-code <str>                    <var>[=<val>] Provide top-level arguments as Jsonnet code. 'If
@@ -55,6 +57,7 @@ usage: sjsonnet [sjsonnet-options] script-file
                                       code from the file
   --tla-str-file <str>                <var>=<file> Provide top-level arguments variable as string from
                                       the file
+  --version                           Print version
   -y --yaml-stream                    Write output as a YAML stream of JSON documents
   --yaml-debug                        Generate source line comments in the output YAML doc to make it
                                       easier to figure out where values come from.

--- a/sjsonnet/src-jvm-native/sjsonnet/Config.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/Config.scala
@@ -7,8 +7,7 @@ final case class Config(
     @arg(
       name = "jpath",
       short = 'J',
-      doc =
-        "Specify an additional library search dir (left-most wins unless reverse-jpaths-priority is set)"
+      doc = "Specify an additional library search dir (right-most wins, matching go-jsonnet)"
     )
     private val jpaths: List[String] = Nil,
     @arg(
@@ -140,7 +139,7 @@ final case class Config(
     throwErrorForInvalidSets: Flag = Flag(),
     @arg(
       name = "reverse-jpaths-priority",
-      doc = """If set, reverses the import order of specified jpaths (so that the rightmost wins)"""
+      doc = """Deprecated compatibility flag; --jpath already uses right-most-wins priority"""
     )
     reverseJpathsPriority: Flag = Flag(),
     @arg(
@@ -166,11 +165,22 @@ final case class Config(
     )
     debugStats: Flag = Flag(),
     @arg(
+      name = "version",
+      doc = "Print version"
+    )
+    version: Flag = Flag(),
+    @arg(
       name = "max-stack",
       short = 's',
       doc = "Number of allowed stack frames (default 500)"
     )
     maxStack: Int = 500,
+    @arg(
+      name = "max-trace",
+      short = 't',
+      doc = "Max length of stack trace before cropping (default 20, 0 means unlimited)"
+    )
+    maxTrace: Int = 20,
     @arg(
       name = "profile",
       doc =
@@ -188,16 +198,15 @@ final case class Config(
    * Returns the sequence of jpaths, combining command-line flags and the JSONNET_PATH environment
    * variable.
    *
-   * JSONNET_PATH directories always have lower priority than --jpath flags. Within JSONNET_PATH,
-   * the left-most entry has the highest priority, matching the behavior of the C++ and Go
-   * implementations.
+   * JSONNET_PATH directories always have lower priority than --jpath flags. Command-line --jpath
+   * flags use right-most-wins priority, while JSONNET_PATH keeps left-most-wins priority, matching
+   * the behavior of the C++ and Go implementations.
    *
-   * The --reverse-jpaths-priority flag only affects the ordering of --jpath flags (reversing them
-   * so that the rightmost wins, matching go-jsonnet behavior). JSONNET_PATH entries are always
-   * appended after the (possibly reversed) --jpath flags.
+   * The --reverse-jpaths-priority flag is retained for CLI compatibility and no longer changes
+   * ordering because sjsonnet now matches go-jsonnet by default. JSONNET_PATH entries are always
+   * appended after --jpath flags.
    *
-   * For example, `JSONNET_PATH=a:b sjsonnet -J c -J d` results in search order: c, d, a, b (default
-   * mode). With --reverse-jpaths-priority, the order becomes: d, c, a, b.
+   * For example, `JSONNET_PATH=a:b sjsonnet -J c -J d` results in search order: d, c, a, b.
    *
    * See [[https://jsonnet-libs.github.io/jsonnet-training-course/lesson2.html#jsonnet_path]] for
    * details.
@@ -215,8 +224,7 @@ final case class Config(
   def getOrderedJpaths(jsonnetPathEnv: Option[String]): Seq[String] = {
     val envValue = jsonnetPathEnv.getOrElse(System.getenv("JSONNET_PATH"))
     val envPaths = Config.jsonnetPathEntries(envValue)
-    val orderedJpaths = if (reverseJpathsPriority.value) jpaths.reverse else jpaths
-    orderedJpaths ++ envPaths
+    jpaths.reverse ++ envPaths
   }
 }
 

--- a/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMainBase.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMainBase.scala
@@ -161,13 +161,27 @@ object SjsonnetMainBase {
         |    JSONNET_PATH=a:b sjsonnet -J c -J d
         |    JSONNET_PATH=d:c:a:b sjsonnet
         |    sjsonnet -J b -J a -J c -J d""".stripMargin
+    val normalizedArgs = normalizeCliArgs(args)
+    if (hasHelp(normalizedArgs.args)) {
+      val helpText = parser.helpText(customName = name, customDoc = doc)
+      stdout.println(helpText + envVarsDoc)
+      return 0
+    }
+    if (hasVersion(normalizedArgs.args)) {
+      stdout.println(name)
+      return 0
+    }
 
     var statsToReport: DebugStats = null
 
     val result = for {
-      config <- parser
+      _ <- {
+        if (normalizedArgs.extraArgsAfterDoubleDash) Left("ERROR: only one filename is allowed")
+        else Right(())
+      }
+      config0 <- parser
         .constructEither(
-          args.toIndexedSeq,
+          normalizedArgs.args.toIndexedSeq,
           allowRepeats = true,
           customName = name,
           customDoc = doc,
@@ -175,9 +189,10 @@ object SjsonnetMainBase {
         )
         .left
         .map(_ + envVarsDoc)
+      config = normalizedArgs.forcedFile.fold(config0)(f => config0.copy(file = f))
       _ <- {
         if (config.noTrailingNewline.value && config.yamlStream.value)
-          Left("error: cannot use --no-trailing-newline with --yaml-stream")
+          Left("ERROR: cannot use --no-trailing-newline with --yaml-stream")
         else Right(())
       }
       file <- Right(config.file)
@@ -194,7 +209,9 @@ object SjsonnetMainBase {
           throwErrorForInvalidSets = config.throwErrorForInvalidSets.value,
           maxParserRecursionDepth = config.maxParserRecursionDepth,
           brokenAssertionLogic = config.brokenAssertionLogic.value,
-          maxStack = config.maxStack
+          maxStack = config.maxStack,
+          countTailCallStackFrames = false,
+          maxTrace = config.maxTrace
         ),
         parseCache,
         wd,
@@ -244,17 +261,110 @@ object SjsonnetMainBase {
               // In multi mode, the file list on stdout always ends with a newline,
               // matching go-jsonnet/C++ jsonnet behavior. --no-trailing-newline only
               // affects the content written to the output files, not the file list.
-              if (config.multi.isDefined || !config.noTrailingNewline.value) stdout.println(str)
+              if (config.yamlStream.value) stdout.print(str)
+              else if (config.multi.isDefined || !config.noTrailingNewline.value)
+                stdout.println(str)
               else stdout.print(str)
               0
             case Some(f) =>
-              handleWriteFile(f)(os.write.over(os.Path(f, wd), str)) match {
+              handleWriteFile(f)(
+                os.write.over(os.Path(f, wd), str, createFolders = config.createDirs.value)
+              ) match {
                 case Left(err) => stderr.println(err); 1
                 case Right(_)  => 0
               }
           }
         } else 0
     }
+  }
+
+  private final case class NormalizedArgs(
+      args: Array[String],
+      forcedFile: Option[String],
+      extraArgsAfterDoubleDash: Boolean)
+  private final val DoubleDashFilePlaceholder = "__sjsonnet_file_after_double_dash__"
+  private val ValueTakingLongOptions = Set(
+    "--ext-code",
+    "--ext-code-file",
+    "--ext-str",
+    "--ext-str-file",
+    "--jpath",
+    "--max-parser-recursion-depth",
+    "--max-stack",
+    "--max-trace",
+    "--multi",
+    "--output-file",
+    "--profile",
+    "--tla-code",
+    "--tla-code-file",
+    "--tla-str",
+    "--tla-str-file",
+    "--indent"
+  )
+  private val ValueTakingShortOptions = Set('A', 'J', 'V', 'm', 'n', 'o', 's', 't')
+
+  private def hasHelp(args: Array[String]): Boolean =
+    hasControlFlag(args, arg => arg == "--help" || arg == "-h")
+
+  private def hasVersion(args: Array[String]): Boolean =
+    hasControlFlag(args, arg => arg == "--version" || arg == "-v")
+
+  private def hasControlFlag(args: Array[String], matches: String => Boolean): Boolean = {
+    var i = 0
+    while (i < args.length) {
+      val arg = args(i)
+      if (optionTakesFollowingValue(arg)) i += 2
+      else {
+        if (matches(arg)) return true
+        i += 1
+      }
+    }
+    false
+  }
+
+  private def optionTakesFollowingValue(arg: String): Boolean =
+    if (arg.startsWith("--")) {
+      val eqIndex = arg.indexOf('=')
+      val optionName = if (eqIndex < 0) arg else arg.substring(0, eqIndex)
+      eqIndex < 0 && ValueTakingLongOptions(optionName)
+    } else arg.length == 2 && arg.charAt(0) == '-' && ValueTakingShortOptions(arg.charAt(1))
+
+  private def normalizeCliArgs(args: Array[String]): NormalizedArgs = {
+    val expanded = Array.newBuilder[String]
+    var i = 0
+    var forcedFile: Option[String] = None
+    var extraArgsAfterDoubleDash = false
+    var expectingValue = false
+    while (i < args.length) {
+      val arg = args(i)
+      if (expectingValue) {
+        expanded += arg
+        expectingValue = false
+      } else if (arg == "--") {
+        if (i + 1 < args.length) {
+          forcedFile = Some(args(i + 1))
+          expanded += DoubleDashFilePlaceholder
+          extraArgsAfterDoubleDash = i + 2 < args.length
+        }
+        i = args.length
+      } else if (arg == "-" || arg.startsWith("--") || arg.length <= 2) {
+        expanded += arg
+        expectingValue = optionTakesFollowingValue(arg)
+      } else if (arg.charAt(0) == '-') {
+        var j = 1
+        var lastExpanded: String = null
+        while (j < arg.length) {
+          lastExpanded = "-" + arg.charAt(j)
+          expanded += lastExpanded
+          j += 1
+        }
+        expectingValue = optionTakesFollowingValue(lastExpanded)
+      } else {
+        expanded += arg
+      }
+      i += 1
+    }
+    NormalizedArgs(expanded.result(), forcedFile, extraArgsAfterDoubleDash)
   }
 
   private def rendererForConfig(wr: Writer, config: Config, getCurrentPosition: () => Position) =
@@ -304,11 +414,11 @@ object SjsonnetMainBase {
       case e                       => e.toString
     }
 
-  private def handleRenderError[T](f: => T): Either[String, T] =
+  private def handleRenderError[T](maxTrace: Int)(f: => T): Either[String, T] =
     try Right(f)
     catch {
       case e: Error if e.stack.isEmpty => Left(s"sjsonnet.Error: ${e.getMessage}")
-      case e: Error                    => Left(Error.formatError(e))
+      case e: Error                    => Left(Error.formatError(e, maxTrace))
     }
 
   private def writeFile(
@@ -363,6 +473,7 @@ object SjsonnetMainBase {
             val buf = new BufferedOutputStream(out, SjsonnetMainBase.OutputBufferSize)
             val renderer = new ByteRenderer(buf, indent = config.indent)
             val res = interp.interpret0(jsonnetCode, path, renderer)
+            if (res.isRight && !config.noTrailingNewline.value) buf.write('\n')
             buf.flush()
             res.map(_ => "")
           } finally out.close()
@@ -380,12 +491,24 @@ object SjsonnetMainBase {
           val renderer = rendererForConfig(writer, config, getCurrentPosition)
           val res = interp.interpret0(jsonnetCode, path, renderer)
           if (config.yamlOut.value && !config.noTrailingNewline.value) writer.write('\n')
+          else if (
+            config.outputFile.isDefined &&
+            !config.noTrailingNewline.value &&
+            !config.yamlStream.value
+          ) writer.write('\n')
           res
         }
     }
   }
 
-  private def isScalar(v: ujson.Value) = !v.isInstanceOf[ujson.Arr] && !v.isInstanceOf[ujson.Obj]
+  private def jsonTypeName(v: ujson.Value): String = v match {
+    case _: ujson.Obj  => "object"
+    case _: ujson.Arr  => "array"
+    case _: ujson.Str  => "string"
+    case _: ujson.Num  => "number"
+    case _: ujson.Bool => "boolean"
+    case ujson.Null    => "null"
+  }
 
   /**
    * Parse CLI binding arguments.
@@ -563,7 +686,7 @@ object SjsonnetMainBase {
             val renderedFiles: Seq[Either[String, os.FilePath]] =
               obj.value.toSeq.map { case (f, v) =>
                 for {
-                  rendered <- handleRenderError {
+                  rendered <- handleRenderError(config.maxTrace) {
                     val writer = new StringWriter()
                     val renderer = rendererForConfig(writer, config, () => currentPos)
                     ujson.transform(v, renderer)
@@ -595,33 +718,28 @@ object SjsonnetMainBase {
         interp.interpret(jsonnetCode, path).flatMap {
           case arr: ujson.Arr =>
             writeToFile(config, wd) { writer =>
-              handleRenderError {
-                arr.value.toSeq match {
-                  case Nil         => // donothing
-                  case Seq(single) =>
-                    val renderer = rendererForConfig(writer, config, () => currentPos)
-                    single.transform(renderer)
-                    writer.write(if (isScalar(single)) "\n..." else "")
-                  case multiple =>
-                    for ((v, i) <- multiple.zipWithIndex) {
-                      if (i > 0) writer.write('\n')
-                      if (isScalar(v)) writer.write("--- ")
-                      else if (i != 0) writer.write("---\n")
-                      val renderer = rendererForConfig(
-                        writer,
-                        config.copy(yamlOut = mainargs.Flag(true)),
-                        () => currentPos
-                      )
-                      v.transform(renderer)
-                    }
+              handleRenderError(config.maxTrace) {
+                val values = arr.value.toSeq
+                if (values.nonEmpty) {
+                  for (v <- values) {
+                    writer.write("---\n")
+                    val renderer = new Renderer(writer, indent = config.indent)
+                    v.transform(renderer)
+                    writer.write('\n')
+                  }
+                  writer.write("...\n")
                 }
-                writer.write('\n')
                 ""
               }
             }
 
-          case _ =>
-            renderNormal(config, interp, jsonnetCode, path, wd, () => currentPos, stdoutStream)
+          case other =>
+            Left(
+              "RUNTIME ERROR: stream mode: top-level object was a " +
+              jsonTypeName(other) +
+              ", should be an array whose elements hold the JSON for each document in the stream.\n" +
+              "\tDuring manifestation\t\n"
+            )
         }
       case _ =>
         renderNormal(config, interp, jsonnetCode, path, wd, () => currentPos, stdoutStream)

--- a/sjsonnet/src/sjsonnet/Error.scala
+++ b/sjsonnet/src/sjsonnet/Error.scala
@@ -103,7 +103,9 @@ object Error {
 
   private val rootName = Util.wrapInLessThanGreaterThan("root")
 
-  def formatError(e: Throwable): String = e match {
+  def formatError(e: Throwable): String = formatError(e, maxTrace = 0)
+
+  def formatError(e: Throwable, maxTrace: Int): String = e match {
     case err: Error if err.stack.nonEmpty =>
       val sb = new StringBuilder
       sb.append(err.getClass.getName).append(": ")
@@ -148,11 +150,33 @@ object Error {
       }
 
       sb.append(msg)
-      var i = frameStart
-      while (i < frames.size) {
-        val (f, name) = frames.get(i)
-        appendFrame(sb, f, name)
-        i += 1
+      val traceSize = frames.size - frameStart
+      if (maxTrace > 0 && traceSize > maxTrace) {
+        val headCount = maxTrace / 2
+        val tailCount = maxTrace - 1 - headCount
+
+        var i = frameStart
+        while (i < frameStart + headCount) {
+          val (f, name) = frames.get(i)
+          appendFrame(sb, f, name)
+          i += 1
+        }
+
+        sb.append("\n    ...")
+
+        i = frames.size - tailCount
+        while (i < frames.size) {
+          val (f, name) = frames.get(i)
+          appendFrame(sb, f, name)
+          i += 1
+        }
+      } else {
+        var i = frameStart
+        while (i < frames.size) {
+          val (f, name) = frames.get(i)
+          appendFrame(sb, f, name)
+          i += 1
+        }
       }
       if (err.getCause != null) {
         sb.append("\nCaused by: ")

--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -46,7 +46,7 @@ class Evaluator(
       Error.fail("Max stack frames exceeded.", pos)
   }
 
-  @inline private[sjsonnet] final def checkStackDepth(pos: Position, expr: Expr): Unit = {
+  @inline private[sjsonnet] final override def checkStackDepth(pos: Position, expr: Expr): Unit = {
     stackDepth += 1
     if (stackDepth > maxStack)
       Error.fail("Max stack frames exceeded.", pos)
@@ -58,7 +58,7 @@ class Evaluator(
       Error.fail("Max stack frames exceeded.", pos)
   }
 
-  @inline private[sjsonnet] final def decrementStackDepth(): Unit = {
+  @inline private[sjsonnet] final override def decrementStackDepth(): Unit = {
     stackDepth -= 1
   }
 

--- a/sjsonnet/src/sjsonnet/Interpreter.scala
+++ b/sjsonnet/src/sjsonnet/Interpreter.scala
@@ -180,7 +180,7 @@ class Interpreter(
     (for {
       v <- evaluate(txt, path)
       r <- materialize(v, visitor)
-    } yield r).left.map(e => Error.formatError(ensureRootFrame(e)))
+    } yield r).left.map(e => Error.formatError(ensureRootFrame(e), settings.maxTrace))
 
   private def handleException[T](f: => T): Either[Error, T] = {
     try Right(f)

--- a/sjsonnet/src/sjsonnet/Settings.scala
+++ b/sjsonnet/src/sjsonnet/Settings.scala
@@ -13,7 +13,9 @@ final case class Settings(
     maxMaterializeDepth: Int = 1000,
     materializeRecursiveDepthLimit: Int = 128,
     maxStack: Int = 500,
-    strictFormatBooleanConversions: Boolean = false
+    strictFormatBooleanConversions: Boolean = false,
+    countTailCallStackFrames: Boolean = false,
+    maxTrace: Int = 0
 )
 
 object Settings {

--- a/sjsonnet/src/sjsonnet/Val.scala
+++ b/sjsonnet/src/sjsonnet/Val.scala
@@ -3288,42 +3288,47 @@ object TailCall {
    * Error frames preserve the original call-site expression name (e.g. "Apply2") so that TCO does
    * not alter user-visible stack traces.
    */
-  def resolve(current: Val)(implicit ev: EvalScope): Val = resolve(current, false, null, null)
-
-  @tailrec
-  private def resolve(
-      current: Val,
-      booleanIsAnd: Boolean,
-      booleanPos: Position,
-      errorValuePos: Position)(implicit ev: EvalScope): Val =
-    current match {
-      case tc: TailCall =>
+  def resolve(current: Val)(implicit ev: EvalScope): Val = {
+    var enteredStackFrames = 0
+    var next = current
+    var booleanIsAnd = false
+    var booleanPos: Position = null
+    var errorValuePos: Position = null
+    val countStackFrames = ev.settings.countTailCallStackFrames
+    try {
+      while (next.isInstanceOf[TailCall]) {
+        val tc = next.asInstanceOf[TailCall]
         val tcErrorPos = tc.resultErrorValuePos
         val tcBooleanPos = tc.resultBooleanPos
+        if (countStackFrames) {
+          enteredStackFrames += 1
+          ev.checkStackDepth(tc.callSiteExpr.pos, tc.callSiteExpr)
+        }
         if (tcErrorPos ne null) {
           // Inner error throws before any outer continuation can run.
-          resolve(
-            resolveNext(tc),
-            tc.resultBooleanIsAnd,
-            tcBooleanPos,
-            tcErrorPos
-          )
+          next = resolveNext(tc)
+          booleanIsAnd = tc.resultBooleanIsAnd
+          booleanPos = tcBooleanPos
+          errorValuePos = tcErrorPos
         } else if (tcBooleanPos ne null) {
           // If the inner boolean check passes, outer boolean checks necessarily pass on the same
           // boolean value. Preserve only an outer error, which still runs after the inner check.
-          resolve(
-            resolveNext(tc),
-            tc.resultBooleanIsAnd,
-            tcBooleanPos,
-            errorValuePos
-          )
+          next = resolveNext(tc)
+          booleanIsAnd = tc.resultBooleanIsAnd
+          booleanPos = tcBooleanPos
         } else {
-          resolve(resolveNext(tc), booleanIsAnd, booleanPos, errorValuePos)
+          next = resolveNext(tc)
         }
-      case result =>
-        if ((booleanPos eq null) && (errorValuePos eq null)) result
-        else applyResultChecks(result, booleanIsAnd, booleanPos, errorValuePos)
+      }
+      if ((booleanPos eq null) && (errorValuePos eq null)) next
+      else applyResultChecks(next, booleanIsAnd, booleanPos, errorValuePos)
+    } finally {
+      while (enteredStackFrames > 0) {
+        ev.decrementStackDepth()
+        enteredStackFrames -= 1
+      }
     }
+  }
 }
 
 /**
@@ -3346,6 +3351,9 @@ abstract class EvalScope extends EvalErrorScope with Ordering[Val] {
   def debugStats: DebugStats
   def trace(msg: String): Unit
   def warn(e: Error): Unit
+
+  private[sjsonnet] def checkStackDepth(pos: Position, expr: Expr): Unit = ()
+  private[sjsonnet] def decrementStackDepth(): Unit = ()
 
   /**
    * The format cache used by the `%` operator and `std.format` to avoid re-parsing format strings.

--- a/sjsonnet/test/src-jvm-native/sjsonnet/ConfigTests.scala
+++ b/sjsonnet/test/src-jvm-native/sjsonnet/ConfigTests.scala
@@ -53,12 +53,12 @@ object ConfigTests extends TestSuite {
 
     test("getOrderedJpaths") {
       test("jpathsOnlyDefaultOrder") {
-        // Without JSONNET_PATH env set, getOrderedJpaths should return jpaths in original order
+        // Matches go-jsonnet: right-most -J has highest priority
         val config = Config(jpaths = List("/x", "/y", "/z"), file = "test.jsonnet")
         val result = config.getOrderedJpaths(jsonnetPathEnv = Some(""))
-        assert(result == Seq("/x", "/y", "/z"))
+        assert(result == Seq("/z", "/y", "/x"))
       }
-      test("jpathsOnlyReversed") {
+      test("reverseJpathsPriorityIsCompatibilityNoop") {
         import mainargs.Flag
         val config = Config(
           jpaths = List("/x", "/y", "/z"),
@@ -71,8 +71,8 @@ object ConfigTests extends TestSuite {
       test("envPathsAppendedAfterJpaths") {
         val config = Config(jpaths = List("/c", "/d"), file = "test.jsonnet")
         val result = config.getOrderedJpaths(jsonnetPathEnv = Some(s"/a$sep/b"))
-        // -J paths first, then JSONNET_PATH entries in original order
-        assert(result == Seq("/c", "/d", "/a", "/b"))
+        // -J paths first using right-most priority, then JSONNET_PATH entries in original order
+        assert(result == Seq("/d", "/c", "/a", "/b"))
       }
       test("envPathsWithReverse") {
         import mainargs.Flag
@@ -82,7 +82,7 @@ object ConfigTests extends TestSuite {
           file = "test.jsonnet"
         )
         val result = config.getOrderedJpaths(jsonnetPathEnv = Some(s"/a$sep/b"))
-        // reversed -J paths first, then JSONNET_PATH entries in original order
+        // compatibility flag is now a no-op; default already matches go-jsonnet
         assert(result == Seq("/d", "/c", "/a", "/b"))
       }
       test("envPathsOnlyNoJpaths") {

--- a/sjsonnet/test/src-jvm/sjsonnet/MainTests.scala
+++ b/sjsonnet/test/src-jvm/sjsonnet/MainTests.scala
@@ -8,8 +8,6 @@ import java.util
 object MainTests extends TestSuite {
   val workspaceRoot: os.Path = sys.env.get("MILL_WORKSPACE_ROOT").map(os.Path(_)).getOrElse(os.pwd)
   val testSuiteRoot: os.Path = workspaceRoot / "sjsonnet" / "test" / "resources"
-  // stdout mode uses println so it has an extra platform-specific line separator at the end
-  val eol: String = java.lang.System.lineSeparator()
 
   val tests: Tests = Tests {
     // Compare writing to stdout with writing to a file
@@ -42,7 +40,7 @@ object MainTests extends TestSuite {
 
       // println(stdoutBytes.map(_.toInt).mkString(","))
       // println(fileBytes.map(_.toInt).mkString(","))
-      assert(util.Arrays.equals(fileBytes ++ eol.getBytes, stdoutBytes))
+      assert(util.Arrays.equals(fileBytes, stdoutBytes))
     }
 
     test("warnings") {
@@ -55,8 +53,10 @@ object MainTests extends TestSuite {
     }
 
     test("shortVOnlyAliasesExtStr") {
-      val (_, _, err) = runMain("--help")
-      val shortVLines = err.linesIterator.filter(_.startsWith("  -V --")).toSeq
+      val (res, out, err) = runMain("--help")
+      val shortVLines = out.linesIterator.filter(_.startsWith("  -V --")).toSeq
+      assert(res == 0)
+      assert(err.isEmpty)
       assert(shortVLines.length == 1)
       assert(shortVLines.head.contains("--ext-str"))
     }
@@ -75,6 +75,120 @@ object MainTests extends TestSuite {
       assert(res == 1)
       assert(out.isEmpty)
       assert(err.startsWith(expected))
+    }
+
+    test("versionDoesNotRequireInputFile") {
+      val (res, out, err) = runMain("--version")
+      assert(res == 0)
+      assert(out.startsWith("Sjsonnet "))
+      assert(err.isEmpty)
+
+      val (resShort, outShort, errShort) = runMain("-v")
+      assert(resShort == 0)
+      assert(outShort == out)
+      assert(errShort.isEmpty)
+
+      val (resWithFile, outWithFile, errWithFile) = runMain("--version", "ignored.jsonnet")
+      assert(resWithFile == 0)
+      assert(outWithFile == out)
+      assert(errWithFile.isEmpty)
+    }
+
+    test("shortOptionClustersAreExpanded") {
+      val (res, out, err) = runMain("-eS", """"hello"""")
+      assert((res, out, err) == ((0, "hello\n", "")))
+
+      val (resReversed, outReversed, errReversed) = runMain("-Se", """"hello"""")
+      assert((resReversed, outReversed, errReversed) == ((0, "hello\n", "")))
+    }
+
+    test("doubleDashStopsOptionProcessing") {
+      val (resExec, outExec, errExec) = runMain("-e", "--", "1")
+      assert((resExec, outExec, errExec) == ((0, "1\n", "")))
+
+      val fileName = "-sjsonnet-cli-double-dash-test.jsonnet"
+      val file = workspaceRoot / fileName
+      os.write.over(file, "1")
+      try {
+        val (resFile, outFile, errFile) = runMain("--", fileName)
+        assert((resFile, outFile, errFile) == ((0, "1\n", "")))
+      } finally os.remove(file)
+
+      val (resVersionFile, outVersionFile, errVersionFile) = runMain("--", "--version")
+      assert(resVersionFile == 1)
+      assert(outVersionFile.isEmpty)
+      assert(errVersionFile.contains("Opening input file: --version"))
+
+      val (resExtraHelp, outExtraHelp, errExtraHelp) = runMain("--", fileName, "-h")
+      assert(resExtraHelp == 1)
+      assert(outExtraHelp.isEmpty)
+      assert(errExtraHelp.contains("only one filename is allowed"))
+    }
+
+    test("helpIncludesMaxTrace") {
+      val (res, out, err) = runMain("--help")
+      assert(res == 0)
+      assert(out.contains("-t --max-trace"))
+      assert(out.contains("--version"))
+      assert(!out.contains("Missing argument"))
+      assert(!out.contains("Unknown argument"))
+      assert(err.isEmpty)
+    }
+
+    test("maxStackCountsNonTailRecursiveCalls") {
+      val (res, out, err) = runMain(
+        "--exec",
+        "--max-stack",
+        "2",
+        "local f(n) = if n == 0 then 0 else 1 + f(n - 1); f(3)"
+      )
+      assert(res == 1)
+      assert(out.isEmpty)
+      assert(err.contains("Max stack frames exceeded."))
+    }
+
+    test("maxStackDoesNotCountTailRecursiveCalls") {
+      val (res, out, err) = runMain(
+        "--exec",
+        "--max-stack",
+        "2",
+        "local f(n) = if n == 0 then 0 else f(n - 1); f(3)"
+      )
+      assert((res, out, err) == ((0, "0\n", "")))
+    }
+
+    test("defaultMaxStackDoesNotCountTailRecursiveCalls") {
+      val (res, out, err) = runMain(
+        "--exec",
+        "local f(n) = if n == 0 then 0 else f(n - 1); f(1000)"
+      )
+      assert((res, out, err) == ((0, "0\n", "")))
+    }
+
+    test("controlFlagsAreSkippedWhenTheyAreOptionValues") {
+      val wd = os.temp.dir()
+
+      val (resVersion, outVersion, errVersion) =
+        runMainInWd(wd, "--output-file", "--version", "--exec", "1")
+      assert((resVersion, outVersion, errVersion) == ((0, "", "")))
+      assert(os.read(wd / "--version") == "1\n")
+
+      val (resHelp, outHelp, errHelp) =
+        runMainInWd(wd, "--output-file", "--help", "--exec", "1")
+      assert((resHelp, outHelp, errHelp) == ((0, "", "")))
+      assert(os.read(wd / "--help") == "1\n")
+
+      val (resShortVersion, outShortVersion, errShortVersion) =
+        runMainInWd(wd, "-o", "-v", "--exec", "1")
+      assert((resShortVersion, outShortVersion, errShortVersion) == ((0, "", "")))
+      assert(os.read(wd / "-v") == "1\n")
+
+      val (resMaxTrace, outMaxTrace, errMaxTrace) =
+        runMainInWd(wd, "--max-trace", "--version", "--exec", "1")
+      assert(resMaxTrace == 1)
+      assert(outMaxTrace.isEmpty)
+      assert(errMaxTrace.nonEmpty)
+      assert(!outMaxTrace.startsWith("Sjsonnet "))
     }
 
     test("stringModeNonStringReportsCleanError") {
@@ -157,6 +271,34 @@ object MainTests extends TestSuite {
       assert(!err.contains("NoSuchFileException"))
     }
 
+    test("createOutputDirsCreatesOutputFileParents") {
+      val outputDir = os.temp.dir() / "missing" / "parents"
+      val outputFile = outputDir / "out.json"
+      val (res, out, err) =
+        runMain("--exec", "1", "--output-file", outputFile, "--create-output-dirs")
+      assert((res, out, err) == ((0, "", "")))
+      assert(os.read(outputFile) == "1\n")
+    }
+
+    test("createOutputDirsCreatesMultiAndOutputFileParents") {
+      val source = testSuiteRoot / "db" / "multi.jsonnet"
+      val root = os.temp.dir()
+      val multiDest = root / "missing" / "multi"
+      val outputFile = root / "missing" / "lists" / "files.txt"
+      val (res, out, err) =
+        runMain(source, "--multi", multiDest, "--output-file", outputFile, "--create-output-dirs")
+      assert((res, out, err) == ((0, "", "")))
+      assert(os.read(outputFile) == s"$multiDest/hello\n$multiDest/world")
+      val expectedWorld =
+        """[
+          |   2,
+          |   "three",
+          |   true
+          |]""".stripMargin
+      assert(os.read(multiDest / "hello") == "1\n")
+      assert(os.read(multiDest / "world") == expectedWorld + "\n")
+    }
+
     test("missingExtStrFileErrorsAsImport") {
       checkCliStderrGolden(
         "cli_missing_ext_str_file.jsonnet",
@@ -214,11 +356,17 @@ object MainTests extends TestSuite {
     }
 
     val streamedOut =
-      """--- 1
-        |--- 2
-        |--- 3
-        |--- 4
-        |--- 5
+      """---
+        |1
+        |---
+        |2
+        |---
+        |3
+        |---
+        |4
+        |---
+        |5
+        |...
         |""".stripMargin
 
     val expectedWorldDestStr =
@@ -231,7 +379,7 @@ object MainTests extends TestSuite {
     test("yamlStream") {
       val source = testSuiteRoot / "db" / "stream.jsonnet"
       val (res, out, err) = runMain(source, "--yaml-stream")
-      assert((res, out, err) == ((0, streamedOut + "\n", "")))
+      assert((res, out, err) == ((0, streamedOut, "")))
     }
 
     test("exec") {
@@ -254,6 +402,44 @@ object MainTests extends TestSuite {
           |
           |""".stripMargin
       assert((res, out, err) == ((0, expectedYaml, "")))
+    }
+
+    test("maxTraceCropsStackTrace") {
+      val source =
+        """local f8() = error "boom";
+          |local f7() = f8();
+          |local f6() = f7();
+          |local f5() = f6();
+          |local f4() = f5();
+          |local f3() = f4();
+          |local f2() = f3();
+          |local f1() = f2();
+          |f1()""".stripMargin
+      val (res, out, err) = runMain(source, "--exec", "--max-trace", "3")
+      assert(res == 1)
+      assert(out.isEmpty)
+      assert(err.contains("boom"))
+      assert(err.contains("\n    ...\n"))
+      assert(err.linesIterator.count(_.startsWith("    at ")) <= 2)
+    }
+
+    test("maxTraceZeroDisablesStackTraceCropping") {
+      val source =
+        """local f8() = error "boom";
+          |local f7() = f8();
+          |local f6() = f7();
+          |local f5() = f6();
+          |local f4() = f5();
+          |local f3() = f4();
+          |local f2() = f3();
+          |local f1() = f2();
+          |f1()""".stripMargin
+      val (res, out, err) = runMain(source, "--exec", "--max-trace", "0")
+      assert(res == 1)
+      assert(out.isEmpty)
+      assert(err.contains("boom"))
+      assert(!err.contains("\n    ...\n"))
+      assert(err.linesIterator.count(_.startsWith("    at ")) > 2)
     }
 
     test("yamlStreamOutputFile") {
@@ -378,11 +564,16 @@ object MainTests extends TestSuite {
       assertStringModeTypeError(err, "number")
     }
 
-    test("yamlStreamStringRejectsSingleNonStringValue") {
+    test("yamlStreamStringFlagDoesNotRequireStringElements") {
       val (res, out, err) = runMain("[42]", "--exec", "--yaml-stream", "--string")
+      assert((res, out, err) == ((0, "---\n42\n...\n", "")))
+    }
+
+    test("yamlStreamRejectsNonArrayTopLevel") {
+      val (res, out, err) = runMain("{a: 1}", "--exec", "--yaml-stream")
       assert(res == 1)
       assert(out.isEmpty)
-      assertStringModeTypeError(err, "number")
+      assert(err.contains("stream mode: top-level object was a object"))
     }
 
     // -- No trailing newline behavior --
@@ -468,13 +659,13 @@ object MainTests extends TestSuite {
     }
 
     test("noTrailingNewlineOutputFile") {
-      // Default output-file — file has content without trailing newline (file mode)
+      // Default output-file — file has a trailing newline, matching go-jsonnet
       val source = "42"
       val destDefault = os.temp()
       val (resDefault, _, _) = runMain(source, "--exec", "--output-file", destDefault)
       assert(resDefault == 0)
       val defaultContent = os.read(destDefault)
-      assert(defaultContent == "42")
+      assert(defaultContent == "42\n")
 
       // No trailing newline output-file — same behavior
       val dest = os.temp()
@@ -574,6 +765,21 @@ object MainTests extends TestSuite {
         runMainWithEnv(jsonnetPathEnv = libDirEnv.toString, "-J", libDirJ, mainFile)
       assert(res == 0)
       assert(out.trim == "\"from_jflag\"")
+    }
+
+    test("jsonnetPathJpathRightMostWinsByDefault") {
+      val libDirC = os.temp.dir()
+      val libDirD = os.temp.dir()
+
+      os.write(libDirC / "mylib.libsonnet", """{ x: "from_c" }""")
+      os.write(libDirD / "mylib.libsonnet", """{ x: "from_d" }""")
+
+      val mainFile = os.temp(suffix = ".jsonnet")
+      os.write.over(mainFile, """local lib = import 'mylib.libsonnet'; lib.x""")
+
+      val (res, out, _) = runMain("-J", libDirC, "-J", libDirD, mainFile)
+      assert(res == 0)
+      assert(out.trim == "\"from_d\"")
     }
 
     test("debugStats") {
@@ -694,6 +900,9 @@ object MainTests extends TestSuite {
   def runMain(args: os.Shellable*): (Int, String, String) =
     runMainWithEnv(jsonnetPathEnv = "", args*)
 
+  def runMainInWd(wd: os.Path, args: os.Shellable*): (Int, String, String) =
+    runMainWithEnvInWd(jsonnetPathEnv = "", wd, args*)
+
   private def normalizeOutput(s: String): String =
     s.replace("\r\n", "\n").replaceAll("\n+\\z", "")
 
@@ -729,7 +938,13 @@ object MainTests extends TestSuite {
     assert(out.replace("\r\n", "\n") == golden.replace("\r\n", "\n"))
   }
 
-  def runMainWithEnv(jsonnetPathEnv: String, args: os.Shellable*): (Int, String, String) = {
+  def runMainWithEnv(jsonnetPathEnv: String, args: os.Shellable*): (Int, String, String) =
+    runMainWithEnvInWd(jsonnetPathEnv, workspaceRoot, args*)
+
+  def runMainWithEnvInWd(
+      jsonnetPathEnv: String,
+      wd: os.Path,
+      args: os.Shellable*): (Int, String, String) = {
     val err = new ByteArrayOutputStream()
     val perr = new PrintStream(err, true, "UTF-8")
     val out = new ByteArrayOutputStream()
@@ -740,7 +955,7 @@ object MainTests extends TestSuite {
       System.in,
       pout,
       perr,
-      workspaceRoot,
+      wd,
       None,
       jsonnetPathEnv = Some(jsonnetPathEnv)
     )


### PR DESCRIPTION
## Motivation
sjsonnet CLI should be a go-jsonnet-compatible superset for applicable CLI behavior, while making remaining intentional differences explicit.

## Modification
- Allow `--help` / `--version` without an input file and keep control flags inactive when they are option values or after `--`.
- Align `-J` priority with go-jsonnet right-most-wins behavior while keeping `JSONNET_PATH` lower priority.
- Align YAML stream, output-file newline, create-output-dirs, max-trace, and `--` terminator behavior with go-jsonnet where applicable.
- Harden short-option normalization for attached values such as `-Jdir` and `-n4`.
- Keep sjsonnet's existing CLI tail-call optimization behavior and test it explicitly.

## Result
| Case | go-jsonnet v0.22.0 | jrsonnet 0.5.0-pre99 | sjsonnet before | sjsonnet after |
| --- | --- | --- | --- | --- |
| `--version` without input | prints version | prints version | parser error | prints `Sjsonnet 0.7.1-SNAPSHOT` |
| `--help` without input | prints help | prints help | parser error | prints help without parser noise |
| `-- --version` with file named `--version` | evaluates file | evaluates file | parser error | evaluates file |
| `-J a -J b` duplicate import path | imports from `b` | imports from `b` | imports from `a` | imports from `b` |
| `--yaml-stream -e '[{a:1},{b:2}]'` | JSON document stream with `---` | YAML document stream | old stream formatting | JSON document stream with `---` |
| `--max-stack 2` non-tail recursion | stack error | stack error | stack error | stack error |
| `--max-stack 2` tail recursion | stack error | stack error | returns `0` via TCO | returns `0` via TCO |
| `-Jdir` / `-n4` attached values | not supported for `-Jdir` | supported | broken short cluster parsing | supported as sjsonnet robustness |

## References
- Local behavior checks against go-jsonnet v0.22.0 and jrsonnet 0.5.0-pre99.
