### PR TITLE
chore: upgrade scala-yaml to 0.3.3 and Scala.js to 1.22.0

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -164,7 +164,7 @@ object sjsonnet extends VersionFileModule {
       with ScalaJSModule
       with SjsonnetPublishModule {
     def moduleDir = super.moduleDir / os.up
-    def scalaJSVersion = "1.20.2"
+    def scalaJSVersion = "1.22.0"
     val sourceDirs = Seq(
       "src",
       "src-js",
@@ -174,7 +174,7 @@ object sjsonnet extends VersionFileModule {
 
     def mvnDeps = super.mvnDeps() ++
       Seq(
-        mvn"org.virtuslab::scala-yaml::0.3.1"
+        mvn"org.virtuslab::scala-yaml::0.3.3"
       )
 
     def nodeJsArgs: List[String] = List("--stack-size=" + stackSizekBytes)
@@ -281,7 +281,7 @@ object sjsonnet extends VersionFileModule {
     def mvnDeps = super.mvnDeps() ++
       Seq(
         mvn"com.github.lolgab::scala-native-crypto::0.3.0",
-        mvn"org.virtuslab::scala-yaml::0.3.1"
+        mvn"org.virtuslab::scala-yaml::0.3.3"
       )
 
     def releaseMode = ReleaseMode.ReleaseFull


### PR DESCRIPTION
## Summary
- Bump `org.virtuslab::scala-yaml` from 0.3.1 to 0.3.3 (JS + Native modules)
- Bump `scalaJSVersion` from 1.20.2 to 1.22.0 (required for Scala.js IR compatibility with scala-yaml 0.3.3)

scala-yaml 0.3.2 fixes:
- `parseManyYamls` handling of document end markers (`...`) at EOF without trailing newline (VirtusLab/scala-yaml#453)
- `YamlDecoder[Any]` rejecting non-finite float scalars like `.inf`/`.nan` (VirtusLab/scala-yaml#478)

scala-yaml 0.3.3 adds:
- More efficient YAML parsing (VirtusLab/scala-yaml#488)

No sjsonnet code changes needed — existing workarounds (`addExplicitNullsForEmptyDocs`, `normalizeYamlNonFiniteScalar`) address different concerns and remain valid.

## Test plan
- [x] `./mill 'sjsonnet.js[_]'.compile` — SUCCESS
- [x] `./mill 'sjsonnet.native[_]'.compile` — SUCCESS
- [x] `./mill 'sjsonnet.js[_]'.test` — 494/494 passed