### PR TITLE
Revert "chore: bump scalafmt to 3.11.5 (#1093)"

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "3.11.5"
+version = "3.9.10"
 
 docstrings.style = Asterisk
 maxColumn = 100

--- a/sjsonnet/src/sjsonnet/Parser.scala
+++ b/sjsonnet/src/sjsonnet/Parser.scala
@@ -903,7 +903,7 @@ class Parser(
               /*
                * Prevent duplicate fields in list comprehension. See: https://github.com/databricks/sjsonnet/issues/99
                *
-               * If comps._1 is a forspec with value greater than one lhs cannot be a Expr.Str
+             * If comps._1 is a forspec with value greater than one lhs cannot be a Expr.Str
                * Otherwise the field value will be overriden by the multiple iterations of forspec
                */
               (lhs, comps) match {


### PR DESCRIPTION
This reverts commit a638dc473e88f56a225e96c509420ed290ed892d.

Have to wait a few more days before it gets available in our mvn mirror.