### PR TITLE
chore: bump scalafmt to 3.11.5

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "3.9.10"
+version = "3.11.5"
 
 docstrings.style = Asterisk
 maxColumn = 100

--- a/sjsonnet/src/sjsonnet/Parser.scala
+++ b/sjsonnet/src/sjsonnet/Parser.scala
@@ -903,7 +903,7 @@ class Parser(
               /*
                * Prevent duplicate fields in list comprehension. See: https://github.com/databricks/sjsonnet/issues/99
                *
-             * If comps._1 is a forspec with value greater than one lhs cannot be a Expr.Str
+               * If comps._1 is a forspec with value greater than one lhs cannot be a Expr.Str
                * Otherwise the field value will be overriden by the multiple iterations of forspec
                */
               (lhs, comps) match {


### PR DESCRIPTION
## Motivation
Pick up upstream scalafmt bug fixes and Scala 3 formatting improvements shipped between 3.9.10 and 3.11.5, keeping the formatter aligned with the actively maintained release line.

## Modification
- Update the pinned version in `.scalafmt.conf` from `3.9.10` to `3.11.5`.
- Apply the only formatting delta produced by the new version: a block-comment alignment in `sjsonnet/src/sjsonnet/Parser.scala`.

## Result
- `./mill __.reformat` succeeds on all 36 modules.
- `./mill __.checkFormat` reports everything formatted on all 36 modules.
- `./mill 'sjsonnet.jvm[_]'.compile` is green on Scala 2.12 / 2.13 / 3.3.

## References
- scalafmt releases: https://github.com/scalameta/scalafmt/releases