### PR TITLE
docs: describe Scala version lines without patch pins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,26 +2,26 @@
 
 ## Build & Test
 
-Uses [Mill](https://mill-build.org/) 1.1.2. Cross-built for Scala 3.3.7, 2.13.18, and 2.12.21 (JVM only).
+Uses the [Mill](https://mill-build.org/) version declared in `build.mill`. Cross-built against the latest patch releases on the configured Scala 2.12.x (JVM only), 2.13.x, and 3.3.x LTS lines; exact versions are declared by `scalaVersions` and `jvmScalaVersions` in `build.mill`.
 
 ```bash
-# Compile (JVM, Scala 3)
-./mill 'sjsonnet.jvm[3.3.7]'.compile
+# Compile all JVM Scala versions
+./mill 'sjsonnet.jvm[_]'.compile
 
-# Run all JVM tests (Scala 3)
-./mill 'sjsonnet.jvm[3.3.7]'.test
+# Run all JVM tests
+./mill 'sjsonnet.jvm[_]'.test
 
 # Run all tests across all platforms
 ./mill __.test
 
-# Build assembly JAR
-./mill 'sjsonnet.jvm[3.3.7]'.assembly
+# Build assembly JARs
+./mill 'sjsonnet.jvm[_]'.assembly
 
 # GraalVM native image
 ./mill sjsonnet.graal.nativeImage
 ```
 
-The assembly JAR is at `out/sjsonnet/jvm/3.3.7/assembly.dest/out.jar`. Run it with `java -Xss100m -jar out.jar`.
+Assembly JARs are written under `out/sjsonnet/jvm/<scala-version>/assembly.dest/out.jar`. Run one with `java -Xss100m -jar out.jar`.
 
 ## Formatting
 
@@ -71,7 +71,7 @@ Every bug fix should include a regression test:
 2. Create `new_test_suite/<descriptive_name>.jsonnet.golden` with expected output.
    - Success tests: JSON output followed by a newline, using `std.assertEqual` chains ending in `true`.
    - Error tests (filename starts with `error.`): expected stderr including stack traces.
-3. Run `./mill 'sjsonnet.jvm[3.3.7]'.test` to verify.
+3. Run `./mill 'sjsonnet.jvm[_]'.test` to verify.
 
 ## Debug Stats
 

--- a/readme.md
+++ b/readme.md
@@ -335,16 +335,19 @@ To generate the static files without starting a server:
 The output is a single `index.html` file (with the Sjsonnet JS engine inlined) written to `out/playground/bundle.dest/`. You can open it directly in a browser — no server needed — or serve it with any static file server. The editor UI (CodeMirror) is loaded from a CDN at runtime, so an internet connection is required.
 
 ## Development
-To compile the JVM version:
+
+The configured build tracks the latest patch releases on the Scala 2.12.x (JVM only), 2.13.x, and 3.3.x LTS lines. Exact versions are declared in `build.mill`.
+
+To compile the JVM versions:
 
 ```bash
-./mill 'sjsonnet.jvm[3.3.7]'.compile
+./mill 'sjsonnet.jvm[_]'.compile
 ```
 
-To run the tests:
+To run the JVM tests:
 
 ```bash
-./mill 'sjsonnet.jvm[3.3.7]'.test
+./mill 'sjsonnet.jvm[_]'.test
 ```
 
 If you want to test for all platforms and versions, you can run
@@ -357,16 +360,16 @@ If you want to test for all platforms and versions, you can run
 
 Sjsonnet comes with a built in thin-client and background server, to help
 mitigate the unfortunate JVM warmup overhead that adds ~1s to every invocation
-down to 0.2-0.3s. For the simple non-client-server executable, you can use
+down to 0.2-0.3s. For the simple non-client-server executables, you can use
 
 ```bash
-./mill -i show sjsonnet[3.3.7].jvm.assembly
+./mill -i show 'sjsonnet.jvm[_].assembly'
 ```
 
-To create the executable. For the client-server executable, you can use
+For the client-server executables, you can use
 
 ```bash
-./mill -i show sjsonnet[3.3.7].server.assembly
+./mill -i show 'sjsonnet.jvm[_].server.assembly'
 ```
 
 By default, the Sjsonnet background server lives in `~/.sjsonnet`, and lasts 5


### PR DESCRIPTION
Motivation:
Development docs should tell contributors which Scala lines the project tracks: the latest 2.12.x maintenance line for JVM, plus the latest 2.13.x and 3.3.x LTS lines. Embedding exact patch versions in docs still drifts when build.mill changes.

Modification:
Describe the configured Scala version lines in CLAUDE.md and readme.md, keep exact patch versions delegated to build.mill, and retain Mill wildcard cross targets for JVM compile, test, and assembly commands.

Result:
The docs communicate the intended Scala release lines while build.mill remains the single source of truth for exact versions, and the documented commands continue to resolve against the current build matrix.

References:
- https://www.scala-lang.org/download/all.html
- build.mill owns scalaVersions and jvmScalaVersions.