### PR TITLE
perf: intern identifier field names for faster field lookup

### DIFF
--- a/sjsonnet/src/sjsonnet/Parser.scala
+++ b/sjsonnet/src/sjsonnet/Parser.scala
@@ -679,7 +679,8 @@ class Parser(
       CharIn(".[({")./.!.flatMapX { s =>
         val i = new Position(fileScope, implicitly[P[$]].index - 1)
         (s.charAt(0): @switch) match {
-          case '.' => Pass ~ id.map(x => Expr.Select(i, _: Expr, x))
+          case '.' =>
+            Pass ~ id.map(x => Expr.Select(i, _: Expr, internedStrings.getOrElseUpdate(x, x)))
           case '[' =>
             Pass ~ (expr(currentDepth + 1).? ~ (":" ~ expr(currentDepth + 1).?).rep ~ "]").map {
               case (Some(tree), Seq()) => Expr.Lookup(i, _: Expr, tree)
@@ -1008,8 +1009,12 @@ class Parser(
 
   def fieldname[$: P](currentDepth: Int): P[Expr.FieldName] = {
     P(
-      id.map(Expr.FieldName.Fixed.apply) |
-      string.map(Expr.FieldName.Fixed.apply) |
+      id.map(s => Expr.FieldName.Fixed(internedStrings.getOrElseUpdate(s, s))) |
+      string.map(s =>
+        Expr.FieldName.Fixed(
+          if (s.length > 1024) s else internedStrings.getOrElseUpdate(s, s)
+        )
+      ) |
       "[" ~ expr(currentDepth + 1).map(Expr.FieldName.Dyn.apply) ~ "]"
     )
   }


### PR DESCRIPTION
## Motivation

Object field lookup is the hottest path in sjsonnet evaluation. Every field access (`containsKey`, `containsVisibleKey`, `valueRaw`) compares String keys char-by-char via `.equals`, which is wasteful when the same field names repeat across objects (common in K8s manifests, stdlib).

## Modification

- Parser routes identifier field names (`fieldname`, `Select`) through `internedStrings`, sharing String instances across repeated parses (same `> 1024` length guard as the existing string-literal interning).
- With interned keys, `String.equals` hits its built-in reference check on the first line, so lookups short-circuit without char-by-char comparison.

An earlier revision also prefixed the lookup loops with an explicit `(x eq k) ||` fast path; it was dropped because `String.equals` already begins with an identity check on JVM and Scala Native, and on Scala.js both `eq` and `equals` compile to `===`, so the prefix double-compared every non-matching key.

## Result

| Benchmark | master | this PR | Delta |
|-----------|--------|---------|-------|
| ParserBenchmark.main | 1.462 ± 0.053 ms/op | 1.378 ± 0.014 ms/op | **-5.7%** |
| MainBenchmark.main | 3.028 ± 0.536 ms/op | 3.085 ± 0.529 ms/op | +1.9% (noise) |

JMH config: `-f 2 -wi 5 -i 10 -w 1 -r 1` (2 forks × 10 measurement iterations)

All tests pass. Zero behavioral change — interning only affects String identity, never equality semantics.

## Test plan

- [x] `./mill 'sjsonnet.jvm[_]'.test` — all pass
- [x] `./mill bench.runJmh ".*MainBenchmark.*"` — no regression
- [x] `./mill bench.runJmh ".*ParserBenchmark.*"` — 5.7% improvement