### PR TITLE
perf: speed up direct long rendering

### DIFF
--- a/bench/src/sjsonnet/bench/LongRenderingBenchmark.scala
+++ b/bench/src/sjsonnet/bench/LongRenderingBenchmark.scala
@@ -1,0 +1,97 @@
+package sjsonnet.bench
+
+import org.openjdk.jmh.annotations.*
+import org.openjdk.jmh.infra.Blackhole
+import sjsonnet.*
+
+import java.io.ByteArrayOutputStream
+import java.util.concurrent.TimeUnit
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@Fork(1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Thread)
+class LongRenderingBenchmark {
+  import LongRenderingBenchmark.*
+
+  @Benchmark
+  def baseCharRendererLongs(bh: Blackhole): Unit = {
+    val out = new StringBuilderWriter(BatchSize * 20)
+    val renderer = new ExposedCharRenderer(out)
+    var i = 0
+    while (i < BatchSize) {
+      renderer.write(Values(i & ValuesMask))
+      i += 1
+    }
+    renderer.flushCharBuilder()
+    bh.consume(out.getBuilder.length)
+  }
+
+  @Benchmark
+  def baseByteRendererLongs(bh: Blackhole): Unit = {
+    val out = new ByteArrayOutputStream(BatchSize * 20)
+    val renderer = new ExposedByteRenderer(out)
+    var i = 0
+    while (i < BatchSize) {
+      renderer.write(Values(i & ValuesMask))
+      i += 1
+    }
+    renderer.flushByteBuilder()
+    bh.consume(out.size)
+  }
+
+  @Benchmark
+  def tomlRendererExactLongDoubles(bh: Blackhole): Unit = {
+    val out = new StringBuilderWriter(BatchSize * 20)
+    val renderer = new TomlRenderer(out, "", "  ")
+    var i = 0
+    while (i < BatchSize) {
+      renderer.visitFloat64(TomlValues(i & TomlValuesMask), -1)
+      i += 1
+    }
+    bh.consume(out.getBuilder.length)
+  }
+}
+
+object LongRenderingBenchmark {
+  final val BatchSize = 4096
+
+  private val Values: Array[Long] = Array(
+    0L,
+    7L,
+    42L,
+    99L,
+    100L,
+    12345L,
+    99999999L,
+    100000000L,
+    123456789L,
+    999999999999L,
+    9007199254740991L,
+    9007199254740992L,
+    Long.MaxValue,
+    -1L,
+    -123456789L,
+    Long.MinValue
+  )
+  private val ValuesMask = Values.length - 1
+
+  private val TomlValues: Array[Double] = Array(
+    0.0, 7.0, 42.0, 99.0, 100.0, 12345.0, 99999999.0, 100000000.0, 123456789.0, 999999999999.0,
+    9007199254740991.0, 9007199254740992.0, -1.0, -123456789.0, -9007199254740991.0,
+    -9007199254740992.0
+  )
+  private val TomlValuesMask = TomlValues.length - 1
+
+  private final class ExposedCharRenderer(out: StringBuilderWriter)
+      extends BaseCharRenderer[StringBuilderWriter](out) {
+    def write(v: Long): Unit = writeLongDirect(v)
+  }
+
+  private final class ExposedByteRenderer(out: ByteArrayOutputStream)
+      extends BaseByteRenderer[ByteArrayOutputStream](out) {
+    def write(v: Long): Unit = writeLongDirect(v)
+  }
+}

