### PR TITLE
fix: format + flag now correctly overrides space flag

### DIFF
--- a/sjsonnet/src/sjsonnet/Format.scala
+++ b/sjsonnet/src/sjsonnet/Format.scala
@@ -282,8 +282,8 @@ object Format {
       signedConversion: Boolean): String = {
 
     val lhs2 =
-      if (signedConversion && formatted.blankBeforePositive) " " + lhs
-      else if (signedConversion && formatted.signCharacter) "+" + lhs
+      if (signedConversion && formatted.signCharacter) "+" + lhs
+      else if (signedConversion && formatted.blankBeforePositive) " " + lhs
       else lhs
 
     val missingWidth = formatted.widthOr(-1) - lhs2.length - mhs.length - rhs.length


### PR DESCRIPTION
## Summary

- When both `+` and space flags appear in `std.format` (e.g. `"%+ d"`), the `+` flag must override the space flag. sjsonnet had the condition order reversed, causing space to win.

## Behavior comparison

| Expression | sjsonnet (before) | sjsonnet (after) | go-jsonnet v0.22.0 | jrsonnet 0.5.0-pre99 | Python 3 |
|---|---|---|---|---|---|
| `std.format("%+ d", [42])` | `" 42"` ❌ | `"+42"` ✅ | `"+42"` | `"+42"` | `'+42'` |
| `std.format("% +d", [42])` | `" 42"` ❌ | `"+42"` ✅ | `"+42"` | `"+42"` | `'+42'` |
| `std.format("%+ f", [3.14])` | `" 3.140000"` ❌ | `"+3.140000"` ✅ | `"+3.140000"` | `"+3.140000"` | `'+3.140000'` |
| `std.format("%+ d", [0])` | `" 0"` ❌ | `"+0"` ✅ | `"+0"` | `"+0"` | `'+0'` |
| `std.format("% d", [42])` | `" 42"` ✅ | `" 42"` ✅ | `" 42"` | `" 42"` | `' 42'` |
| `std.format("%+d", [42])` | `"+42"` ✅ | `"+42"` ✅ | `"+42"` | `"+42"` | `'+42'` |
| `std.format("%+ d", [-42])` | `"-42"` ✅ | `"-42"` ✅ | `"-42"` | `"-42"` | `'-42'` |

## Specification reference

- C99 §7.19.6.1: *"If the `+` and space flags both appear, the space flag is ignored."*
- Python `%` formatting: `'%+ d' % 42` → `'+42'`
- Jsonnet spec: format operator is "based on Python's `%`"

## Test plan

- [x] `./mill 'sjsonnet.jvm[2.13.18]'.test` — all tests pass, no regressions
- [x] Verified output matches go-jsonnet v0.22.0 and jrsonnet 0.5.0-pre99 for all flag combinations