### PR TITLE
fix: use codepoint count for std.format width padding

### DIFF
--- a/sjsonnet/src/sjsonnet/Format.scala
+++ b/sjsonnet/src/sjsonnet/Format.scala
@@ -286,7 +286,13 @@ object Format {
       else if (signedConversion && formatted.signCharacter) "+" + lhs
       else lhs
 
-    val missingWidth = formatted.widthOr(-1) - lhs2.length - mhs.length - rhs.length
+    val missingWidth =
+      if (numeric) formatted.widthOr(-1) - lhs2.length - mhs.length - rhs.length
+      else
+        formatted.widthOr(-1) -
+        lhs2.codePointCount(0, lhs2.length) -
+        mhs.codePointCount(0, mhs.length) -
+        rhs.codePointCount(0, rhs.length)
 
     if (missingWidth <= 0) {
       // Avoid unnecessary string concatenation when parts are empty

--- a/sjsonnet/test/resources/new_test_suite/format_width_codepoint.jsonnet
+++ b/sjsonnet/test/resources/new_test_suite/format_width_codepoint.jsonnet
@@ -1,0 +1,11 @@
+// Width padding must count codepoints, not UTF-16 code units.
+// Supplementary characters (surrogate pairs) count as 1 codepoint.
+[
+  std.assertEqual("%5s" % "😀", "    😀"),
+  std.assertEqual("%-5s" % "😀", "😀    "),
+  std.assertEqual("%5s" % "a😀b", "  a😀b"),
+  std.assertEqual("%3s" % "😀😀", " 😀😀"),
+  std.assertEqual("%5.1s" % "😀x", "    😀"),
+  std.assertEqual("%5s" % "hello", "hello"),
+  std.assertEqual("%10s" % "hello", "     hello"),
+]

--- a/sjsonnet/test/resources/new_test_suite/format_width_codepoint.jsonnet.golden
+++ b/sjsonnet/test/resources/new_test_suite/format_width_codepoint.jsonnet.golden
@@ -1,0 +1,9 @@
+[
+   true,
+   true,
+   true,
+   true,
+   true,
+   true,
+   true
+]


### PR DESCRIPTION
## Motivation

`std.format("%5s", "😀")` produced 3 spaces instead of 4 because width was computed using `String.length` (UTF-16 code units), counting the surrogate pair as 2. Python's `%` formatting defines width as codepoint count; go-jsonnet uses `len([]rune(str))`. Both yield 4 spaces.

Mathematical basis: Python 3 strings are sequences of Unicode codepoints. The `%` operator's width field specifies "minimum field width" measured in characters (codepoints), not UTF-16 code units or bytes.

## Modification

In `widen`, use `codePointCount` for non-numeric (string) paths where supplementary characters can appear. Numeric paths (`%d`/`%f`/`%g`/`%x`/`%o`) retain O(1) `.length` since their output is provably ASCII — avoiding O(n) scans on every numeric format call.

## Result

Width padding counts supplementary characters as 1 codepoint, matching go-jsonnet and Python. Numeric formatting performance is unchanged.

## Behavior comparison

| Input | go-jsonnet | jrsonnet | Python | sjsonnet (before) | sjsonnet (after) |
|-------|-----------|----------|--------|-------------------|------------------|
| `"%5s" % "😀"` | `"    😀"` (4 spaces) | `" 😀"` (1 space, byte-len) | `"    😀"` (4 spaces) | `"   😀"` (3 spaces) | `"    😀"` (4 spaces) |
| `"%-5s" % "😀"` | `"😀    "` (4 spaces) | `"😀 "` (1 space) | `"😀    "` (4 spaces) | `"😀   "` (3 spaces) | `"😀    "` (4 spaces) |
| `"%5s" % "a😀b"` | `"  a😀b"` (2 spaces) | — | `"  a😀b"` (2 spaces) | `" a😀b"` (1 space) | `"  a😀b"` (2 spaces) |
| `"%5s" % "hello"` | `"hello"` | `"hello"` | `"hello"` | `"hello"` | `"hello"` (unchanged) |
| `"%05d" % 42` | `"00042"` | `"00042"` | `"00042"` | `"00042"` | `"00042"` (unchanged) |

Note: jrsonnet uses UTF-8 byte length (a third behavior); go-jsonnet is the reference implementation.

## Test plan

- [x] Added `format_width_codepoint.jsonnet` regression test with golden file
- [x] `"%5s" % "😀"` → 4 spaces + emoji (matches go-jsonnet/Python)
- [x] `"%5.1s" % "😀x"` → 4 spaces + emoji (precision + width combined)
- [x] ASCII strings unaffected (numeric path uses `.length`)
- [x] Full test suite passes