--- a/sjsonnet/src/sjsonnet/BaseByteRenderer.scala
+++ b/sjsonnet/src/sjsonnet/BaseByteRenderer.scala
@@ -28,7 +28,7 @@ class BaseByteRenderer[T <: java.io.OutputStream](
 
   protected val elemBuilder = new upickle.core.ByteBuilder
   private val unicodeCharBuilder = new upickle.core.CharBuilder
-  private val longScratchBuf: Array[Byte] = new Array[Byte](20)
+  private val longScratchBuf: Array[Byte] = new Array[Byte](FastLongRenderer.MaxLongChars)
 
   def flushByteBuilder(): Unit = {
     elemBuilder.writeOutToIfLongerThan(out, if (depth == 0) 0 else 8192)
@@ -166,49 +166,18 @@ class BaseByteRenderer[T <: java.io.OutputStream](
 
   /**
    * Write a long integer directly into elemBuilder without intermediate String allocation. Uses
-   * digit-pair lookup table for fast two-digits-at-a-time conversion.
+   * digit-pair lookup tables and 8-digit chunking to keep hardware long division out of the common
+   * int-sized path and to reduce it to at most two divisions for larger longs.
    */
   protected def writeLongDirect(v: Long): Unit = {
     flushBuffer()
-    if (v == 0L) {
-      elemBuilder.ensureLength(1)
-      elemBuilder.appendUnsafeC('0')
-      return
-    }
-    if (v == Long.MinValue) {
-      visitFloat64StringParts("-9223372036854775808", -1, -1, -1)
-      return
-    }
-    val negative = v < 0
-    var abs = if (negative) -v else v
-    // Write digits backward into a small local buffer, then bulk-copy.
-    // Max Long digits = 19, plus sign = 20.
     val buf = longScratchBuf
-    var pos = 20
-    while (abs >= 100) {
-      val q = abs / 100
-      val r = (abs - q * 100L).toInt
-      abs = q
-      pos -= 2
-      buf(pos + 1) = BaseByteRenderer.DIGIT_ONES(r)
-      buf(pos) = BaseByteRenderer.DIGIT_TENS(r)
-    }
-    if (abs >= 10) {
-      val r = abs.toInt
-      pos -= 2
-      buf(pos + 1) = BaseByteRenderer.DIGIT_ONES(r)
-      buf(pos) = BaseByteRenderer.DIGIT_TENS(r)
-    } else {
-      pos -= 1
-      buf(pos) = ('0' + abs.toInt).toByte
-    }
-    if (negative) { pos -= 1; buf(pos) = '-'.toByte }
-    val totalLen = 20 - pos
-    elemBuilder.ensureLength(totalLen)
+    val len = FastLongRenderer.writeLong(v, buf, 0)
+    elemBuilder.ensureLength(len)
     val bArr = elemBuilder.arr
     val startPos = elemBuilder.length
-    System.arraycopy(buf, pos, bArr, startPos, totalLen)
-    elemBuilder.length = startPos + totalLen
+    System.arraycopy(buf, 0, bArr, startPos, len)
+    elemBuilder.length = startPos + len
   }
 
   def visitString(s: CharSequence, index: Int): T = {
@@ -545,21 +514,4 @@ object BaseByteRenderer {
     'f'.toByte
   )
 
-  /**
-   * Digit-pair lookup tables for two-digits-at-a-time integer rendering. DIGIT_TENS(i) gives the
-   * tens digit byte for value i (0..99). DIGIT_ONES(i) gives the ones digit byte for value i
-   * (0..99).
-   */
-  private[sjsonnet] val DIGIT_TENS: Array[Byte] = {
-    val a = new Array[Byte](100)
-    var i = 0
-    while (i < 100) { a(i) = ('0' + i / 10).toByte; i += 1 }
-    a
-  }
-  private[sjsonnet] val DIGIT_ONES: Array[Byte] = {
-    val a = new Array[Byte](100)
-    var i = 0
-    while (i < 100) { a(i) = ('0' + i % 10).toByte; i += 1 }
-    a
-  }
 }

--- a/sjsonnet/src/sjsonnet/BaseCharRenderer.scala
+++ b/sjsonnet/src/sjsonnet/BaseCharRenderer.scala
@@ -15,20 +15,6 @@ object BaseCharRenderer {
    */
   final val MaxCachedDepth = 32
 
-  /** Digit-pair lookup tables for two-digits-at-a-time integer rendering. */
-  private[sjsonnet] val DIGIT_TENS: Array[Char] = {
-    val a = new Array[Char](100)
-    var i = 0
-    while (i < 100) { a(i) = ('0' + i / 10).toChar; i += 1 }
-    a
-  }
-  private[sjsonnet] val DIGIT_ONES: Array[Char] = {
-    val a = new Array[Char](100)
-    var i = 0
-    while (i < 100) { a(i) = ('0' + i % 10).toChar; i += 1 }
-    a
-  }
-
   private[sjsonnet] val HEX_CHARS: Array[Char] =
     Array('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f')
 }
@@ -54,7 +40,7 @@ class BaseCharRenderer[T <: upickle.core.CharOps.Output](
     elemBuilder.writeOutToIfLongerThan(out, if (depth == 0) 0 else 1000)
   }
 
-  private val longScratchBuf: Array[Char] = new Array[Char](20)
+  private val longScratchBuf: Array[Byte] = new Array[Byte](FastLongRenderer.MaxLongChars)
 
   protected var depth: Int = 0
 
@@ -218,49 +204,24 @@ class BaseCharRenderer[T <: upickle.core.CharOps.Output](
 
   /**
    * Write a long integer directly into elemBuilder without intermediate String allocation. Uses
-   * digit-pair lookup table for fast two-digits-at-a-time conversion.
+   * digit-pair lookup tables and 8-digit chunking to keep hardware long division out of the common
+   * int-sized path and to reduce it to at most two divisions for larger longs.
    */
   protected def writeLongDirect(v: Long): Unit = {
     flushBuffer()
-    if (v == 0L) {
-      elemBuilder.ensureLength(1)
-      elemBuilder.appendUnsafe('0')
-      return
-    }
-    if (v == Long.MinValue) {
-      visitFloat64StringParts("-9223372036854775808", -1, -1, -1)
-      return
-    }
-    val negative = v < 0
-    var abs = if (negative) -v else v
-    // Write digits backward into a small local buffer, then bulk-copy.
-    // Max Long digits = 19, plus sign = 20.
     val buf = longScratchBuf
-    var pos = 20
-    while (abs >= 100) {
-      val q = abs / 100
-      val r = (abs - q * 100L).toInt
-      abs = q
-      pos -= 2
-      buf(pos + 1) = BaseCharRenderer.DIGIT_ONES(r)
-      buf(pos) = BaseCharRenderer.DIGIT_TENS(r)
-    }
-    if (abs >= 10) {
-      val r = abs.toInt
-      pos -= 2
-      buf(pos + 1) = BaseCharRenderer.DIGIT_ONES(r)
-      buf(pos) = BaseCharRenderer.DIGIT_TENS(r)
-    } else {
-      pos -= 1
-      buf(pos) = ('0' + abs.toInt).toChar
-    }
-    if (negative) { pos -= 1; buf(pos) = '-' }
-    val totalLen = 20 - pos
-    elemBuilder.ensureLength(totalLen)
+    val len = FastLongRenderer.writeLong(v, buf, 0)
+    elemBuilder.ensureLength(len)
     val cbArr = elemBuilder.arr
-    val startPos = elemBuilder.getLength
-    System.arraycopy(buf, pos, cbArr, startPos, totalLen)
-    elemBuilder.length = startPos + totalLen
+    var pos = elemBuilder.getLength
+    val end = pos + len
+    var i = 0
+    while (pos < end) {
+      cbArr(pos) = buf(i).toChar
+      pos += 1
+      i += 1
+    }
+    elemBuilder.length = end
   }
 
   def visitString(s: CharSequence, index: Int): T = {

--- a/sjsonnet/src/sjsonnet/FastLongRenderer.scala
+++ b/sjsonnet/src/sjsonnet/FastLongRenderer.scala
@@ -1,0 +1,158 @@
+package sjsonnet
+
+private[sjsonnet] object FastLongRenderer {
+  final val MaxLongChars = 20
+
+  private final val LongChunkSize = 100000000L
+  // Same 1e8/1e16 reciprocal-multiply constants used by jsoniter-scala's JVM/Native writer.
+  // The 1441151881 constant below is only used for jeaiii-style digit extraction inside
+  // int-sized chunks; it is not a general replacement for direct Long / 100.
+  private final val Div1e8Multiplier = 6189700196426901375L
+  private final val Div1e16Multiplier = 8307674973655724206L
+  private final val UInt32Mask = 0xffffffffL
+  private final val UInt47Mask = 0x7fffffffffffL
+  private final val UInt57Mask = 0x1ffffffffffffffL
+  private[this] final val LongMinValueString = "-9223372036854775808"
+  private[this] val LongMinValueBytes: Array[Byte] = {
+    val a = new Array[Byte](LongMinValueString.length)
+    var i = 0
+    while (i < a.length) {
+      a(i) = LongMinValueString.charAt(i).toByte
+      i += 1
+    }
+    a
+  }
+  private[this] val DigitTens: Array[Byte] = {
+    val a = new Array[Byte](100)
+    var i = 0
+    while (i < 100) {
+      a(i) = ('0' + i / 10).toByte
+      i += 1
+    }
+    a
+  }
+  private[this] val DigitOnes: Array[Byte] = {
+    val a = new Array[Byte](100)
+    var i = 0
+    while (i < 100) {
+      a(i) = ('0' + i % 10).toByte
+      i += 1
+    }
+    a
+  }
+
+  def writeLong(v: Long, buf: Array[Byte], p: Int): Int = {
+    if (v == Long.MinValue) {
+      System.arraycopy(LongMinValueBytes, 0, buf, p, LongMinValueBytes.length)
+      p + LongMinValueBytes.length
+    } else {
+      val negative = v < 0
+      val abs = if (negative) -v else v
+      var pos = p
+      if (negative) {
+        buf(pos) = '-'.toByte
+        pos += 1
+      }
+      writePositiveLongDigits(abs, buf, pos)
+    }
+  }
+
+  @inline private def divideBy1e8(x: Long): Long =
+    Math.multiplyHigh(x, Div1e8Multiplier) >>> 25
+
+  @inline private def divideBy1e16(x: Long): Long =
+    Math.multiplyHigh(x, Div1e16Multiplier) >>> 52
+
+  private def writePositiveLongDigits(abs: Long, buf: Array[Byte], p: Int): Int = {
+    if (abs < LongChunkSize) writePositiveIntDigits(abs.toInt, buf, p)
+    else {
+      val q1 = divideBy1e8(abs)
+      val r1 = (abs - q1 * LongChunkSize).toInt
+      var pos =
+        if (q1 < LongChunkSize) writePositiveIntDigits(q1.toInt, buf, p)
+        else {
+          val q2 = divideBy1e16(abs)
+          val afterHigh = writePositiveIntDigits(q2.toInt, buf, p)
+          write8Digits((q1 - q2 * LongChunkSize).toInt, buf, afterHigh)
+        }
+      pos = write8Digits(r1, buf, pos)
+      pos
+    }
+  }
+
+  private def writeDigitPair(i: Int, buf: Array[Byte], pos: Int): Int = {
+    buf(pos) = DigitTens(i)
+    buf(pos + 1) = DigitOnes(i)
+    pos + 2
+  }
+
+  private def writePositiveIntDigits(q0: Int, buf: Array[Byte], p: Int): Int = {
+    var pos = p
+    if (q0 < 100) {
+      if (q0 < 10) {
+        buf(pos) = ('0' + q0).toByte
+        pos + 1
+      } else writeDigitPair(q0, buf, pos)
+    } else if (q0 < 10000) {
+      val q1 = q0 * 5243 >> 19
+      if (q0 < 1000) {
+        buf(pos) = ('0' + q1).toByte
+        pos = writeDigitPair(q0 - q1 * 100, buf, pos + 1)
+      } else {
+        pos = writeDigitPair(q1, buf, pos)
+        pos = writeDigitPair(q0 - q1 * 100, buf, pos)
+      }
+      pos
+    } else if (q0 < 1000000) {
+      val q1 = q0 * 429497L
+      val q2 = (q1 & UInt32Mask) * 100L
+      val q3 = (q2 & UInt32Mask) * 100L
+      val r1 = (q1 >>> 32).toInt
+      if (q0 < 100000) {
+        buf(pos) = ('0' + r1).toByte
+        pos += 1
+      } else pos = writeDigitPair(r1, buf, pos)
+      pos = writeDigitPair((q2 >>> 32).toInt, buf, pos)
+      writeDigitPair((q3 >>> 32).toInt, buf, pos)
+    } else if (q0 < 100000000) {
+      val q1 = q0 * 140737489L
+      val q2 = (q1 & UInt47Mask) * 100L
+      val q3 = (q2 & UInt47Mask) * 100L
+      val q4 = (q3 & UInt47Mask) * 100L
+      val r1 = (q1 >>> 47).toInt
+      if (q0 < 10000000) {
+        buf(pos) = ('0' + r1).toByte
+        pos += 1
+      } else pos = writeDigitPair(r1, buf, pos)
+      pos = writeDigitPair((q2 >>> 47).toInt, buf, pos)
+      pos = writeDigitPair((q3 >>> 47).toInt, buf, pos)
+      writeDigitPair((q4 >>> 47).toInt, buf, pos)
+    } else {
+      val q1 = q0 * 1441151881L
+      val q2 = (q1 & UInt57Mask) * 100L
+      val q3 = (q2 & UInt57Mask) * 100L
+      val q4 = (q3 & UInt57Mask) * 100L
+      val q5 = (q4 & UInt57Mask) * 100L
+      val r1 = (q1 >>> 57).toInt
+      if (q0 < 1000000000) {
+        buf(pos) = ('0' + r1).toByte
+        pos += 1
+      } else pos = writeDigitPair(r1, buf, pos)
+      pos = writeDigitPair((q2 >>> 57).toInt, buf, pos)
+      pos = writeDigitPair((q3 >>> 57).toInt, buf, pos)
+      pos = writeDigitPair((q4 >>> 57).toInt, buf, pos)
+      writeDigitPair((q5 >>> 57).toInt, buf, pos)
+    }
+  }
+
+  private def write8Digits(q0: Int, buf: Array[Byte], p: Int): Int = {
+    val q1 = q0 * 140737489L
+    val q2 = (q1 & UInt47Mask) * 100L
+    val q3 = (q2 & UInt47Mask) * 100L
+    val q4 = (q3 & UInt47Mask) * 100L
+    var pos = writeDigitPair((q1 >>> 47).toInt, buf, p)
+    pos = writeDigitPair((q2 >>> 47).toInt, buf, pos)
+    pos = writeDigitPair((q3 >>> 47).toInt, buf, pos)
+    writeDigitPair((q4 >>> 47).toInt, buf, pos)
+  }
+}

--- a/sjsonnet/src/sjsonnet/TomlRenderer.scala
+++ b/sjsonnet/src/sjsonnet/TomlRenderer.scala
@@ -62,16 +62,10 @@ class TomlRenderer(
       case Double.NegativeInfinity                     => out.write("-inf")
       case d if java.lang.Double.isNaN(d)              => out.write("nan")
       case d if java.lang.Double.compare(d, -0.0) == 0 => out.write("-0")
-      case d if math.round(d).toDouble == d => out.write(java.lang.Long.toString(d.toLong))
-      case d if d % 1 == 0                  =>
-        out.write(
-          java.math.BigDecimal
-            .valueOf(d)
-            .setScale(0, java.math.RoundingMode.HALF_EVEN)
-            .toBigInteger
-            .toString
-        )
-      case d => out.write(RenderUtils.formatDoubleString(java.lang.Double.toString(d)))
+      case d                                           =>
+        val l = d.toLong
+        if (RenderUtils.isExactLongDouble(d, l)) out.getBuilder.append(l)
+        else out.write(RenderUtils.renderDouble(d))
     }
     flush
   }

--- a/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
+++ b/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
@@ -1170,6 +1170,8 @@ object EvaluatorTests extends TestSuite {
       eval("""std.manifestJson(1e100)""") ==> ujson.Str(expected1e100)
       eval("""std.manifestJson(1e308)""") ==> ujson.Str(expected1e308)
       eval("""std.manifestToml({a: 1e100})""") ==> ujson.Str("a = " + expected1e100)
+      eval("""std.manifestToml({a: 9223372036854775808})""") ==>
+        ujson.Str("a = 9223372036854776000")
     }
 
     test("assertBooleanTypeCheck") {

--- a/sjsonnet/test/src/sjsonnet/RendererTests.scala
+++ b/sjsonnet/test/src/sjsonnet/RendererTests.scala
@@ -4,6 +4,15 @@ import java.io.{ByteArrayOutputStream, StringWriter}
 import utest._
 
 object RendererTests extends TestSuite {
+  private final class ExposedCharRenderer(out: StringBuilderWriter)
+      extends BaseCharRenderer[StringBuilderWriter](out) {
+    def write(v: Long): Unit = writeLongDirect(v)
+  }
+  private final class ExposedByteRenderer(out: ByteArrayOutputStream)
+      extends BaseByteRenderer[ByteArrayOutputStream](out) {
+    def write(v: Long): Unit = writeLongDirect(v)
+  }
+
   def tests: Tests = Tests {
     test("hello") {
       ujson.transform(ujson.Arr(ujson.Num(1), ujson.Num(2)), new Renderer()).toString ==>
@@ -56,6 +65,80 @@ object RendererTests extends TestSuite {
       test("large") { render(9999999999L) ==> "9999999999" }
       test("maxValue") { render(Long.MaxValue) ==> Long.MaxValue.toString }
       test("minValue") { render(Long.MinValue) ==> Long.MinValue.toString }
+    }
+
+    test("writeLongDirectBoundaries") {
+      def renderChar(v: Long): String = {
+        val out = new StringBuilderWriter
+        val renderer = new ExposedCharRenderer(out)
+        renderer.write(v)
+        renderer.flushCharBuilder()
+        out.toString
+      }
+      def renderByte(v: Long): String = {
+        val out = new ByteArrayOutputStream
+        val renderer = new ExposedByteRenderer(out)
+        renderer.write(v)
+        renderer.flushByteBuilder()
+        new String(out.toByteArray, java.nio.charset.StandardCharsets.UTF_8)
+      }
+
+      val values = Seq(
+        0L,
+        1L,
+        -1L,
+        9L,
+        10L,
+        99L,
+        100L,
+        101L,
+        9999L,
+        10000L,
+        99999L,
+        100000L,
+        999999L,
+        1000000L,
+        9999999L,
+        10000000L,
+        99999999L,
+        100000000L,
+        100000001L,
+        999999999L,
+        1000000000L,
+        Int.MaxValue.toLong,
+        999999999999999L,
+        1000000000000000L,
+        9999999999999999L,
+        10000000000000000L,
+        10000000000000001L,
+        99999999999999999L,
+        100000000000000000L,
+        999999999999999999L,
+        1000000000000000000L,
+        1000000000000000001L,
+        -9999999999999999L,
+        -10000000000000000L,
+        -10000000000000001L,
+        (1L << 37) - 1L,
+        1L << 37,
+        (1L << 37) + 1L,
+        (1L << 53) - 1L,
+        1L << 53,
+        Long.MaxValue,
+        Long.MinValue
+      )
+      for (value <- values) {
+        val expected = value.toString
+        renderChar(value) ==> expected
+        renderByte(value) ==> expected
+      }
+      val random = new java.util.Random(0)
+      for (_ <- 0 until 4096) {
+        val value = random.nextLong()
+        val expected = value.toString
+        renderChar(value) ==> expected
+        renderByte(value) ==> expected
+      }
     }
 
     test("visitFloat64Integers") {


### PR DESCRIPTION
## Motivation

Direct long rendering in sjsonnet was already fairly optimized: it used scratch buffers and digit-pair lookup tables instead of repeatedly allocating `String`s on the hot renderer paths. The remaining cost was the `/100` loop for every two digits, plus TOML exact-long doubles still went through an intermediate string path and used a `math.round` guard that saturates near `Long.MaxValue`.

This uses the jeaiii integer-formatting idea and jsoniter-scala v2.38.17 as references, but applies them conservatively for sjsonnet: the blog-style `1441151881` `/100` reciprocal is only safe in a bounded range, so the full `Long` path uses jsoniter-style `Math.multiplyHigh` chunking by `1e8`/`1e16`, then digit-pair extraction for int-sized chunks.

References:
- https://jk-jeon.github.io/posts/2022/02/jeaiii-algorithm/
- https://github.com/plokhotnyuk/jsoniter-scala/releases/tag/v2.38.17 which leverages this 

## Modification

- Add a shared `FastLongRenderer` for ASCII `Long` rendering.
- Route both `BaseByteRenderer` and `BaseCharRenderer` through that shared helper.
- Keep TOML exact-Long doubles on `StringBuilder.append(Long)` and fall back to `RenderUtils.renderDouble` for non-exact Long values, avoiding the previous `math.round(...).toLong` saturation case.
- Add renderer boundary/random regression coverage and a committed JMH benchmark so the long-rendering comparison can be reproduced from the PR.

## Result

The PR is squashed to one commit on top of `databricks/master`. The shared code lives under `sjsonnet/src`, so the optimization is used by JVM, Scala.js, Scala Native, and WASM builds. Local checks covered formatting, JVM tests, compile coverage across JVM/JS/WASM/Native, and renderer tests on JS/WASM/Native.

JMH command:

```bash
./mill bench.runJmh ".*LongRenderingBenchmark.*" -f 1 -wi 5 -i 8 -r 1s -w 1s
```

Local JMH on JDK 21, Apple Silicon, lower is better:

| Benchmark | upstream/master | this PR | Change |
| --- | ---: | ---: | ---: |
| `baseByteRendererLongs` | 40.280 ± 1.054 us/op | 32.865 ± 0.277 us/op | 1.23x faster |
| `baseCharRendererLongs` | 48.081 ± 1.233 us/op | 45.992 ± 0.229 us/op | 1.05x faster |
| `tomlRendererExactLongDoubles` | 81.820 ± 0.939 us/op | 43.046 ± 1.273 us/op | 1.90x faster |

The smaller char-renderer win is expected: the existing char path was already optimized with a scratch buffer and digit-pair tables, so most of the new gain comes from removing repeated division and sharing the full-Long chunking logic.


