### PR TITLE
Align two error message wordings with go-jsonnet and C++ jsonnet

### DIFF
--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -1180,7 +1180,7 @@ class Evaluator(
       e.asserted.msg match {
         case null => Error.fail("Assertion failed", e)
         case msg  =>
-          Error.fail("Assertion failed: " + materializeError(visitExpr(msg)), e)
+          Error.fail(materializeError(visitExpr(msg)), e)
       }
     }
     visitExpr(e.returned)
@@ -1641,7 +1641,7 @@ class Evaluator(
         e.asserted.msg match {
           case null => Error.fail("Assertion failed", e)
           case msg  =>
-            Error.fail("Assertion failed: " + materializeError(visitExpr(msg)), e)
+            Error.fail(materializeError(visitExpr(msg)), e)
         }
       }
       visitExprWithTailCallSupport(e.returned)
@@ -1761,7 +1761,7 @@ class Evaluator(
             case null => Error.fail("Assertion failed", a.value.pos)
             case msg  =>
               Error.fail(
-                "Assertion failed: " + materializeError(visitExpr(msg)(newScope)),
+                materializeError(visitExpr(msg)(newScope)),
                 a.value.pos
               )
           }

--- a/sjsonnet/src/sjsonnet/stdlib/StdLibModule.scala
+++ b/sjsonnet/src/sjsonnet/stdlib/StdLibModule.scala
@@ -95,7 +95,9 @@ object StdLibModule {
   private val extVarFunction = new Val.Builtin1("extVar", "x") {
     def evalRhs(_x: Eval, ev: EvalScope, pos: Position): Val = {
       val x = _x.value.asString
-      ev.visitExpr(ev.extVars(x).getOrElse(Error.fail("Unknown extVar: " + x)))(ValScope.empty)
+      ev.visitExpr(
+        ev.extVars(x).getOrElse(Error.fail("Undefined external variable: " + x))
+      )(ValScope.empty)
     }
 
     override def staticSafe = false

--- a/sjsonnet/test/resources/go_test_suite/assert_failed_custom.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/assert_failed_custom.jsonnet.golden
@@ -1,3 +1,3 @@
-sjsonnet.Error: Assertion failed: Custom Message
+sjsonnet.Error: Custom Message
     at [<root>].(assert_failed_custom.jsonnet:1:1)
 

--- a/sjsonnet/test/resources/go_test_suite/extvar_unknown.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/extvar_unknown.jsonnet.golden
@@ -1,2 +1,3 @@
-sjsonnet.Error: [std.extVar] Unknown extVar: UNKNOWN
+sjsonnet.Error: [std.extVar] Undefined external variable: UNKNOWN
     at [<root>].(extvar_unknown.jsonnet:1:11)
+

--- a/sjsonnet/test/resources/go_test_suite/object_invariant14.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/object_invariant14.jsonnet.golden
@@ -1,3 +1,3 @@
-sjsonnet.Error: Assertion failed: xxx
+sjsonnet.Error: xxx
     at [<root>].(object_invariant14.jsonnet:1:1)
 

--- a/sjsonnet/test/resources/go_test_suite/object_invariant_plus6.jsonnet.golden
+++ b/sjsonnet/test/resources/go_test_suite/object_invariant_plus6.jsonnet.golden
@@ -1,3 +1,3 @@
-sjsonnet.Error: Assertion failed: yyy
+sjsonnet.Error: yyy
     at [<root>].(object_invariant_plus6.jsonnet:1:25)
 

--- a/sjsonnet/test/resources/new_test_suite/error.object_assert_non_string_msg.jsonnet.golden
+++ b/sjsonnet/test/resources/new_test_suite/error.object_assert_non_string_msg.jsonnet.golden
@@ -1,1 +1,3 @@
-sjsonnet.Error: Assertion failed: 42
+sjsonnet.Error: 42
+    at [<root>].(error.object_assert_non_string_msg.jsonnet:1:7)
+

--- a/sjsonnet/test/resources/test_suite/error.assert.fail2.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.assert.fail2.jsonnet.golden
@@ -1,3 +1,3 @@
-sjsonnet.Error: Assertion failed: foo was not equal to bar
+sjsonnet.Error: foo was not equal to bar
     at [<root>].(error.assert.fail2.jsonnet:17:7)
 

--- a/sjsonnet/test/resources/test_suite/error.invariant.option.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.invariant.option.jsonnet.golden
@@ -1,3 +1,3 @@
-sjsonnet.Error: Assertion failed: Option "d" not in ["a", "b", "c"].
+sjsonnet.Error: Option "d" not in ["a", "b", "c"].
     at [<root>].(error.invariant.option.jsonnet:17:7)
 

--- a/sjsonnet/test/resources/test_suite/error.invariant.simple2.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.invariant.simple2.jsonnet.golden
@@ -1,3 +1,3 @@
-sjsonnet.Error: Assertion failed: my error message
+sjsonnet.Error: my error message
     at [<root>].(error.invariant.simple2.jsonnet:17:1)
 

--- a/sjsonnet/test/resources/test_suite/error.obj_assert.fail2.jsonnet.golden
+++ b/sjsonnet/test/resources/test_suite/error.obj_assert.fail2.jsonnet.golden
@@ -1,3 +1,3 @@
-sjsonnet.Error: Assertion failed: foo was not equal to bar
+sjsonnet.Error: foo was not equal to bar
     at [<root>].(error.obj_assert.fail2.jsonnet:17:7)
 


### PR DESCRIPTION
Two small diagnostic-wording alignments, one commit each, found by four-way differential testing (sjsonnet vs go-jsonnet vs jrsonnet vs spec).

## 1. `std.extVar` unknown variable (commit 1)

| | message |
|---|---|
| sjsonnet before | `sjsonnet.Error: [std.extVar] Unknown extVar: UNKNOWN` |
| sjsonnet after | `sjsonnet.Error: [std.extVar] Undefined external variable: UNKNOWN` |
| go-jsonnet v0.22.0 | `RUNTIME ERROR: Undefined external variable: UNKNOWN` |

sjsonnet's `[std.extVar]` builtin prefix is retained.

## 2. Assert messages verbatim (commit 2)

The spec desugars `assert e : msg` to raising `msg` as the error value; go-jsonnet and C++ jsonnet report the bare message.

| Program | sjsonnet before | sjsonnet after | go-jsonnet |
|---|---|---|---|
| `assert false : "Custom Message"` | `Assertion failed: Custom Message` | `Custom Message` | `Custom Message` |
| `assert 1==2 : '%s != %s' % [x, y]` | `Assertion failed: foo was not equal to bar` | `foo was not equal to bar` | `foo was not equal to bar` |
| `assert false : 42` (non-string) | `Assertion failed: 42` | `42` | `42` |
| `assert false` (no message) | `Assertion failed` | `Assertion failed` (unchanged) | `Assertion failed` |

All three assert failure sites are updated (top-level assert, object assert, object-comprehension assert); eight goldens refreshed across `test_suite`, `go_test_suite`, `new_test_suite`.

## Deliberately not included

`std.format` too-few/too-many-values wording: go-jsonnet's messages there are path-dependent (`Too many values to format: 2, expected 1` vs `Not enough values to format: 1, expected more than 1`), so exact alignment is not meaningful, and sjsonnet's current messages (`too few values to format: 1, expected at least 2`) are at least as precise. Left as is.

## Test plan

- [x] `./mill 'sjsonnet.jvm[_].test'` — all Scala versions (2.12.21 / 2.13.18 / 3.3.8) pass
- [x] `./mill __.checkFormat` — clean