### PR TITLE
fix: align std.lines with official semantics

### DIFF
--- a/sjsonnet/src/sjsonnet/stdlib/ManifestModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/ManifestModule.scala
@@ -347,25 +347,14 @@ object ManifestModule extends AbstractFunctionModule {
    */
   private object Lines extends Val.Builtin1("lines", "arr") {
     def evalRhs(v1: Eval, ev: EvalScope, pos: Position): Val = {
+      val out = new StringBuilder
       v1.value.asArr.foreach {
-        case _: Val.Str | _: Val.Null => // donothing
-        case x                        =>
+        case s: Val.Str  => out.append(s.str).append('\n')
+        case _: Val.Null => // skip nulls like std.join
+        case x           =>
           Error.fail("std.lines: expected string or null element, got " + x.value.prettyName)
       }
-      Val.Str(
-        pos,
-        Materializer
-          .apply(v1.value)(ev)
-          .asInstanceOf[ujson.Arr]
-          .value
-          .filter(_ != ujson.Null)
-          .map {
-            case ujson.Str(s) => s + "\n"
-            case _            =>
-              throw new RuntimeException("Unexpected") /* we ensure it's all strings above */
-          }
-          .mkString
-      )
+      Val.Str(pos, out.toString)
     }
   }
 

--- a/sjsonnet/test/resources/new_test_suite/error.std_lines_string.jsonnet
+++ b/sjsonnet/test/resources/new_test_suite/error.std_lines_string.jsonnet
@@ -1,0 +1,1 @@
+std.lines("a\nb\n")

--- a/sjsonnet/test/resources/new_test_suite/error.std_lines_string.jsonnet.golden
+++ b/sjsonnet/test/resources/new_test_suite/error.std_lines_string.jsonnet.golden
@@ -1,0 +1,2 @@
+sjsonnet.Error: [std.lines] Wrong parameter type: expected Array, got string
+    at [<root>].(error.std_lines_string.jsonnet:1:10)

--- a/sjsonnet/test/src/sjsonnet/StdLibOfficialCompatibilityTests.scala
+++ b/sjsonnet/test/src/sjsonnet/StdLibOfficialCompatibilityTests.scala
@@ -15,6 +15,15 @@ object StdLibOfficialCompatibilityTests extends TestSuite {
       assert(evalErr("""std.flattenArrays([[1], null, [2]])""").contains("array and null"))
     }
 
+    test("lines follows official array-to-text semantics") {
+      eval("""std.lines(["a", "b"])""") ==> ujson.Str("a\nb\n")
+      eval("""std.lines(["a", null, "b"])""") ==> ujson.Str("a\nb\n")
+
+      val stringInputError = evalErr("""std.lines("a\nb\n")""")
+      assert(stringInputError.contains("expected Array"))
+      assert(stringInputError.contains("got string"))
+    }
+
     test("flattenDeepArray wraps scalar values") {
       eval("""std.flattenDeepArray(1)""") ==> ujson.Arr(1)
       eval("""std.flattenDeepArray(null)""") ==> ujson.Arr(ujson.Null)


### PR DESCRIPTION
Motivation:
Official Jsonnet documents `std.lines(arr)` as concatenating an array of strings into a text file with a newline after each string. It is not a line-splitting function for string input.

The native sjsonnet implementation should therefore preserve array-to-text semantics and reject non-array input. This also resolves the behavioral confusion discussed in google/go-jsonnet#885 without treating the upstream issue thread as the specification.

Modification:
- Rewrite the native `std.lines` path to iterate over `Val.Arr` directly with a `StringBuilder`.
- Preserve existing `std.join`-compatible handling for `null` array elements.
- Add regression coverage for array input, null elements, and string-input rejection.

Result:
`std.lines(["a", "b"])` follows the documented text-file construction behavior, including the trailing newline. `std.lines("a\nb\n")` remains a type error because the documented parameter is an array. The table below includes the old sjsonnet behavior from `master` before this PR.

| Case | Official meaning | C++ jsonnet / go-jsonnet | jrsonnet | sjsonnet before this PR | sjsonnet after this PR |
|---|---|---|---|---|---|
| `std.lines(["a", "b"])` | array-to-text with trailing newlines | `"a\nb\n"` | `"a\nb\n"` | `"a\nb\n"` | `"a\nb\n"` |
| `std.lines(["a", null, "b"])` | preserve existing null-skipping join behavior | `"a\nb\n"` | `"a\nb\n"` | `"a\nb\n"` | `"a\nb\n"` |
| `std.lines("a\nb\n")` | invalid input type | type error | type error | `[std.lines] Wrong parameter type: expected Array, got string` | type error |

The observed external behavior on `master` already matches the documented cases above; this PR keeps that behavior explicit with focused native-path tests and implementation cleanup.

References:
- Official Jsonnet `std.lines` documentation: https://jsonnet.org/ref/stdlib.html#std-lines
- go-jsonnet issue motivating the comparison: https://github.com/google/go-jsonnet/issues/885

