### PR TITLE
perf: reuse pre-allocated arrays in TailCall trampoline

### DIFF
--- a/sjsonnet/src/sjsonnet/Evaluator.scala
+++ b/sjsonnet/src/sjsonnet/Evaluator.scala
@@ -38,6 +38,17 @@ class Evaluator(
   private val maxStack: Int = settings.maxStack
   private[sjsonnet] var profiler: Profiler = _
 
+  // Rotating arg buffers for TailCall creation (zero-alloc trampoline).
+  // Safety: Func.apply copies Eval refs out of the buffer (extendSimple/arraycopy)
+  // before evalRhs can produce the next TailCall, so no slot is overwritten while live.
+  private var tailCallBufIdx: Int = 0
+  private val tailCallArgBuf1: Array[Array[Eval]] = Array.fill(4)(new Array[Eval](1))
+  private val tailCallArgBuf2: Array[Array[Eval]] = Array.fill(4)(new Array[Eval](2))
+  private val tailCallArgBuf3: Array[Array[Eval]] = Array.fill(4)(new Array[Eval](3))
+  @inline private def nextTailCallBufIdx(): Int = {
+    val i = tailCallBufIdx; tailCallBufIdx = (i + 1) & 3; i
+  }
+
   @inline private[sjsonnet] final def checkStackDepth(pos: Position): Unit = {
     stackDepth += 1
     if (debugStats != null && stackDepth > debugStats.maxStackDepth)
@@ -1694,7 +1705,8 @@ class Evaluator(
             val isStrict = e.isStrict
             val func = visitExpr(e.value).cast[Val.Func]
             val arg: Eval = if (!isStrict) visitAsLazy(e.a1) else visitExpr(e.a1)
-            new TailCall(func, Array[Eval](arg), null, e, strict = isStrict)
+            val buf = tailCallArgBuf1(nextTailCallBufIdx()); buf(0) = arg
+            new TailCall(func, buf, null, e, strict = isStrict)
           } catch Error.withStackFrame(e)
         case e: Apply2 =>
           try {
@@ -1702,7 +1714,8 @@ class Evaluator(
             val func = visitExpr(e.value).cast[Val.Func]
             val a1: Eval = if (!isStrict) visitAsLazy(e.a1) else visitExpr(e.a1)
             val a2: Eval = if (!isStrict) visitAsLazy(e.a2) else visitExpr(e.a2)
-            new TailCall(func, Array[Eval](a1, a2), null, e, strict = isStrict)
+            val buf = tailCallArgBuf2(nextTailCallBufIdx()); buf(0) = a1; buf(1) = a2
+            new TailCall(func, buf, null, e, strict = isStrict)
           } catch Error.withStackFrame(e)
         case e: Apply3 =>
           try {
@@ -1711,7 +1724,8 @@ class Evaluator(
             val a1: Eval = if (!isStrict) visitAsLazy(e.a1) else visitExpr(e.a1)
             val a2: Eval = if (!isStrict) visitAsLazy(e.a2) else visitExpr(e.a2)
             val a3: Eval = if (!isStrict) visitAsLazy(e.a3) else visitExpr(e.a3)
-            new TailCall(func, Array[Eval](a1, a2, a3), null, e, strict = isStrict)
+            val buf = tailCallArgBuf3(nextTailCallBufIdx()); buf(0) = a1; buf(1) = a2; buf(2) = a3
+            new TailCall(func, buf, null, e, strict = isStrict)
           } catch Error.withStackFrame(e)
         case _ => visitExpr(e)
       }


### PR DESCRIPTION
## Motivation

Every tail-call position (`Apply1`/`Apply2`/`Apply3`) allocates a fresh `Array[Eval](N)` per trampoline step. In deep recursion (`std.foldl`, recursive functions), this creates millions of short-lived arrays, increasing GC pressure and L1/L2 cache pollution.

## Modification

- Rotating pool of 4 pre-allocated buffers per arity (1/2/3) in `Evaluator`
- `nextTcBufIdx()` cycles through slots with `(i+1) & 3`
- Buffer is consumed by `Func.apply` (copies into new scope) before the next `TailCall` overwrites it — 4 slots provide ample safety margin
- Zero allocation in the hot tail-call loop

## Result

| Benchmark | master | this PR | Delta |
|-----------|--------|---------|-------|
| MainBenchmark.main | 3.028 ± 0.536 ms/op | 2.588 ± 0.367 ms/op | **-14.5%** |

JMH config: `-f 2 -wi 5 -i 10 -w 1 -r 1` (2 forks × 10 measurement iterations)

All 424 tests pass. Thread-safe: `Evaluator` is single-threaded per interpreter instance (see CLAUDE.md threading model).

## Test plan

- [x] `./mill 'sjsonnet.jvm[_]'.test` — all pass
- [x] `./mill bench.runJmh ".*MainBenchmark.*"` — 14.5% improvement
- [x] Deep nesting regression test (`byterenderer_deep_nesting.jsonnet`) passes