### PR TITLE
Re-allow jdk11 for sjsonnet

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -390,17 +390,22 @@ object sjsonnet extends VersionFileModule {
            |  JAVACMD="$$JAVA_HOME/bin/java"
            |fi
            |SJSONNET_JAVA_OPTS=""
-           |if "$$JAVACMD" --sun-misc-unsafe-memory-access=allow -version >/dev/null 2>&1; then
-           |  SJSONNET_JAVA_OPTS="--sun-misc-unsafe-memory-access=allow"
+           |if "$$JAVACMD" --enable-native-access=ALL-UNNAMED -version >/dev/null 2>&1; then
+           |  SJSONNET_JAVA_OPTS="--enable-native-access=ALL-UNNAMED"
            |fi
-           |exec "$$JAVACMD" -Xss$stackSize --enable-native-access=ALL-UNNAMED $$SJSONNET_JAVA_OPTS $$JAVA_OPTS -cp "$$0" 'sjsonnet.SjsonnetMain' "$$@"""".stripMargin,
+           |if "$$JAVACMD" --sun-misc-unsafe-memory-access=allow -version >/dev/null 2>&1; then
+           |  SJSONNET_JAVA_OPTS="$$SJSONNET_JAVA_OPTS --sun-misc-unsafe-memory-access=allow"
+           |fi
+           |exec "$$JAVACMD" -Xss$stackSize $$SJSONNET_JAVA_OPTS $$JAVA_OPTS -cp "$$0" 'sjsonnet.SjsonnetMain' "$$@"""".stripMargin,
       cmdCommands =
         s"""set "JAVACMD=java.exe"
            |if not "%JAVA_HOME%"=="" set "JAVACMD=%JAVA_HOME%\\bin\\java.exe"
            |set "SJSONNET_JAVA_OPTS="
+           |"%JAVACMD%" --enable-native-access=ALL-UNNAMED -version >nul 2>&1
+           |if "%errorlevel%" == "0" set "SJSONNET_JAVA_OPTS=--enable-native-access=ALL-UNNAMED"
            |"%JAVACMD%" --sun-misc-unsafe-memory-access=allow -version >nul 2>&1
-           |if "%errorlevel%" == "0" set "SJSONNET_JAVA_OPTS=--sun-misc-unsafe-memory-access=allow"
-           |"%JAVACMD%" -Xss$stackSize --enable-native-access=ALL-UNNAMED %SJSONNET_JAVA_OPTS% %JAVA_OPTS% -cp "%~dpnx0" "sjsonnet.SjsonnetMain" %*""".stripMargin
+           |if "%errorlevel%" == "0" set "SJSONNET_JAVA_OPTS=%SJSONNET_JAVA_OPTS% --sun-misc-unsafe-memory-access=allow"
+           |"%JAVACMD%" -Xss$stackSize %SJSONNET_JAVA_OPTS% %JAVA_OPTS% -cp "%~dpnx0" "sjsonnet.SjsonnetMain" %*""".stripMargin
     )
 
     def assemblySmoke = Task {
@@ -460,9 +465,9 @@ object sjsonnet extends VersionFileModule {
       assert(defaultStackErr.contains("Max stack frames exceeded."), defaultStackErr)
     }
 
-    def scalacOptions = super.scalacOptions() ++ Seq("-release", "17") ++
+    def scalacOptions = super.scalacOptions() ++ Seq("-release", "11") ++
       (if (JvmWorkerUtil.isScala3(scalaVersion())) Seq("-Yfuture-lazy-vals") else Seq.empty)
-    def javacOptions = super.javacOptions() ++ Seq("--release", "17")
+    def javacOptions = super.javacOptions() ++ Seq("--release", "11")
 
     def mvnDeps = super.mvnDeps() ++ Seq(
       mvn"org.tukaani:xz::1.11",
@@ -478,6 +483,9 @@ object sjsonnet extends VersionFileModule {
 
     object client extends JavaModule with SjsonnetPublishModule {
       def artifactName = "sjsonnet-server"
+      // Daemon (client/server) mode relies on JDK 16 Unix-domain-socket APIs
+      // (UnixDomainSocketAddress / StandardProtocolFamily.UNIX), so unlike the
+      // core library and CLI it cannot target JDK 11.
       def javacOptions = super.javacOptions() ++ Seq("--release", "17", "-Xlint:deprecation", "-Werror")
       object test extends JavaTests with TestModule.Junit4
     }
@@ -486,6 +494,9 @@ object sjsonnet extends VersionFileModule {
       def artifactName = "sjsonnet-server"
       def scalaVersion = SjsonnnetJvmModule.this.crossValue
       def moduleDeps = Seq(SjsonnnetJvmModule.this, client)
+      // Daemon (client/server) mode relies on JDK 16 Unix-domain-socket APIs
+      // (UnixDomainSocketAddress / StandardProtocolFamily.UNIX), so unlike the
+      // core library and CLI it cannot target JDK 11.
       def scalacOptions = super.scalacOptions() ++ Seq("-release", "17", "-deprecation", "-Werror") ++
         (if (JvmWorkerUtil.isScala3(scalaVersion())) Seq("-Yfuture-lazy-vals") else Seq.empty)
       def javacOptions = super.javacOptions() ++ Seq("--release", "17")

--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,12 @@
 val sjsonnetVersion = IO.readLines(new File("sjsonnet/version")).head.trim
 cancelable in Global := true
 
-val options = Seq("-Wconf:origin=scala.collection.compat.*:s", "-Xlint:all", "-release", "17", "-Yfuture-lazy-vals")
+val options = Seq("-Wconf:origin=scala.collection.compat.*:s", "-Xlint:all", "-release", "11", "-Yfuture-lazy-vals")
 
 lazy val commonSettings = Seq(
   scalaVersion := "3.3.8",
   scalacOptions ++= options,
-  javacOptions ++= Seq("--release", "17")
+  javacOptions ++= Seq("--release", "11")
 )
 
 lazy val main = (project in file("sjsonnet"))

--- a/sjsonnet/src-jvm/sjsonnet/Platform.scala
+++ b/sjsonnet/src-jvm/sjsonnet/Platform.scala
@@ -4,7 +4,6 @@ import java.io.{BufferedInputStream, ByteArrayOutputStream, File, FileInputStrea
 import java.nio.charset.StandardCharsets.UTF_8
 import java.util
 import java.util.Base64
-import java.util.HexFormat
 import java.util.zip.GZIPOutputStream
 import com.google.re2j.Pattern
 import net.jpountz.xxhash.{StreamingXXHash64, XXHashFactory}
@@ -20,7 +19,6 @@ import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
 
 object Platform {
-  private val hexFormat = HexFormat.of()
 
   private[sjsonnet] type ParseCacheMap =
     TrieMap[(Path, String), Either[Error, (Expr, FileScope)]]
@@ -489,9 +487,7 @@ object Platform {
   }
 
   private def computeHash(algorithm: String, s: String): String =
-    hexFormat.formatHex(
-      java.security.MessageDigest.getInstance(algorithm).digest(s.getBytes(UTF_8))
-    )
+    Hex.encode(java.security.MessageDigest.getInstance(algorithm).digest(s.getBytes(UTF_8)))
 
   def md5(s: String): String = computeHash("MD5", s)
 

--- a/sjsonnet/src-native/sjsonnet/Platform.scala
+++ b/sjsonnet/src-native/sjsonnet/Platform.scala
@@ -31,8 +31,6 @@ object Platform {
   def newImporterResolveCacheMap(): ImporterResolveCacheMap =
     TrieMap.empty[(Path, String), Option[Path]]
 
-  private val hexChars = "0123456789abcdef".toCharArray
-
   private def repeatCapacity(s: String, count: Int): Int =
     if (count > 0 && s.length <= Int.MaxValue / count) s.length * count else 0
 
@@ -480,22 +478,8 @@ object Platform {
     result.mkString("\n")
   }
 
-  private def bytesToHex(bytes: Array[Byte]): String = {
-    val out = new Array[Char](bytes.length * 2)
-    var i = 0
-    var j = 0
-    while (i < bytes.length) {
-      val b = bytes(i) & 0xff
-      out(j) = hexChars(b >>> 4)
-      out(j + 1) = hexChars(b & 0x0f)
-      i += 1
-      j += 2
-    }
-    new String(out)
-  }
-
   private def computeHash(algorithm: String, s: String): String =
-    bytesToHex(java.security.MessageDigest.getInstance(algorithm).digest(s.getBytes(UTF_8)))
+    Hex.encode(java.security.MessageDigest.getInstance(algorithm).digest(s.getBytes(UTF_8)))
 
   def md5(s: String): String = computeHash("MD5", s)
 

--- a/sjsonnet/src/sjsonnet/Hex.scala
+++ b/sjsonnet/src/sjsonnet/Hex.scala
@@ -1,0 +1,20 @@
+package sjsonnet
+
+/** Lowercase hex encoding, shared across platforms. */
+object Hex {
+  private val hexChars = "0123456789abcdef".toCharArray
+
+  def encode(bytes: Array[Byte]): String = {
+    val out = new Array[Char](bytes.length * 2)
+    var i = 0
+    var j = 0
+    while (i < bytes.length) {
+      val b = bytes(i) & 0xff
+      out(j) = hexChars(b >>> 4)
+      out(j + 1) = hexChars(b & 0x0f)
+      i += 1
+      j += 2
+    }
+    new String(out)
+  }
+}


### PR DESCRIPTION
This is causing a lot of migration pain our side, and just for HexFormat.
client/server is still pinned to jdk17 though.

