### PR TITLE
Revert Scala.js to 1.20.2

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -169,7 +169,7 @@ object sjsonnet extends Module {
       with ScalaJSModule
       with SjsonnetPublishModule {
     def moduleDir = super.moduleDir / os.up
-    def scalaJSVersion = "1.22.0"
+    def scalaJSVersion = "1.20.2"
     val sourceDirs = Seq(
       "src",
       "src-js",


### PR DESCRIPTION
Mill 1.1.6’s Scala.js configuration API only supports ES versions through ES2021, while Scala.js 1.22’s Wasm backend now hard-requires ES2022.

Need to wait for Mill 1.1.8