### PR TITLE
fix: add bounds check for star width/precision in std.format

### DIFF
--- a/sjsonnet/src/sjsonnet/Format.scala
+++ b/sjsonnet/src/sjsonnet/Format.scala
@@ -687,6 +687,13 @@ object Format {
                       )
                     }
                     i += 1
+                    if (i >= valuesArr.length)
+                      Error.fail(
+                        "too few values to format: %d, expected at least %d".format(
+                          valuesArr.length,
+                          i + 1
+                        )
+                      )
                     formatted = withStarWidth(formatted, width, idx)
                     valuesArr.value(i)
                   case (false, true) =>
@@ -697,6 +704,13 @@ object Format {
                       )
                     }
                     i += 1
+                    if (i >= valuesArr.length)
+                      Error.fail(
+                        "too few values to format: %d, expected at least %d".format(
+                          valuesArr.length,
+                          i + 1
+                        )
+                      )
                     formatted = withStarPrecision(formatted, precision, idx)
                     valuesArr.value(i)
                   case (true, true) =>
@@ -707,6 +721,13 @@ object Format {
                       )
                     }
                     i += 1
+                    if (i >= valuesArr.length)
+                      Error.fail(
+                        "too few values to format: %d, expected at least %d".format(
+                          valuesArr.length,
+                          i + 1
+                        )
+                      )
                     val precision = valuesArr.value(i)
                     if (!precision.isInstanceOf[Val.Num]) {
                       Error.fail(
@@ -714,6 +735,13 @@ object Format {
                       )
                     }
                     i += 1
+                    if (i >= valuesArr.length)
+                      Error.fail(
+                        "too few values to format: %d, expected at least %d".format(
+                          valuesArr.length,
+                          i + 1
+                        )
+                      )
                     formatted =
                       withStarPrecision(withStarWidth(formatted, width, idx), precision, idx)
                     valuesArr.value(i)


### PR DESCRIPTION
## Motivation

`std.format("%*d", [5])` threw `ArrayIndexOutOfBoundsException` instead of a clean error. The bounds check at the top of the loop ran before star consumption but not after — once `*` width/precision consumed values and incremented `i`, the subsequent `valuesArr.value(i)` access had no guard.

Both go-jsonnet and jrsonnet report a clean "not enough values" error. Python raises `TypeError: not enough arguments for format string`.

## Modification

Add `i >= valuesArr.length` guards after each `i += 1` in the three star-consuming branches: `(true,false)`, `(false,true)`, and `(true,true)`. The error message matches the existing pre-loop check format.

## Result

Star format specs with insufficient values now produce a clean user-facing error instead of an internal crash.

## Behavior comparison

| Input | go-jsonnet | jrsonnet | Python | sjsonnet (before) | sjsonnet (after) |
|-------|-----------|----------|--------|-------------------|------------------|
| `"%*d" % [5]` | error: "Not enough values to format: 1, expected more than 1" | error: "not enough values" | TypeError: not enough arguments | **AIOOBE crash** | error: "too few values to format: 1, expected at least 2" |
| `"%*.*d" % [5, 3]` | error: "Not enough values to format: 2, expected more than 2" | error: "not enough values" | TypeError: not enough arguments | **AIOOBE crash** | error: "too few values to format: 2, expected at least 3" |
| `"%*d" % [5, 42]` | `"   42"` | `"   42"` | `"   42"` | `"   42"` | `"   42"` (unchanged) |
| `"%*s" % []` | error: "Not enough values" | error: "not enough values" | TypeError | error: "too few values to format: 0, expected at least 1" | (unchanged, caught by pre-loop check) |

## Test plan

- [x] `std.format("%*d", [5])` → clean error instead of AIOOBE
- [x] `std.format("%*.*d", [5, 3])` → clean error instead of AIOOBE
- [x] `std.format("%*d", [5, 42])` → `"   42"` (no regression)
- [x] Full test suite passes (73/73)