### PR TITLE
fix: include line number in std.trace output

### DIFF
--- a/sjsonnet/src/sjsonnet/stdlib/StdLibModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/StdLibModule.scala
@@ -75,9 +75,9 @@ object StdLibModule {
    */
   private val traceFunction = new Val.Builtin2("trace", "str", "rest") {
     def evalRhs(str: Eval, rest: Eval, ev: EvalScope, pos: Position): Val = {
-      ev.trace(
-        s"TRACE: ${pos.fileScope.currentFileLastPathElement} " + str.value.asString
-      )
+      val file = pos.fileScope.currentFileLastPathElement
+      val line = ev.prettyIndex(pos).map { case (l, _) => ":" + l }.getOrElse("")
+      ev.trace(s"TRACE: $file$line " + str.value.asString)
       rest.value
     }
 

--- a/sjsonnet/test/resources/new_test_suite/comprehension_no_unsafe_hoist_trace.jsonnet.golden
+++ b/sjsonnet/test/resources/new_test_suite/comprehension_no_unsafe_hoist_trace.jsonnet.golden
@@ -1,3 +1,3 @@
-TRACE: comprehension_no_unsafe_hoist_trace.jsonnet comp-no-hoist 1
-TRACE: comprehension_no_unsafe_hoist_trace.jsonnet comp-no-hoist 1
+TRACE: comprehension_no_unsafe_hoist_trace.jsonnet:2 comp-no-hoist 1
+TRACE: comprehension_no_unsafe_hoist_trace.jsonnet:2 comp-no-hoist 1
 true

--- a/sjsonnet/test/resources/new_test_suite/lazy_array_reverse_cache_trace.jsonnet.golden
+++ b/sjsonnet/test/resources/new_test_suite/lazy_array_reverse_cache_trace.jsonnet.golden
@@ -1,4 +1,4 @@
-TRACE: lazy_array_reverse_cache_trace.jsonnet lazy-array-make-reverse-cache 0
-TRACE: lazy_array_reverse_cache_trace.jsonnet lazy-array-map-reverse-cache 0
-TRACE: lazy_array_reverse_cache_trace.jsonnet lazy-array-mapWithIndex-reverse-cache 0
+TRACE: lazy_array_reverse_cache_trace.jsonnet:2 lazy-array-make-reverse-cache 0
+TRACE: lazy_array_reverse_cache_trace.jsonnet:4 lazy-array-map-reverse-cache 0
+TRACE: lazy_array_reverse_cache_trace.jsonnet:6 lazy-array-mapWithIndex-reverse-cache 0
 true

--- a/sjsonnet/test/resources/test_suite/trace.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/trace.jsonnet.golden
@@ -1,12 +1,12 @@
-TRACE: trace.jsonnet 
-TRACE: trace.jsonnet 
-TRACE: trace.jsonnet 
-TRACE: trace.jsonnet 
-TRACE: trace.jsonnet 
-TRACE: trace.jsonnet 
-TRACE: trace.jsonnet 
-TRACE: trace.jsonnet 
-TRACE: trace.jsonnet 
-TRACE: trace.jsonnet 
-TRACE: trace.jsonnet Some Trace Message
+TRACE: trace.jsonnet:17 
+TRACE: trace.jsonnet:18 
+TRACE: trace.jsonnet:19 
+TRACE: trace.jsonnet:20 
+TRACE: trace.jsonnet:21 
+TRACE: trace.jsonnet:22 
+TRACE: trace.jsonnet:23 
+TRACE: trace.jsonnet:24 
+TRACE: trace.jsonnet:25 
+TRACE: trace.jsonnet:26 
+TRACE: trace.jsonnet:27 Some Trace Message
 true

--- a/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
+++ b/sjsonnet/test/src/sjsonnet/EvaluatorTests.scala
@@ -623,7 +623,7 @@ object EvaluatorTests extends TestSuite {
 
       val (used, usedTraces) = evalWithTraces("""std.trace("used trace", 1)""")
       used ==> ujson.Num(1)
-      usedTraces ==> Vector("TRACE: (memory) used trace")
+      usedTraces ==> Vector("TRACE: (memory):1 used trace")
     }
     test("identityFunctionTraces") {
       // Issue #815: the identity-elision fast paths must force the argument exactly as a normal
@@ -631,7 +631,7 @@ object EvaluatorTests extends TestSuite {
       // Direct identity elision: the traced argument is forced exactly once.
       val (idVal, idTraces) = evalWithTraces("""(function(x) x)(std.trace("idtrace", 5))""")
       idVal ==> ujson.Num(5)
-      idTraces ==> Vector("TRACE: (memory) idtrace")
+      idTraces ==> Vector("TRACE: (memory):1 idtrace")
 
       // Self-composition identity (g = id): still forced exactly once.
       val (compVal, compTraces) =
@@ -639,7 +639,7 @@ object EvaluatorTests extends TestSuite {
           """local g = function(x) x; local f = function(x) g(g(x)); f(std.trace("comp", 9))"""
         )
       compVal ==> ujson.Num(9)
-      compTraces ==> Vector("TRACE: (memory) comp")
+      compTraces ==> Vector("TRACE: (memory):1 comp")
 
       // Laziness preserved: identity map stays lazy, so std.length does not force the element.
       val (lazyVal, lazyTraces) =


### PR DESCRIPTION
## Summary
- `std.trace` now outputs `TRACE: <file>:<line> <msg>` instead of `TRACE: <file> <msg>`
- Aligns with go-jsonnet, jrsonnet, C++ jsonnet, and the official documentation example
- Uses the existing `EvalErrorScope.prettyIndex` infrastructure to resolve line numbers

## Motivation

All other Jsonnet implementations include the line number in trace output:
- go-jsonnet: `TRACE: test.jsonnet:3 hello`
- jrsonnet: `TRACE: test.jsonnet:3 hello`
- C++ jsonnet: `TRACE: test.jsonnet:3 hello`
- Official docs: `TRACE: test.jsonnet:3 cond is true returning {"b": true}`

sjsonnet was the only implementation omitting it, making trace output less useful for debugging.

## Test plan
- [x] Updated golden files for `trace.jsonnet`, `comprehension_no_unsafe_hoist_trace.jsonnet`, `lazy_array_reverse_cache_trace.jsonnet`
- [x] Updated `EvaluatorTests` trace assertions
- [x] Full test suite passes (`sjsonnet.jvm.2_13_18.test`)