### PR TITLE
fix: align std.assertEqual failure messages

### DIFF
--- a/sjsonnet/src/sjsonnet/stdlib/TypeModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/TypeModule.scala
@@ -137,13 +137,14 @@ object TypeModule extends AbstractFunctionModule {
     def evalRhs(v1: Eval, v2: Eval, ev: EvalScope, pos: Position): Val = {
       val a = v1.value
       val b = v2.value
-      // Use structural equality first (avoids double materialization on success path)
+      // Use structural equality first (avoids double materialization on success path).
       if (ev.equal(a, b)) Val.True(pos)
       else {
-        // Only materialize on failure for the error message
-        val x1 = Materializer(a)(ev)
-        val x2 = Materializer(b)(ev)
-        Error.fail("std.assertEqual: " + x1 + " != " + x2)
+        // Match official std.jsonnet: strings are JSON-escaped, and non-strings are
+        // stringified through Jsonnet value rendering by the later concatenation.
+        val x1 = Materializer.stringify(a)(ev)
+        val x2 = Materializer.stringify(b)(ev)
+        Error.fail("Assertion failed. " + x1 + " != " + x2)
       }
     }
   }

--- a/sjsonnet/test/resources/go_test_suite/assert_equal5.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/assert_equal5.jsonnet.golden
@@ -1,2 +1,2 @@
-sjsonnet.Error: [std.assertEqual] "\n " != "\n"
+sjsonnet.Error: [std.assertEqual] Assertion failed. "\n " != "\n"
     at [<root>].(assert_equal5.jsonnet:1:16)

--- a/sjsonnet/test/resources/go_test_suite/assert_equal6.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/assert_equal6.jsonnet.golden
@@ -1,2 +1,2 @@
-sjsonnet.Error: [std.assertEqual] "\u001b[31m" != ""
+sjsonnet.Error: [std.assertEqual] Assertion failed. "\u001b[31m" != ""
     at [<root>].(assert_equal6.jsonnet:1:16)

--- a/sjsonnet/test/resources/new_test_suite/error.assert_equal_official_message.jsonnet
+++ b/sjsonnet/test/resources/new_test_suite/error.assert_equal_official_message.jsonnet
@@ -1,0 +1,1 @@
+std.assertEqual({x: 1}, {x: 2})

--- a/sjsonnet/test/resources/new_test_suite/error.assert_equal_official_message.jsonnet.golden
+++ b/sjsonnet/test/resources/new_test_suite/error.assert_equal_official_message.jsonnet.golden
@@ -1,2 +1,2 @@
 sjsonnet.Error: [std.assertEqual] Assertion failed. {"x": 1} != {"x": 2}
-    at [<root>].(assert_equal4.jsonnet:1:16)
+    at [<root>].(error.assert_equal_official_message.jsonnet:1:16)

--- a/sjsonnet/test/resources/test_suite/error.assert_equal_obj.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.assert_equal_obj.jsonnet.golden
@@ -1,2 +1,2 @@
-sjsonnet.Error: [std.assertEqual] {"a":1} != {"b":1}
+sjsonnet.Error: [std.assertEqual] Assertion failed. {"a": 1} != {"b": 1}
     at [<root>].(error.assert_equal_obj.jsonnet:17:16)

--- a/sjsonnet/test/resources/test_suite/error.assert_equal_str.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.assert_equal_str.jsonnet.golden
@@ -1,2 +1,2 @@
-sjsonnet.Error: [std.assertEqual] "one\ntwo" != "three\nfour\n"
+sjsonnet.Error: [std.assertEqual] Assertion failed. "one\ntwo" != "three\nfour\n"
     at [<root>].(error.assert_equal_str.jsonnet:17:16)

--- a/sjsonnet/test/resources/test_suite/error.sanity.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.sanity.jsonnet.golden
@@ -1,2 +1,2 @@
-sjsonnet.Error: [std.assertEqual] 1 != 2
+sjsonnet.Error: [std.assertEqual] Assertion failed. 1 != 2
     at [<root>].(error.sanity.jsonnet:17:16)


### PR DESCRIPTION
Motivation:
`std.assertEqual` is defined by the official stdlib as `true` when `a == b`, otherwise an error whose message starts with `Assertion failed. `. The stdlib also escapes string operands for display and relies on Jsonnet stringification for non-string operands.

sjsonnet's native builtin skipped the official prefix and rendered failure operands through `ujson.Value.toString`, so object and array diffs were compact JSON such as `{"x":1}` instead of Jsonnet-rendered values such as `{"x": 1}`.

Modification:
- Keep the existing success fast path through `ev.equal(a, b)` before materializing either operand.
- Render failure operands with `Materializer.stringify`, matching Jsonnet value rendering for objects, arrays, strings, numbers, booleans, and null.
- Change the builtin failure text to `Assertion failed. <lhs> != <rhs>`.
- Update the existing upstream/go golden files and add a focused `new_test_suite` regression for object rendering in the failure message.

Result:
| Case | Official std.jsonnet / C++ jsonnet | go-jsonnet | jrsonnet | sjsonnet before | sjsonnet after |
| --- | --- | --- | --- | --- | --- |
| `std.assertEqual(1, 2)` | `Assertion failed. 1 != 2` | `Assertion failed. 1 != 2` | `Assertion failed. 1 != 2` | `[std.assertEqual] 1 != 2` | `[std.assertEqual] Assertion failed. 1 != 2` |
| `std.assertEqual({x: 1}, {x: 2})` | `Assertion failed. {"x": 1} != {"x": 2}` | `Assertion failed. {"x": 1} != {"x": 2}` | `Assertion failed. {"x": 1} != {"x": 2}` | `[std.assertEqual] {"x":1} != {"x":2}` | `[std.assertEqual] Assertion failed. {"x": 1} != {"x": 2}` |
| `std.assertEqual("\n ", "\n")` | `Assertion failed. "\n " != "\n"` | `Assertion failed. "\n " != "\n"` | `Assertion failed.` with raw newline text | `[std.assertEqual] "\n " != "\n"` | `[std.assertEqual] Assertion failed. "\n " != "\n"` |
| `std.assertEqual({x:: 42}, {})` | `true` | `true` | `true` | `true` | `true` |
| `std.assertEqual(function() 1, function() 2)` | equality error before assertion diff | equality error before assertion diff | equality error before assertion diff | equality error before assertion diff | equality error before assertion diff |

sjsonnet still keeps its existing formatted builtin frame prefix (`[std.assertEqual]`) around native builtin errors; this PR intentionally avoids a broad error-format change.

References:
- https://jsonnet.org/ref/stdlib.html#std-assertEqual
- https://github.com/google/jsonnet/blob/9fdb2b9653be6b2cfc6eb012a7915679ba9447cd/stdlib/std.jsonnet#L853-L861
