### PR TITLE
Validate CLI numeric limits

### DIFF
--- a/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMainBase.scala
+++ b/sjsonnet/src-jvm-native/sjsonnet/SjsonnetMainBase.scala
@@ -195,6 +195,21 @@ object SjsonnetMainBase {
           Left("ERROR: cannot use --no-trailing-newline with --yaml-stream")
         else Right(())
       }
+      _ <- {
+        if (config.maxStack < 1) Left(s"ERROR: invalid --max-stack value: ${config.maxStack}")
+        else Right(())
+      }
+      _ <- {
+        if (config.maxTrace < 0) Left(s"ERROR: invalid --max-trace value: ${config.maxTrace}")
+        else Right(())
+      }
+      _ <- {
+        if (config.maxParserRecursionDepth < 0)
+          Left(
+            s"ERROR: invalid --max-parser-recursion-depth value: ${config.maxParserRecursionDepth}"
+          )
+        else Right(())
+      }
       file <- Right(config.file)
       debugStats =
         if (config.debugStats.value) { val s = new DebugStats; statsToReport = s; s }

--- a/sjsonnet/test/src-jvm/sjsonnet/MainTests.scala
+++ b/sjsonnet/test/src-jvm/sjsonnet/MainTests.scala
@@ -147,6 +147,47 @@ object MainTests extends TestSuite {
       assert(err.contains("Max stack frames exceeded."))
     }
 
+    test("maxStackRejectsNonPositiveValues") {
+      val (zeroRes, zeroOut, zeroErr) = runMain("--exec", "1", "--max-stack", "0")
+      assert(zeroRes == 1)
+      assert(zeroOut.isEmpty)
+      assert(zeroErr.contains("ERROR: invalid --max-stack value: 0"))
+      assert(!zeroErr.contains("Max stack frames exceeded."))
+
+      val (negativeRes, negativeOut, negativeErr) = runMain("--exec", "1", "--max-stack", "-1")
+      assert(negativeRes == 1)
+      assert(negativeOut.isEmpty)
+      assert(negativeErr.contains("ERROR: invalid --max-stack value: -1"))
+      assert(!negativeErr.contains("Max stack frames exceeded."))
+    }
+
+    test("maxTraceRejectsNegativeValues") {
+      val (res, out, err) = runMain("--exec", "error 'x'", "--max-trace", "-1")
+      assert(res == 1)
+      assert(out.isEmpty)
+      assert(err.contains("ERROR: invalid --max-trace value: -1"))
+      assert(!err.contains("sjsonnet.Error"))
+    }
+
+    test("maxParserRecursionDepthRejectsNegativeValues") {
+      val (res, out, err) = runMain("--exec", "1", "--max-parser-recursion-depth", "-1")
+      assert(res == 1)
+      assert(out.isEmpty)
+      assert(err.contains("ERROR: invalid --max-parser-recursion-depth value: -1"))
+      assert(!err.contains("Parsing exceeded maximum recursion depth of -1"))
+    }
+
+    test("maxParserRecursionDepthZeroAllowsNonRecursiveExpressions") {
+      val (res, out, err) = runMain("--exec", "1", "--max-parser-recursion-depth", "0")
+      assert((res, out, err) == ((0, "1\n", "")))
+
+      val (nestedRes, nestedOut, nestedErr) =
+        runMain("--exec", "[1]", "--max-parser-recursion-depth", "0")
+      assert(nestedRes == 1)
+      assert(nestedOut.isEmpty)
+      assert(nestedErr.contains("Parsing exceeded maximum recursion depth of 0"))
+    }
+
     test("maxStackDoesNotCountTailRecursiveCalls") {
       val (res, out, err) = runMain(
         "--exec",


### PR DESCRIPTION
Motivation:
sjsonnet accepted invalid numeric CLI limits. `--max-stack 0` and `--max-stack -1` could still evaluate constant expressions, but the same settings make function-stack checks fail immediately once evaluation needs a stack frame. `--max-trace -1` entered evaluation and behaved as an undocumented full-trace setting. `--max-parser-recursion-depth -1` reached the parser and reported `Parsing exceeded maximum recursion depth of -1` instead of being rejected as an invalid CLI value.

This is a CLI compatibility and input-validation issue rather than a Jsonnet language or stdlib semantics issue. C++ jsonnet and go-jsonnet both reject invalid values for the shared stack/trace flags during CLI parsing; `--max-parser-recursion-depth` is sjsonnet-specific, so the other implementations have no comparable CLI flag. jrsonnet differs for `--max-stack 0` but rejects negative numeric values at its CLI parser.

| Case | C++ jsonnet observed | go-jsonnet observed | jrsonnet observed | sjsonnet before this PR | sjsonnet after this PR |
| --- | --- | --- | --- | --- | --- |
| `--exec 1 --max-stack 0` | Rejects `ERROR: invalid --max-stack value: 0` | Rejects `ERROR: invalid --max-stack value: 0` | Prints `1` | Prints `1` | Rejects `ERROR: invalid --max-stack value: 0` |
| `--exec 1 --max-stack -1` | Rejects `ERROR: invalid --max-stack value: -1` | Rejects `ERROR: invalid --max-stack value: -1` | Rejects invalid CLI value | Prints `1` | Rejects `ERROR: invalid --max-stack value: -1` |
| `--exec "error \"x\"" --max-trace -1` | Rejects `ERROR: invalid --max-trace value: -1` | Rejects `ERROR: invalid --max-trace value: -1` | Rejects invalid CLI value | Enters evaluation and reports `sjsonnet.Error: x` | Rejects `ERROR: invalid --max-trace value: -1` |
| `--exec 1 --max-trace 0` | Prints `1` | Prints `1` | Prints `1` | Prints `1` | Prints `1` |
| `--exec 1 --max-parser-recursion-depth -1` | No comparable CLI flag | No comparable CLI flag | No comparable CLI flag | Parser error `Parsing exceeded maximum recursion depth of -1` | Rejects `ERROR: invalid --max-parser-recursion-depth value: -1` |
| `--exec 1 --max-parser-recursion-depth 0` | No comparable CLI flag | No comparable CLI flag | No comparable CLI flag | Prints `1` | Prints `1` |
| `--exec "[1]" --max-parser-recursion-depth 0` | No comparable CLI flag | No comparable CLI flag | No comparable CLI flag | Parser error `Parsing exceeded maximum recursion depth of 0` | Parser error `Parsing exceeded maximum recursion depth of 0` |

Modification:
Validate `--max-stack >= 1`, `--max-trace >= 0`, and `--max-parser-recursion-depth >= 0` after CLI argument normalization and before constructing `Settings`. Add JVM CLI regression tests for `--max-stack 0`, `--max-stack -1`, `--max-trace -1`, `--max-parser-recursion-depth -1`, and the `--max-parser-recursion-depth 0` boundary.

Result:
Invalid numeric CLI limits now fail before evaluation or parsing with user-facing CLI errors. The change matches C++ jsonnet and go-jsonnet for shared invalid stack/trace values, preserves documented `--max-trace 0` full-trace behavior, and keeps the existing sjsonnet-specific `--max-parser-recursion-depth 0` boundary semantics.

References:
- C++ jsonnet `cmd/jsonnet.cpp` rejects `--max-stack < 1` and `--max-trace < 0`.
- go-jsonnet `cmd/jsonnet/cmd.go` rejects `--max-stack < 1` and `--max-trace < 0`.
- sjsonnet `readme.md` documents `--max-parser-recursion-depth` but gives no negative-value semantics.