### PR TITLE
fix: keep multi outputs under target directory

### DIFF
--- a/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMainBase.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMainBase.scala
@@ -421,6 +421,20 @@ object SjsonnetMainBase {
       case e: Error                    => Left(Error.formatError(e, maxTrace))
     }
 
+  private def multiOutputPath(multiPath: String, fileName: String): Either[String, os.FilePath] =
+    Try {
+      // Multi output names must stay under the requested output directory.
+      val normalizedFileName = fileName.dropWhile(_ == '/')
+      (os.FilePath(multiPath) / os.SubPath(normalizedFileName)).asInstanceOf[os.FilePath]
+    }.toEither.left.map {
+      case e: IllegalArgumentException
+          if Option(e.getMessage).exists(_.contains("ups must be zero")) =>
+        s"openat $fileName: path escapes from parent"
+      case e: InvalidPathException     => s"openat $fileName: ${e.getMessage}"
+      case e: IllegalArgumentException => s"openat $fileName: ${e.getMessage}"
+      case e                           => e.toString
+    }
+
   private def writeFile(
       config: Config,
       f: os.Path,
@@ -692,7 +706,7 @@ object SjsonnetMainBase {
                     ujson.transform(v, renderer)
                     writer.toString
                   }
-                  relPath = (os.FilePath(multiPath) / os.RelPath(f)).asInstanceOf[os.FilePath]
+                  relPath <- multiOutputPath(multiPath, f)
                   _ <- writeFile(config, relPath.resolveFrom(wd), rendered, trailingNewline)
                 } yield relPath
               }

--- a/sjsonnet/test/src-jvm/sjsonnet/MainTests.scala
+++ b/sjsonnet/test/src-jvm/sjsonnet/MainTests.scala
@@ -299,6 +299,59 @@ object MainTests extends TestSuite {
       assert(os.read(multiDest / "world") == expectedWorld + "\n")
     }
 
+    test("multiRejectsOutputPathsEscapingParent") {
+      val root = os.temp.dir()
+      val multiDest = root / "out"
+      val (res, out, err) =
+        runMain("""{"../escape.txt": "owned"}""", "--exec", "--multi", multiDest, "--string")
+      assert(res == 1)
+      assert(out.isEmpty)
+      assert(err.contains("path escapes from parent"))
+      assert(!err.contains("IllegalArgumentException"))
+      assert(!os.exists(root / "escape.txt"))
+    }
+
+    test("multiRejectsNestedOutputPathsEscapingParent") {
+      val root = os.temp.dir()
+      val multiDest = root / "out"
+      val (res, out, err) =
+        runMain("""{"a/../../escape.txt": "owned"}""", "--exec", "--multi", multiDest, "--string")
+      assert(res == 1)
+      assert(out.isEmpty)
+      assert(err.contains("path escapes from parent"))
+      assert(!err.contains("IllegalArgumentException"))
+      assert(!os.exists(root / "escape.txt"))
+    }
+
+    test("multiAllowsNormalizedOutputPathsInsideParent") {
+      val root = os.temp.dir()
+      val multiDest = root / "out"
+      os.makeDir.all(multiDest)
+      val (res, out, err) =
+        runMain("""{"dir/../ok.txt": "ok"}""", "--exec", "--multi", multiDest, "--string")
+      assert((res, out, err) == ((0, s"$multiDest/ok.txt\n", "")))
+      assert(os.read(multiDest / "ok.txt") == "ok\n")
+    }
+
+    test("multiNormalizesAbsoluteOutputPathsInsideParent") {
+      val root = os.temp.dir()
+      val multiDest = root / "out"
+      val externalPath = root / "external" / "abs.txt"
+      val expectedPath = multiDest / os.SubPath(externalPath.toString.dropWhile(_ == '/'))
+      val (res, out, err) =
+        runMain(
+          "{" + ujson.write(externalPath.toString) + ": \"inside\"}",
+          "--exec",
+          "--multi",
+          multiDest,
+          "--string",
+          "--create-output-dirs"
+        )
+      assert((res, out, err) == ((0, s"$expectedPath\n", "")))
+      assert(os.read(expectedPath) == "inside\n")
+      assert(!os.exists(externalPath))
+    }
+
     test("missingExtStrFileErrorsAsImport") {
       checkCliStderrGolden(
         "cli_missing_ext_str_file.jsonnet",


### PR DESCRIPTION
Motivation:
`sjsonnet --multi <dir>` is documented as writing multiple files to the requested directory and listing those files on stdout. Before this PR, sjsonnet built output paths with `os.RelPath` from Jsonnet object keys, so keys containing parent traversal could escape the selected output directory. Absolute-looking keys could also surface raw JVM path exceptions instead of predictable CLI behavior.

Modification:
Add a dedicated `multiOutputPath` helper for multi-output file names. It strips leading POSIX separators so absolute-looking keys become output-directory-relative, joins the remaining name as an `os.SubPath`, and maps rejected parent traversal to a clean `openat ... path escapes from parent` error. Add JVM CLI regressions for direct parent traversal, nested parent traversal, valid normalization that stays inside the output directory, and absolute-key normalization.

Result:
Multi-output keys now stay under the requested directory. Escaping paths fail before any outside write, valid normalized paths still work, and absolute-looking keys are normalized under the output directory when parent creation is requested.

| Case | go-jsonnet observed | C++ jsonnet observed | jrsonnet observed | sjsonnet before this PR | sjsonnet after this PR |
|---|---|---|---|---|---|
| `--multi out --string` with key `../escape.txt` and existing `out` | rejects with `openat ../escape.txt: path escapes from parent`; no outside write | writes `out/../escape.txt`, escaping `out` | writes `out/../escape.txt`, escaping `out` | writes outside `out` | rejects with `path escapes from parent`; no outside write |
| `--multi out --string` with key `a/../../escape.txt` | rejects parent escape | writes outside `out` when parents allow it | writes outside `out` | writes outside `out` | rejects with `path escapes from parent`; no outside write |
| `--multi out --string` with key `dir/../ok.txt` and existing `out` | writes normalized `out/ok.txt` | writes inside `out` via `out/dir/../ok.txt` | writes inside `out` via `out/dir/../ok.txt` | writes inside `out` | writes inside `out/ok.txt` |
| `--multi out --string --create-output-dirs` with an absolute key like `/tmp/.../external/abs.txt` | writes under `out/tmp/.../external/abs.txt` | has no create-dirs option; observed CLI fails opening the output-dir-relative path when parents are missing | writes the absolute outside path | throws a raw `IllegalArgumentException` stack | writes under `out/tmp/.../external/abs.txt` |

References:
- `README.md` documents `--multi <str>` as `Write multiple files to the directory, list files on stdout`.